### PR TITLE
Fix ordering

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -213,7 +213,7 @@ def model_factory(table: DatasetTableSchema, base_app_name=None) -> Type[Dynamic
             "db_table": get_db_table_name(table),
             "app_label": app_label,
             "verbose_name": table.id.title(),
-            "ordering": ("id",),
+            "ordering": (table.identifier,),
         },
     )
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.9.0",
+    version="0.9.1",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
Nog een bugje, schema-tools ging in meta-model definitie nog uit van het bestaand van een 'id' veld. We hebben nu met rioolknopen een eerste dataset tabel waarin deze ontbreekt.