### PR TITLE
Slugify dataset and table ids

### DIFF
--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -20,7 +20,7 @@ from schematools.types import (
     DatasetSchema,
     DatasetTableSchema,
     is_possible_display_field,
-    get_db_table_name
+    get_db_table_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -130,12 +130,12 @@ class DynamicModel(models.Model):
 
     @classmethod
     def get_dataset_id(cls) -> str:
-        return cls._table_schema._parent_schema.id
+        return slugify(cls._table_schema._parent_schema.id, sign="_")
 
     @classmethod
     def get_table_id(cls) -> str:
         """Give access to the table name"""
-        return cls._table_schema.id
+        return slugify(cls._table_schema.id, sign="_")
 
 
 class Dataset(models.Model):
@@ -238,6 +238,7 @@ class Dataset(models.Model):
     def create_models(self) -> List[Type[DynamicModel]]:
         """Extract the models found in the schema"""
         from schematools.contrib.django.factories import schema_models_factory
+
         return schema_models_factory(self.schema)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def sqlalchemy_connect_url(request, db_url):
 
 @pytest.fixture()
 def schema_url():
-    return "https://schemas.data.amsterdam.nl/datasets/"
+    return os.environ.get("SCHEMA_URL", "https://schemas.data.amsterdam.nl/datasets/")
 
 
 @pytest.fixture(scope="function")
@@ -51,7 +51,7 @@ def dbsession(engine, dbsession, sqlalchemy_keep_db) -> Session:
 
 
 @pytest.fixture()
-def schemas_mock(requests_mock: Mocker):
+def schemas_mock(requests_mock: Mocker, schema_url):
     """Mock the requests to import schemas.
 
     This allows to run "schema import schema afvalwegingen".
@@ -59,7 +59,7 @@ def schemas_mock(requests_mock: Mocker):
     # `requests_mock` is a fixture from the requests_mock package
     afvalwegingen_json = HERE / "files" / "afvalwegingen.json"
     requests_mock.get(
-        "https://schemas.data.amsterdam.nl/datasets/",
+        schema_url,
         json=[
             {
                 "name": "afvalwegingen",
@@ -69,7 +69,7 @@ def schemas_mock(requests_mock: Mocker):
         ],
     )
     requests_mock.get(
-        "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/",
+        f"{schema_url}afvalwegingen/",
         json=[
             {
                 "name": "afvalwegingen",
@@ -81,7 +81,7 @@ def schemas_mock(requests_mock: Mocker):
     )
     with open(afvalwegingen_json, "rb") as fh:
         requests_mock.get(
-            "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen",
+            f"{schema_url}afvalwegingen/afvalwegingen",
             content=fh.read(),
         )
     yield requests_mock


### PR DESCRIPTION
To prevent spaces in urls

And fixed the test, the tests assumed hard-coded schema url