### PR TITLE
Loose n m relations

### DIFF
--- a/django_tests/test_models.py
+++ b/django_tests/test_models.py
@@ -135,3 +135,19 @@ def test_model_factory_loose_relations(meldingen_schema):
     model_cls = model_dict["statistieken"]
     meta = model_cls._meta
     assert isinstance(meta.get_field("buurt"), LooseRelationField)
+
+
+def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_schema):
+    """Prove that a loose relation is created when column
+    is part of relation definition (<dataset>:<table>:column)
+    """
+    model_dict = {
+        cls._meta.model_name: cls
+        for cls in schema_models_factory(
+            woningbouwplannen_schema, base_app_name="dso_api.dynamic_api"
+        )
+    }
+    model_cls = model_dict["woningbouwplan"]
+    meta = model_cls._meta
+    assert isinstance(meta.get_field("buurten"), models.ManyToManyField)
+

--- a/django_tests/test_models.py
+++ b/django_tests/test_models.py
@@ -1,7 +1,7 @@
 from django.contrib.gis.db import models
 from django_postgres_unlimited_varchar import UnlimitedCharField
 from schematools.contrib.django.factories import model_factory, schema_models_factory
-from schematools.contrib.django.models import LooseRelationField
+from schematools.contrib.django.models import LooseRelationField, LooseRelationManyToManyField
 
 
 def test_model_factory_fields(afval_schema):
@@ -149,5 +149,5 @@ def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_schema):
     }
     model_cls = model_dict["woningbouwplan"]
     meta = model_cls._meta
-    assert isinstance(meta.get_field("buurten"), models.ManyToManyField)
+    assert isinstance(meta.get_field("buurten"), LooseRelationManyToManyField)
 

--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -110,7 +110,6 @@ class FieldMaker:
                 return LooseRelationField, args, kwargs
 
 
-
         if relation is not None or nm_relation is not None:
             assert not (relation and nm_relation)
             field_cls = models.ManyToManyField if nm_relation else models.ForeignKey

--- a/schematools/contrib/django/managers.py
+++ b/schematools/contrib/django/managers.py
@@ -1,5 +1,4 @@
-from django.db.models import QuerySet
-
+from django.db.models import QuerySet, Manager
 
 class DatasetQuerySet(QuerySet):
     """Extra ORM methods for the Dataset model."""
@@ -14,3 +13,14 @@ class DatasetQuerySet(QuerySet):
 
     def api_enabled(self):
         return self.filter(enable_api=True)
+
+
+    def hallo(self):
+        return "hallo"
+
+
+class LooseRelationsManager(Manager):
+    def get_queryset(self):
+        # Hier logica om te dealen met loose relations
+        qs = super().get_queryset()
+        return qs

--- a/schematools/contrib/django/managers.py
+++ b/schematools/contrib/django/managers.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet, Manager
+from django.db.models import QuerySet
 
 class DatasetQuerySet(QuerySet):
     """Extra ORM methods for the Dataset model."""
@@ -15,12 +15,3 @@ class DatasetQuerySet(QuerySet):
         return self.filter(enable_api=True)
 
 
-    def hallo(self):
-        return "hallo"
-
-
-class LooseRelationsManager(Manager):
-    def get_queryset(self):
-        # Hier logica om te dealen met loose relations
-        qs = super().get_queryset()
-        return qs

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -27,7 +27,6 @@ from schematools.types import (
 )
 from schematools.utils import to_snake_case
 
-from .managers import LooseRelationsManager
 
 from . import managers
 from .validators import URLPathValidator
@@ -162,11 +161,9 @@ class DynamicModel(models.Model):
     _display_field = None
 
     objects = Manager()
-    loose_objects = LooseRelationsManager()
 
     class Meta:
         abstract = True
-        base_manager_name = 'loose_objects'
 
     def __str__(self):
         if self._display_field:
@@ -243,7 +240,6 @@ class Dataset(models.Model):
 
     objects = managers.DatasetQuerySet.as_manager()
 
-    loose_objects = managers.LooseRelationsManager  # JVD
 
     class Meta:
         ordering = ("ordering", "name")

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -13,9 +13,6 @@ from django.contrib.postgres.fields import ArrayField, JSONField
 from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-
-from django.db.models import Manager
-
 from django_postgres_unlimited_varchar import UnlimitedCharField
 from gisserver.types import CRS
 from schematools.types import (
@@ -159,8 +156,6 @@ class DynamicModel(models.Model):
     #: Overwritten by subclasses / factory
     _table_schema: DatasetTableSchema = None
     _display_field = None
-
-    objects = Manager()
 
     class Meta:
         abstract = True

--- a/tests/files/woningbouwplannen.json
+++ b/tests/files/woningbouwplannen.json
@@ -1,0 +1,53 @@
+{
+  "type": "dataset",
+  "id": "woningbouwplannen",
+  "title": "Woningbouwplannen en Strategische ruimtes",
+  "description": "Deze dataset bevat de gegevens over de te realiseren woningen in Amsterdam.",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "woningbouwplan",
+      "type": "table",
+      "provenance": "wbw_woningbouwplan",
+      "title": "Woningbouwplan",
+      "description": "De aantallen vormen de planvoorraad. Dit zijn niet de aantallen die definitief worden gerealiseerd. Ervaring leert dat een deel van de planvoorraad wordt opgeschoven. Niet alle woningbouw initiatieven doorlopen de verschillende plaberumfasen. Met name kleinere particuliere projecten worden in de regel pas toegevoegd aan de monitor zodra er een intentieovereenkomst of afsprakenbrief is getekend.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "id",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "mainGeometry": "geometrie",
+        "display": "id",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unieke id van het object",
+            "provenance": "wbw_woningbouwplan_id"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "projectnaam": {
+            "type": "string",
+            "description": "Naam van het project"
+          },
+          "buurten": {
+            "type": "array",
+            "relation": "gebieden:buurten:identificatie",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Buurten waarin het woningbouwplan ligt"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -84,3 +84,8 @@ def meldingen_schema(schema_json) -> DatasetSchema:
 @pytest.fixture()
 def woonplaatsen_schema(schema_json) -> DatasetSchema:
     return DatasetSchema.from_dict(schema_json("woonplaatsen.json"))
+
+
+@pytest.fixture()
+def woningbouwplannen_schema(schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(schema_json("woningbouwplannen.json"))


### PR DESCRIPTION
LooseRelationManyToManyField is a custom field, used when a non-temporal dataset refers many-to-many to a temporal dataset. 

In the non-temporal dataset (the source) we get an array of identifiers, which refer to temporal objects (the target) having both an identifier and a sequence number (volgnummer). The volgnummer is unspecified, making it impossible to have an exact foreign key relation, but when viewed we want to see the latest (highest) one. This is being resolved in the dso-api serializer.


