### PR TITLE
Fixing errors delated to NULLable fields in models.

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -54,7 +54,9 @@ class FieldMaker:
         **kwargs,
     ) -> TypeAndSignature:
         kwargs["primary_key"] = field.is_primary
-        kwargs["null"] = not field.required
+        if not field.is_primary:
+            # Primary can not be Null
+            kwargs["null"] = not field.required
         if self.value_getter:
             kwargs = {**kwargs, **self.value_getter(dataset, field)}
         return field_cls, args, kwargs
@@ -86,7 +88,8 @@ class FieldMaker:
 
         if relation is not None:
             field_cls = models.ForeignKey
-            args = [self._make_related_classname(relation), models.SET_NULL]
+            on_delete = models.CASCADE if field.required else models.SET_NULL
+            args = [self._make_related_classname(relation), on_delete]
 
             if field._parent_table.has_parent_table:
                 kwargs["related_name"] = field._parent_table["originalID"]

--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -70,4 +70,3 @@ def schema_def_from_file(filename) -> Dict[str, types.DatasetSchema]:
     with open(filename, "r") as file_handler:
         schema_info = json.load(file_handler)
         return {schema_info["id"]: types.DatasetSchema.from_dict(schema_info)}
-

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.5.0",
+    version="0.5.1",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
Minor fix for Nullable fields in django.

Primary key can not be null and we can safely set `CASCADE` for not nullable fields.
