### PR TITLE
Bugfix. Amsterdam_schema app is not used anymore.

### DIFF
--- a/schematools/maps/__init__.py
+++ b/schematools/maps/__init__.py
@@ -1,4 +1,4 @@
-from amsterdam_schema.types import DatasetSchema
+from schematools.types import DatasetSchema
 from . import create
 
 

--- a/schematools/maps/create.py
+++ b/schematools/maps/create.py
@@ -1,4 +1,4 @@
-from amsterdam_schema.types import DatasetSchema
+from schematools.types import DatasetSchema
 from .generators.mapfile import MapfileGenerator
 
 # XXX see generators/mapfile.py about this import

--- a/schematools/maps/generators/mapfile.py
+++ b/schematools/maps/generators/mapfile.py
@@ -1,7 +1,7 @@
 from collections import ChainMap
 from dataclasses import dataclass
 import typing
-from amsterdam_schema.types import DatasetSchema, DatasetTableSchema
+from schematools.types import DatasetSchema, DatasetTableSchema
 
 from ..interfaces.mapfile import types, serializers
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.4.0",
+    version="0.4.1",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.0.4",
+    version="0.4.0",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
Remove code dependencies on `amsterdam_schema` app.