### PR TITLE
DS-339 For backwards relations add related_name

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -96,21 +96,20 @@ class FieldMaker:
             else:
                 related_name = None
                 _, related_table_name = relation.split(":")
-                relations = {}
-                for table in dataset.tables:
-                    if table.id == related_table_name and table.relations:
-                        relations = table.relations
-                        break
-                if relations:
-                    for name, relation in relations.items():
+                try:
+                    table = dataset.get_table_by_id(related_table_name)
+                    for name, relation in table.relations.items():
                         if (
                             relation["table"] == field.table.id
                             and relation["field"] == field.name
                         ):
                             related_name = name
                             break
+                except ValueError:
+                    pass
+
                 if related_name:
-                    kwargs["related_name"] = name
+                    kwargs["related_name"] = related_name
                 else:
                     kwargs["related_name"] = "+"
 

--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -93,6 +93,26 @@ class FieldMaker:
 
             if field._parent_table.has_parent_table:
                 kwargs["related_name"] = field._parent_table["originalID"]
+            else:
+                related_name = None
+                _, related_table_name = relation.split(":")
+                relations = {}
+                for table in dataset.tables:
+                    if table.id == related_table_name and table.relations:
+                        relations = table.relations
+                        break
+                if relations:
+                    for name, relation in relations.items():
+                        if (
+                            relation["table"] == field.table.id
+                            and relation["field"] == field.name
+                        ):
+                            related_name = name
+                            break
+                if related_name:
+                    kwargs["related_name"] = name
+                else:
+                    kwargs["related_name"] = "+"
 
             # In schema foreign keys should be specified without _id,
             # but the db_column should be with _id

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.8.12",
+    version="0.8.13",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
If for a forward relation no additionalRelations have been defined in the target table
set related_name to + so that  no backwards relations are  defined in the Django model

Otherwise set the related_name for to the matching name in the additionRelations definition