### PR TITLE
Expose filters schema property.

### DIFF
--- a/schematools/types.py
+++ b/schematools/types.py
@@ -159,6 +159,11 @@ class DatasetTableSchema(SchemaType):
     def has_parent_table(self):
         return "parentTableID" in self["schema"]
 
+    @property
+    def filters(self):
+        """Fetch list of additional filters"""
+        return self["schema"].get("additionalFilters", {})
+
 
 class DatasetFieldSchema(DatasetType):
     """ A single field (column) in a table """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.8.0",
+    version="0.8.1",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
This PR allows parsing of `additionalFilters` schema parameter and transforms it into new additional filters that are mapped to one or multiple fields.

Including `effective` filter that will create Range filter `start__lte=x` & `end__gt=x`.

Schema will look as follows:

```
"tables": {
   "x":  {
      "schema":  {
        ...
        "additionalFilters": {
          "effective": {                                     << Filter name. For now we have only `effective`.
            "name": "regimes.inWerkingOp",  << String to be presented in URI.
            "start": "regimes.begin tijd",          << Start field name. Relations are separated with dots.
            "end": "regimes.eind tijd"              << End field name. Relations are separated with dots.
          }
        },
        "properties": {...}
     }
```
Full example: https://github.com/Amsterdam/dso-api/pull/47/files#diff-b4fad29bf58070e15c0606a6475b2f87