### PR TITLE
Fix the fields for an nm-relation

### DIFF
--- a/schematools/importer/base.py
+++ b/schematools/importer/base.py
@@ -382,17 +382,29 @@ def table_factory(
 
                 elif field.is_through_table:
                     # We need a 'through' table for the n-m relation
-                    _, related_table = [
-                        to_snake_case(part) for part in field.nm_relation.split(":")
-                    ]
                     sub_columns = [
                         Column(f"{dataset_table.id}_id", String,),
-                        Column(f"{related_table}_id", String,),
+                        Column(f"{field_name}_id", String,),
                     ]
+                    # And the field(s) for the left side of the relation
+                    # if this left table has a compound key
+                    if dataset_table.has_compound_key:
+                        for id_field in dataset_table.get_fields_by_id(
+                            dataset_table.identifier
+                        ):
+                            sub_columns.append(
+                                Column(
+                                    f"{dataset_table.id}_{to_snake_case(id_field.name)}",
+                                    fetch_col_type(id_field),
+                                )
+                            )
 
                 for sub_field in field.sub_fields:
                     sub_columns.append(
-                        Column(sub_field.name, fetch_col_type(sub_field))
+                        Column(
+                            f"{field_name}_{to_snake_case(sub_field.name)}",
+                            fetch_col_type(sub_field),
+                        )
                     )
 
                 sub_tables[sub_table_id] = Table(sub_table_id, metadata, *sub_columns,)

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -235,6 +235,11 @@ class DatasetTableSchema(SchemaType):
                 _name="id", _parent_table=self, _required=True, type="string"
             )
 
+    def get_fields_by_id(self, field_names) -> typing.List[DatasetFieldSchema]:
+        for field in self.fields:
+            if field.name in set(field_names):
+                yield field
+
     @property
     def display_field(self):
         """Tell which fields can be used as display field."""
@@ -371,11 +376,6 @@ class DatasetFieldSchema(DatasetType):
     @property
     def format(self) -> typing.Optional[str]:
         return self.get("format")
-
-    @property
-    def is_array(self) -> bool:
-        """Tell whether the field references an array."""
-        return self.get("type") == "array"
 
     @property
     def is_object(self) -> bool:

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -235,7 +235,7 @@ class DatasetTableSchema(SchemaType):
                 _name="id", _parent_table=self, _required=True, type="string"
             )
 
-    def get_fields_by_id(self, field_names) -> typing.List[DatasetFieldSchema]:
+    def get_fields_by_id(self, field_names) -> typing.Generator[DatasetFieldSchema, None, None]:
         for field in self.fields:
             if field.name in set(field_names):
                 yield field

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,8 @@ def stadsdelen_schema(schema_json) -> DatasetSchema:
 @pytest.fixture()
 def verblijfsobjecten_schema(schema_json) -> DatasetSchema:
     return DatasetSchema.from_dict(schema_json("verblijfsobjecten.json"))
+
+
+@pytest.fixture()
+def kadastraleobjecten_schema(schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(schema_json("kadastraleobjecten.json"))

--- a/tests/files/data/kadastraleobjecten.ndjson
+++ b/tests/files/data/kadastraleobjecten.ndjson
@@ -1,0 +1,2 @@
+{"identificatie": "KAD.001", "volgnummer": 1, "isOntstaanUitKadastraalobject": [{"identificatie": "KAD.002", "volgnummer": 1}]}
+{"identificatie": "KAD.002", "volgnummer": 1, "isOntstaanUitKadastraalobject": []}

--- a/tests/files/kadastraleobjecten.json
+++ b/tests/files/kadastraleobjecten.json
@@ -1,0 +1,66 @@
+{
+  "type": "dataset",
+  "id": "brk",
+  "title": "brk",
+  "status": "niet_beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "auth": "BRK/RSN",
+  "identifier": "identificatie",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+    }
+  },
+  "tables": [
+    {
+      "id": "kadastraleobjecten",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "identificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "De unieke aanduiding van een Kadastraal object."
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "registratiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De datum waarop de toestand is geregistreerd."
+          },
+          "isOntstaanUitKadastraalobject": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
+              }
+            },
+            "relation": "brk:kadastraleobjecten",
+            "description": "Onderliggende percelen. Alleen gevuld wanneer het beschreven kadastrale object een A-perceel betreft."
+          }
+        },
+        "mainGeometry": "geometrie"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Make names more specific for both sides of the relation.
This avoids name-clashes for self-referencing nm-relations

Add the left-side values of an nm-relation for compound keys