### PR TITLE
added the option uri as definition for format

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -16,7 +16,7 @@ from schematools.types import (
 )
 from schematools.utils import to_snake_case
 from .models import (
-    DATE_MODELS_LOOKUP,
+    FORMAT_MODELS_LOOKUP,
     JSON_TYPE_TO_DJANGO,
     DynamicModel,
 )
@@ -134,7 +134,7 @@ class FieldMaker:
     ) -> TypeAndSignature:
         format_ = field.format
         if format_ is not None:
-            field_cls = DATE_MODELS_LOOKUP[format_]
+            field_cls = FORMAT_MODELS_LOOKUP[format_]
         return field_cls, args, kwargs
 
     def __call__(

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -29,10 +29,11 @@ logger = logging.getLogger(__name__)
 
 GEOJSON_PREFIX = "https://geojson.org/schema/"
 
-DATE_MODELS_LOOKUP = {
+FORMAT_MODELS_LOOKUP = {
     "date": models.DateField,
     "time": models.TimeField,
     "date-time": models.DateTimeField,
+    "uri": models.URLField
 }
 
 RD_NEW = CRS.from_string("EPSG:28992")  # Amersfoort / RD New


### PR DESCRIPTION
Usage in the Amsterdam schema definition:
- "type" : "string"
- "format" : "uri"

The format uri specification translates it URLfield django definition, which is stored as a charfield type with default value length 200 char.