### PR TITLE
Disable geosearch

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -14,7 +14,7 @@ from schematools.types import (
     is_possible_display_field,
     get_db_table_name,
 )
-from schematools.utils import to_snake_case, toCamelCase
+from schematools.utils import to_snake_case
 from .models import (
     DATE_MODELS_LOOKUP,
     JSON_TYPE_TO_DJANGO,

--- a/schematools/contrib/django/management/commands/change_dataset.py
+++ b/schematools/contrib/django/management/commands/change_dataset.py
@@ -46,6 +46,15 @@ class Command(BaseCommand):
             metavar="bool",
             help="Enable the API endpoint.",
         )
+        parser.add_argument(
+            "--enable-geosearch",
+            dest="enable_geosearch",
+            nargs="?",
+            type=_strtobool,
+            const=True,
+            metavar="bool",
+            help="Enable GeoSearch for all tables in dataset.",
+        )
         parser.add_argument("--url-prefix", help="Set a prefix for the API URL.")
         parser.add_argument("--auth", help="Assign OAuth roles.")
         parser.add_argument(
@@ -74,6 +83,10 @@ class Command(BaseCommand):
                 options["enable_db"] = False
 
         changed = False
+        if options.get("enable_geosearch") is not None:
+            dataset.tables.all().update(enable_geosearch=options.get("enable_geosearch"))
+            changed = True
+
         for field in self.setting_options:
             value = options.get(field)
             if value is None:

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -10,7 +10,6 @@ from django.contrib.postgres.fields import ArrayField, JSONField
 from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from django.utils.text import camel_case_to_spaces
 
 from django_postgres_unlimited_varchar import UnlimitedCharField
 from gisserver.types import CRS

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.8.11",
+    version="0.8.12",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
Allow managing `enable_geosearch` setting via command line.