### PR TITLE
Fix columnames for nm-through tables

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -111,6 +111,7 @@ class FieldMaker:
                 kwargs["through"] = self._make_through_classname(
                     dataset.id, field._parent_table.id, field.name
                 )
+                kwargs["through_fields"] = (parent_table, snakecased_fieldname)
             elif field._parent_table.has_parent_table:
                 kwargs["related_name"] = field._parent_table["originalID"]
             else:

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -166,7 +166,7 @@ class DatasetSchema(SchemaType):
                         "type": "integer",
                         "relation": f"{left_dataset}:{left_table}",
                     },
-                    right_table: {
+                    snakecased_fieldname: {
                         "type": "integer",
                         "relation": f"{right_dataset}:{right_table}",
                     },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,12 +110,12 @@ def test_model_factory_temporary_n_m_relation(ggwgebieden_schema):
     # Through table has refs to both 'sides' and extra fields for the relation
     through_table_field_names = {
         "ggwgebieden",
-        "buurten",
+        "bestaatuitbuurten",
         "identificatie",
         "volgnummer",
     }
     fields_dict = {f.name: f for f in model_dict[through_table_name]._meta.fields}
 
     assert set(fields_dict.keys()) > through_table_field_names
-    for field_name in ("ggwgebieden", "buurten"):
+    for field_name in ("ggwgebieden", "bestaatuitbuurten"):
         assert isinstance(fields_dict[field_name], models.ForeignKey)


### PR DESCRIPTION
Recent rename of the target table columns was not
yet changed for the Django models