### PR TITLE
Permissions ext

### DIFF
--- a/schematools/cli.py
+++ b/schematools/cli.py
@@ -149,14 +149,16 @@ def permissions_revoke(db_url, role):
 @argument_profile_location
 #@argument_role
 #@argument_scope
-@click.option("--auto", is_flag=True, default=False, help="Grant each scope X to their associated db role scope_x")
+@click.option("--auto", is_flag=True, default=False, help="Grant each scope X to their associated db role scope_x.")
 @click.option("--role", is_flag=False, default="", help="Role to receive grants. Ignored when --auto=True")
 @click.option("--scope", is_flag=False, default="", help="Scope to be granted. Ignored when --auto=True")
-@click.option("--dry-run", is_flag=True, default=False, help="Don't execute the GRANT statements")
+@click.option("--execute/--dry-run", default=False, help="Execute SQL statements or dry-run [default]")
 @click.option("--create-roles", is_flag=True, default=False, help="Create missing postgres roles")
+@click.option("--revoke", is_flag=True, default=False, help="Revoke all previous table and column permissions")
 
-def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, auto, role, scope, dry_run, create_roles):
+def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, auto, role, scope, execute, create_roles, revoke):
     """Set permissions for a postgres role associated with a scope from Amsterdam Schema or Profiles."""
+    dry_run = not execute
     if auto:
         role = "AUTO"
         scope = "ALL"
@@ -187,7 +189,7 @@ def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_
         profile = _fetch_json(profile_location)
         profiles = {profile["name"]: profile}
     if auto or (role and scope):
-        apply_schema_and_profile_permissions(engine, ams_schema, profiles, role, scope, dry_run, create_roles)
+        apply_schema_and_profile_permissions(engine, ams_schema, profiles, role, scope, dry_run, create_roles, revoke)
     else:
         print("Choose --auto or specify both a --role and a --scope to be able to grant permissions")
 

--- a/schematools/cli.py
+++ b/schematools/cli.py
@@ -158,16 +158,6 @@ def permissions_apply(db_url, schema_url, profile_url, schema_filename, profile_
         role = "AUTO"
         scope = "ALL"
 
-    def _fetch_json(location):
-        if not location.startswith("http"):
-            with open(location) as f:
-                json_obj = json.load(f)
-        else:
-            response = requests.get(location)
-            response.raise_for_status()
-            json_obj = response.json()
-        return json_obj
-
     engine = _get_engine(db_url)
 
     if schema_filename:
@@ -177,7 +167,7 @@ def permissions_apply(db_url, schema_url, profile_url, schema_filename, profile_
         ams_schema = schema_defs_from_url(schemas_url=schema_url)
 
     if profile_filename:
-        profile = _fetch_json(profile_filename)
+        profile = schema_fetch_url_file(profile_filename)
         profiles = {profile["name"]: profile}
     else:
         # Profiles not live yet, temporarilly commented out

--- a/schematools/cli.py
+++ b/schematools/cli.py
@@ -66,14 +66,6 @@ argument_profile_location = click.argument(
 )
 
 
-argument_role = click.argument(
-    "role", metavar="(POSTGRES-ROLE | AUTO)"
-)
-
-argument_scope = click.argument(
-    "scope", metavar="(SCOPE-NAME | ALL)"
-)
-
 def _get_engine(db_url, pg_schemas=None):
     """Initialize the SQLAlchemy engine, and report click errors"""
     kwargs = {}
@@ -147,14 +139,12 @@ def permissions_revoke(db_url, role):
 @option_profile_url
 @argument_schema_location
 @argument_profile_location
-#@argument_role
-#@argument_scope
 @click.option("--auto", is_flag=True, default=False, help="Grant each scope X to their associated db role scope_x.")
 @click.option("--role", is_flag=False, default="", help="Role to receive grants. Ignored when --auto=True")
 @click.option("--scope", is_flag=False, default="", help="Scope to be granted. Ignored when --auto=True")
 @click.option("--execute/--dry-run", default=False, help="Execute SQL statements or dry-run [default]")
 @click.option("--create-roles", is_flag=True, default=False, help="Create missing postgres roles")
-@click.option("--revoke", is_flag=True, default=False, help="Revoke all previous table and column permissions")
+@click.option("--revoke", is_flag=True, default=False, help="Before granting new permissions, revoke first all previous table and column permissions")
 
 def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, auto, role, scope, execute, create_roles, revoke):
     """Set permissions for a postgres role associated with a scope from Amsterdam Schema or Profiles."""

--- a/schematools/cli.py
+++ b/schematools/cli.py
@@ -65,6 +65,10 @@ argument_profile_location = click.argument(
     "profile_location", metavar="(PROFILE-FILENAME | NONE)",
 )
 
+argument_role = click.argument(
+    "role",
+)
+
 
 def _get_engine(db_url, pg_schemas=None):
     """Initialize the SQLAlchemy engine, and report click errors"""
@@ -137,8 +141,9 @@ def permissions_revoke(db_url, role):
 @option_db_url
 @option_schema_url
 @option_profile_url
-@argument_schema_location
-@argument_profile_location
+@click.option("--schema-filename", is_flag=False, help="Filename of local Amsterdam Schema (single dataset). If specified, it will be used instead of schema-url")
+@click.option("--profile-filename", is_flag=False, help="Filename of local Profile. If specified, it will be used instead of profile-url")
+@click.option("--pg_schema", is_flag=False, default='public', show_default=True, help="Postgres schema containing the data")
 @click.option("--auto", is_flag=True, default=False, help="Grant each scope X to their associated db role scope_x.")
 @click.option("--role", is_flag=False, default="", help="Role to receive grants. Ignored when --auto=True")
 @click.option("--scope", is_flag=False, default="", help="Scope to be granted. Ignored when --auto=True")
@@ -146,7 +151,7 @@ def permissions_revoke(db_url, role):
 @click.option("--create-roles", is_flag=True, default=False, help="Create missing postgres roles")
 @click.option("--revoke", is_flag=True, default=False, help="Before granting new permissions, revoke first all previous table and column permissions")
 
-def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, auto, role, scope, execute, create_roles, revoke):
+def permissions_apply(db_url, schema_url, profile_url, schema_filename, profile_filename, pg_schema, auto, role, scope, execute, create_roles, revoke):
     """Set permissions for a postgres role associated with a scope from Amsterdam Schema or Profiles."""
     dry_run = not execute
     if auto:
@@ -164,22 +169,23 @@ def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_
         return json_obj
 
     engine = _get_engine(db_url)
-    if schema_location in {"None", "NONE"}:
-        ams_schema = None
-    elif schema_location == 'ALL':
-        ams_schema = schema_defs_from_url(schemas_url=schema_url)
-    else:
-        dataset_schema = _get_dataset_schema(schema_url, schema_location)
+
+    if schema_filename:
+        dataset_schema = DatasetSchema.from_file(schema_filename)
         ams_schema = {dataset_schema.id: dataset_schema}
-    if profile_location in {"None", "NONE"}:
-        profiles = None
-    elif profile_location == 'ALL':
-        profiles = profile_defs_from_url(schemas_url=profile_url)
     else:
-        profile = _fetch_json(profile_location)
+        ams_schema = schema_defs_from_url(schemas_url=schema_url)
+
+    if profile_filename:
+        profile = _fetch_json(profile_filename)
         profiles = {profile["name"]: profile}
+    else:
+        # Profiles not live yet, temporarilly commented out
+        # profiles = profile_defs_from_url(profiles_url=profile_url)
+        profiles = None
+
     if auto or (role and scope):
-        apply_schema_and_profile_permissions(engine, ams_schema, profiles, role, scope, dry_run, create_roles, revoke)
+        apply_schema_and_profile_permissions(engine, pg_schema, ams_schema, profiles, role, scope, dry_run, create_roles, revoke)
     else:
         print("Choose --auto or specify both a --role and a --scope to be able to grant permissions")
 

--- a/schematools/cli.py
+++ b/schematools/cli.py
@@ -67,11 +67,11 @@ argument_profile_location = click.argument(
 
 
 argument_role = click.argument(
-    "role",
+    "role", metavar="(POSTGRES-ROLE | AUTO)"
 )
 
 argument_scope = click.argument(
-    "scope",
+    "scope", metavar="(SCOPE-NAME | ALL)"
 )
 
 def _get_engine(db_url, pg_schemas=None):
@@ -150,7 +150,8 @@ def permissions_revoke(db_url, role):
 @argument_role
 @argument_scope
 @click.option("--dry-run", is_flag=True, default=False, help="Don't execute the GRANT statements")
-def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, role, scope, dry_run):
+@click.option("--create-roles", is_flag=True, default=False, help="Create missing postgres roles")
+def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_location, role, scope, dry_run, create_roles):
     """Set permissions for a postgres role associated with a scope from Amsterdam Schema or Profiles."""
     def _fetch_json(location):
         if not location.startswith("http"):
@@ -177,7 +178,7 @@ def permissions_apply(db_url, schema_url, profile_url, schema_location, profile_
     else:
         profile = _fetch_json(profile_location)
         profiles = {profile["name"]: profile}
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, role, scope, dry_run)
+    apply_schema_and_profile_permissions(engine, ams_schema, profiles, role, scope, dry_run, create_roles)
 
 
 @schema.group()

--- a/schematools/permissions.py
+++ b/schematools/permissions.py
@@ -104,7 +104,9 @@ def create_acl_from_profiles(engine, pg_schema, profile_list, role, scope):
                         engine.execute(grant_statement)
 
 
-def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run, create_roles):
+def create_acl_from_schema(
+    session, pg_schema, ams_schema, role, scope, dry_run, create_roles
+):
     grantee = None if role == "AUTO" else role
     if create_roles and grantee:
         _create_role_if_not_exists(session, grantee)
@@ -163,7 +165,7 @@ def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run,
                         field_scope_set, table_scope_set, field.name, table_name
                     )
                 )
-                if role == 'AUTO':
+                if role == "AUTO":
                     grantees = [scope_to_role(scope) for scope in field_scope_set]
                 elif scope in field_scope_set:
                     grantees = [role]
@@ -188,7 +190,7 @@ def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run,
                         ),
                         dry_run=dry_run,
                     )
-        if role == 'AUTO':
+        if role == "AUTO":
             grantees = [scope_to_role(scope) for scope in table_scope_set]
         elif scope in table_scope_set:
             grantees = [role]

--- a/schematools/permissions.py
+++ b/schematools/permissions.py
@@ -188,15 +188,14 @@ def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run,
                         ),
                         dry_run=dry_run,
                     )
+        if role == 'AUTO':
+            grantees = [scope_to_role(scope) for scope in table_scope_set]
+        elif scope in table_scope_set:
+            grantees = [role]
+        else:
+            grantees = []
         if contains_field_grants:
             #  only grant those fields without their own scope. The other field have already been granted above
-            grantees = (
-                [scope_to_role(scope) for scope in table_scope_set]
-                if role == "AUTO"
-                else [role]
-                if scope in table_scope_set
-                else []
-            )
             for grantee in grantees:
                 if create_roles:
                     _create_role_if_not_exists(session, grantee, dry_run=dry_run)
@@ -220,13 +219,6 @@ def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run,
                         )
         else:
             # we can grant the whole table instead of field by field
-            grantees = (
-                [scope_to_role(scope) for scope in table_scope_set]
-                if role == "AUTO"
-                else [role]
-                if scope in table_scope_set
-                else []
-            )
             for grantee in grantees:
                 if create_roles:
                     _create_role_if_not_exists(session, grantee, dry_run=dry_run)

--- a/schematools/permissions.py
+++ b/schematools/permissions.py
@@ -163,13 +163,12 @@ def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run,
                         field_scope_set, table_scope_set, field.name, table_name
                     )
                 )
-                grantees = (
-                    [scope_to_role(scope) for scope in field_scope_set]
-                    if role == "AUTO"
-                    else [role]
-                    if scope in field_scope_set
-                    else []
-                )
+                if role == 'AUTO':
+                    grantees = [scope_to_role(scope) for scope in field_scope_set]
+                elif scope in field_scope_set:
+                    grantees = [role]
+                else:
+                    grantees = []
                 for grantee in grantees:
                     if create_roles:
                         _create_role_if_not_exists(session, grantee, dry_run=dry_run)

--- a/schematools/permissions.py
+++ b/schematools/permissions.py
@@ -44,7 +44,14 @@ def revoke_permissions(engine, role):
 
 
 def apply_schema_and_profile_permissions(
-    engine, ams_schema, profiles, role, scope, dry_run=False, create_roles=False, revoke=False
+    engine,
+    ams_schema,
+    profiles,
+    role,
+    scope,
+    dry_run=False,
+    create_roles=False,
+    revoke=False,
 ):
     Session = sessionmaker(bind=engine)
     session = Session()
@@ -232,7 +239,9 @@ def create_acl_from_schema(session, ams_schema, role, scope, dry_run, create_rol
                 )
 
 
-def create_acl_from_schemas(session, schemas, role, scopes, dry_run, create_roles, revoke):
+def create_acl_from_schemas(
+    session, schemas, role, scopes, dry_run, create_roles, revoke
+):
     #  acl_list = query.get_all_table_acls(engine, schema='public')
     #  acl_table_list = [item.name for item in acl_list]
     #  table_names = list()
@@ -249,7 +258,9 @@ def create_acl_from_schemas(session, schemas, role, scopes, dry_run, create_role
 
 def _revoke_all_priviliges_from_role(session, role, echo=True, dry_run=False):
     status_msg = "Skipped" if dry_run else "Executed"
-    revoke_statement = f"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM {role}"
+    revoke_statement = (
+        f"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM {role}"
+    )
     sql_statement = (
         "DO $$ "
         "BEGIN "
@@ -280,7 +291,6 @@ def _revoke_all_priviliges_from_scope_roles(session, echo=True, dry_run=False):
             session.execute(
                 text(revoke_statement)
             )  # .execution_options(autocommit=True))
-
 
 
 def _execute_grant(session, grant_statement, echo=True, dry_run=False):

--- a/schematools/permissions.py
+++ b/schematools/permissions.py
@@ -59,7 +59,14 @@ def apply_schema_and_profile_permissions(
     try:
         if ams_schema:
             create_acl_from_schemas(
-                session, pg_schema, ams_schema, role, scope, dry_run, create_roles, revoke
+                session,
+                pg_schema,
+                ams_schema,
+                role,
+                scope,
+                dry_run,
+                create_roles,
+                revoke,
             )
         if profiles:
             profile_list = profiles.values()
@@ -97,7 +104,9 @@ def create_acl_from_profiles(engine, pg_schema, profile_list, role, scope):
                         engine.execute(grant_statement)
 
 
-def create_acl_from_schema(session, pg_schema, ams_schema, role, scope, dry_run, create_roles):
+def create_acl_from_schema(
+    session, pg_schema, ams_schema, role, scope, dry_run, create_roles
+):
     grantee = role if role != "AUTO" else None
     if create_roles and grantee:
         _create_role_if_not_exists(session, grantee)
@@ -258,11 +267,11 @@ def create_acl_from_schemas(
         )
 
 
-def _revoke_all_priviliges_from_role(session, pg_schema, role, echo=True, dry_run=False):
+def _revoke_all_priviliges_from_role(
+    session, pg_schema, role, echo=True, dry_run=False
+):
     status_msg = "Skipped" if dry_run else "Executed"
-    revoke_statement = (
-        f"REVOKE ALL PRIVILEGES ON ALL TABLES IN {pg_schema} FROM {role}"
-    )
+    revoke_statement = f"REVOKE ALL PRIVILEGES ON ALL TABLES IN {pg_schema} FROM {role}"
     sql_statement = (
         "DO $$ "
         "BEGIN "
@@ -277,16 +286,16 @@ def _revoke_all_priviliges_from_role(session, pg_schema, role, echo=True, dry_ru
         session.execute(sql_statement)
 
 
-def _revoke_all_priviliges_from_scope_roles(session, pg_schema, echo=True, dry_run=False):
+def _revoke_all_priviliges_from_scope_roles(
+    session, pg_schema, echo=True, dry_run=False
+):
     status_msg = "Skipped" if dry_run else "Executed"
     # with engine.begin() as connection:
     result = session.execute(
         text(f"SELECT rolname FROM pg_roles WHERE rolname LIKE 'scope\_%'")
     )
     for rolname in result:
-        revoke_statement = (
-            f"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA {pg_schema} FROM {rolname[0]};"
-        )
+        revoke_statement = f"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA {pg_schema} FROM {rolname[0]};"
         if echo:
             print(f"{status_msg} --> {revoke_statement}")
         if not dry_run:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,6 +3,7 @@ from schematools.importer.ndjson import NDJSONImporter
 from pg_grant import query
 from schematools.permissions import create_acl_from_profiles, apply_schema_and_profile_permissions
 from sqlalchemy.exc import ProgrammingError
+from psycopg2.errors import DuplicateObject
 import pytest
 from schematools.types import DatasetSchema
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -28,7 +28,7 @@ def test_auto_permissions(here, engine, gebieden_schema_auth, dbsession):
     profiles = {profile["name"]: profile}
 
     # Apply the permissions from Schema and Profiles.
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "AUTO", "ALL", create_roles=True)
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "AUTO", "ALL", create_roles=True)
     _check_permission_granted(engine, "scope_level_a", "gebieden_buurten")
     _check_permission_granted(engine, "scope_level_b", "gebieden_bouwblokken", "id, eind_geldigheid")
     _check_permission_granted(engine, "scope_level_c", "gebieden_bouwblokken", "begin_geldigheid")
@@ -57,8 +57,8 @@ def test_openbaar_permissions(here, engine, afval_schema, dbsession):
     _check_permission_denied(engine, "openbaar", "afvalwegingen_containers")
     _check_permission_denied(engine, "bag_r", "afvalwegingen_clusters")
 
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "openbaar", "OPENBAAR")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "bag_r", "BAG/R")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "openbaar", "OPENBAAR")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "bag_r", "BAG/R")
 
     _check_permission_granted(engine, "openbaar", "afvalwegingen_containers")
     _check_permission_denied(engine, "openbaar", "afvalwegingen_clusters")
@@ -98,9 +98,9 @@ def test_interacting_permissions(here, engine, gebieden_schema_auth, dbsession):
             _check_permission_denied(engine, test_role, table)
 
     # Apply the permissions from Schema and Profiles.
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_a", "LEVEL/A")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_b", "LEVEL/B")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_c", "LEVEL/C")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_a", "LEVEL/A")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_b", "LEVEL/B")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_c", "LEVEL/C")
 
     # Check if the read priviliges are correct
     _check_permission_denied(engine, "level_a", "gebieden_bouwblokken")
@@ -148,12 +148,12 @@ def test_auth_list_permissions(here, engine, gebieden_schema_auth_list, dbsessio
             _check_permission_denied(engine, test_role, table)
 
     # Apply the permissions from Schema and Profiles.
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_a1", "LEVEL/A1")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_b1", "LEVEL/B1")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_c1", "LEVEL/C1")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_a2", "LEVEL/A2")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_b2", "LEVEL/B2")
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "level_c2", "LEVEL/C2")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_a1", "LEVEL/A1")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_b1", "LEVEL/B1")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_c1", "LEVEL/C1")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_a2", "LEVEL/A2")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_b2", "LEVEL/B2")
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "level_c2", "LEVEL/C2")
 
     # Check if the read priviliges are correct
     _check_permission_denied(engine, "level_a1", "gebieden_bouwblokken")
@@ -205,7 +205,7 @@ def test_auto_create_roles(here, engine, gebieden_schema_auth, dbsession):
     # _check_role_does_not_exist(engine, "scope_level_c")
 
     # Apply the permissions from Schema and Profiles.
-    apply_schema_and_profile_permissions(engine, ams_schema, profiles, "AUTO", "ALL", create_roles=True)
+    apply_schema_and_profile_permissions(engine, "public", ams_schema, profiles, "AUTO", "ALL", create_roles=True)
     # Check if roles exist and the read priviliges are correct
     _check_permission_denied(engine, "scope_level_a", "gebieden_bouwblokken")
     _check_permission_granted(engine, "scope_level_a", "gebieden_buurten")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,7 +3,6 @@ from schematools.importer.ndjson import NDJSONImporter
 from pg_grant import query
 from schematools.permissions import create_acl_from_profiles, apply_schema_and_profile_permissions
 from sqlalchemy.exc import ProgrammingError
-from psycopg2.errors import DuplicateObject
 import pytest
 from schematools.types import DatasetSchema
 


### PR DESCRIPTION
All database activities of the permissions CLI are now in a single transaction, to allow automatic rollback if something goes wrong.

The CLI interface is a bit cleaner, see `schema permissions apply --help` for options.
A typical way to invoke it would be:

`schema permissions apply --create-roles --auto --revoke --dry-run`

this creates missing db group roles, revokes any old table/column permissions, and sets new permissions according to scope.
(change `--dry-run` for `--execute` to actually run it).

`--auto` means that scope `ABC/DEF` will be associated to group role `scope_abc_def`.

