### PR TITLE
Add datetime model lookup

### DIFF
--- a/schematools/contrib/django/management/commands/import_schemas.py
+++ b/schematools/contrib/django/management/commands/import_schemas.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--no-create-tables", dest="create_tables", action="store_false"
         )
-        parser.set_defaults(create_tables=True)
+        parser.set_defaults(create_tables=False)
 
     def handle(self, *args, **options):
         if options["schema"]:

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -49,6 +49,7 @@ JSON_TYPE_TO_DJANGO = {
     "integer": (models.IntegerField, None),
     "integer/autoincrement": (models.AutoField, None),
     "date": (models.DateField, None),
+    "datetime": (models.DateTimeField, None),
     "time": (models.TimeField, None),
     "number": (models.FloatField, None),
     "boolean": (models.BooleanField, None),


### PR DESCRIPTION
Changed create_tables default to False
That is more convenient locally (because of the brp dataset)