### PR TITLE
Make temporal dimension fields optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,12 +86,22 @@ def tconn(engine, local_metadata):
 
 
 @pytest.fixture(scope="module")
-def local_metadata(engine):
+def module_metadata(engine):
     """A module scoped metadata. This can be used to collect table structures
     during tests that are part of a particular module. At the module boundary, these tables
     are dropped. When Table models are constructed serveral times in these tests,
     the 'extend_existing' constructor arg. can be used, to avoid errors.
     Tables are just replaced in the same metadata object.
+    """
+    _meta = MetaData()
+    yield _meta
+    _meta.drop_all(bind=engine)
+
+
+@pytest.fixture
+def local_metadata(engine):
+    """A function scoped metadata. Some tests really need to destroy and not update
+    previous instances of SA Table objects.
     """
     _meta = MetaData()
     yield _meta

--- a/tests/files/ggwgebieden.json
+++ b/tests/files/ggwgebieden.json
@@ -8,11 +8,91 @@
   "temporal": {
     "identifier": "volgnummer",
     "dimensions": {
-      "geldigOp": ["begingeldigheid", "eindgeldigheid"]
+      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
     }
   },
   "crs": "EPSG:28992",
   "tables": [
+    {
+      "id": "buurten",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "registratiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De datum waarop de toestand is geregistreerd."
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "naam": {
+            "type": "string",
+            "description": "De naam van het object."
+          },
+          "code": {
+            "type": "string",
+            "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "documentdatum": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "documentnummer": {
+            "type": "string",
+            "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "cbsCode": {
+            "type": "string",
+            "description": "De CBS-code van het object."
+          },
+          "ligtInWijk": {
+            "type": "object",
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "integer"
+              }
+            },
+            "relation": "gebieden:wijken",
+            "description": "De wijk waar de buurt in ligt."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Geometrische beschrijving van een object."
+          }
+        }
+      }
+    },
     {
       "id": "ggwgebieden",
       "type": "table",
@@ -98,4 +178,3 @@
     }
   ]
 }
-

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,6 @@
 from datetime import datetime, date
 from dateutil.parser import parse as dtparse
+import pytest
 from schematools.events import EventsProcessor
 
 # pytestmark = pytest.mark.skip("all tests disabled")
@@ -19,9 +20,7 @@ def test_event_process_insert(here, tconn, local_metadata, gebieden_schema):
     assert records[0]["begin_geldigheid"] == date(2006, 6, 12)
 
 
-def test_event_process_update(
-    here, tconn, local_metadata, transaction, gebieden_schema
-):
+def test_event_process_update(here, tconn, local_metadata, gebieden_schema):
     events_path = here / "files" / "data" / "bouwblokken_update.gobevents"
     importer = EventsProcessor(
         [gebieden_schema], 28992, tconn, local_metadata=local_metadata, truncate=True
@@ -34,9 +33,7 @@ def test_event_process_update(
     assert records[0]["registratiedatum"] == datetime(2020, 2, 5, 15, 6, 43)
 
 
-def test_event_process_delete(
-    here, tconn, local_metadata, transaction, gebieden_schema
-):
+def test_event_process_delete(here, tconn, local_metadata, gebieden_schema):
     events_path = here / "files" / "data" / "bouwblokken_delete.gobevents"
     importer = EventsProcessor(
         [gebieden_schema], 28992, tconn, local_metadata=local_metadata, truncate=True
@@ -47,13 +44,15 @@ def test_event_process_delete(
     assert records[0]["code"] == "AA01"
 
 
+@pytest.mark.parametrize("use_dimension_fields", (True, False))
 def test_event_process_1n_relation_insert(
-    here, tconn, local_metadata, transaction, gebieden_schema
+    here, tconn, local_metadata, gebieden_schema, use_dimension_fields
 ):
     events_bb_path = here / "files" / "data" / "bouwblokken.gobevents"
     events_rel_path = (
         here / "files" / "data" / "gebieden_bouwblokken_ligt_in_buurt.gobevents"
     )
+    gebieden_schema.use_dimension_fields = use_dimension_fields
     importer = EventsProcessor(
         [gebieden_schema],
         28992,
@@ -68,20 +67,24 @@ def test_event_process_1n_relation_insert(
     assert records[1]["ligt_in_buurt_id"] == "03630000000707.2"
     assert records[1]["ligt_in_buurt_source_id"] == "03630012094861.1.AMSBI.geometrie"
     # Proper subset
-    assert {
-        "ligt_in_buurt_begin_geldigheid",
-        "ligt_in_buurt_eind_geldigheid",
-        "ligt_in_buurt_source_id",
-    } < records[0].keys()
+    available_columns = {"ligt_in_buurt_source_id"}
+    if use_dimension_fields:
+        available_columns |= {
+            "ligt_in_buurt_begin_geldigheid",
+            "ligt_in_buurt_eind_geldigheid",
+        }
+    available_columns < records[0].keys()
 
 
+@pytest.mark.parametrize("use_dimension_fields", (False, True))
 def test_event_process_1n_relation_delete(
-    here, tconn, local_metadata, transaction, gebieden_schema
+    here, tconn, local_metadata, gebieden_schema, use_dimension_fields
 ):
     events_bb_path = here / "files" / "data" / "bouwblokken.gobevents"
     events_rel_path = (
         here / "files" / "data" / "gebieden_bouwblokken_ligt_in_buurt_delete.gobevents"
     )
+    gebieden_schema.use_dimension_fields = use_dimension_fields
     importer = EventsProcessor(
         [gebieden_schema], 28992, tconn, local_metadata=local_metadata, truncate=True
     )
@@ -91,19 +94,26 @@ def test_event_process_1n_relation_delete(
     assert len(records) == 2
     # The source_id need to be saved, for future updates
     assert records[1]["ligt_in_buurt_source_id"] is not None
-    assert records[1]["ligt_in_buurt_begin_geldigheid"] is None
-    assert records[1]["ligt_in_buurt_eind_geldigheid"] is None
+    if use_dimension_fields:
+        assert records[1]["ligt_in_buurt_begin_geldigheid"] is None
+        assert records[1]["ligt_in_buurt_eind_geldigheid"] is None
     assert records[1]["ligt_in_buurt_identificatie"] is None
     assert records[1]["ligt_in_buurt_volgnummer"] is None
     assert records[1]["ligt_in_buurt_id"] is None
 
 
+@pytest.mark.parametrize("use_dimension_fields", (True, False))
 def test_event_process_nm_relation_insert(
-    here, tconn, local_metadata, transaction, gebieden_schema
+    here,
+    tconn,
+    local_metadata,
+    gebieden_schema,
+    use_dimension_fields,
 ):
     events_rel_path = (
         here / "files" / "data" / "gebieden_ggwgebieden_bestaat_uit_buurten.gobevents"
     )
+    gebieden_schema.use_dimension_fields = use_dimension_fields
     importer = EventsProcessor(
         [gebieden_schema], 28992, tconn, local_metadata=local_metadata, truncate=True
     )
@@ -117,7 +127,7 @@ def test_event_process_nm_relation_insert(
         records["03630950000016.1.AMSBI.N65d"]["bestaat_uit_buurten_id"]
         == "03630000000658.1"
     )
-    assert list(records.values())[0].keys() == {
+    available_columns = {
         "source_id",
         "ggwgebieden_id",
         "bestaat_uit_buurten_id",
@@ -125,13 +135,16 @@ def test_event_process_nm_relation_insert(
         "ggwgebieden_volgnummer",
         "bestaat_uit_buurten_identificatie",
         "bestaat_uit_buurten_volgnummer",
-        "begin_geldigheid",
-        "eind_geldigheid",
     }
 
+    if use_dimension_fields:
+        available_columns |= {"begin_geldigheid", "eind_geldigheid"}
+    assert available_columns <= list(records.values())[0].keys()
 
+
+@pytest.mark.parametrize("use_dimension_fields", (True, False))
 def test_event_process_nm_relation_update(
-    here, tconn, local_metadata, transaction, gebieden_schema
+    here, tconn, local_metadata, gebieden_schema, use_dimension_fields
 ):
     events_rel_path = (
         here
@@ -139,6 +152,7 @@ def test_event_process_nm_relation_update(
         / "data"
         / "gebieden_ggwgebieden_bestaat_uit_buurten_update.gobevents"
     )
+    gebieden_schema.use_dimension_fields = use_dimension_fields
     importer = EventsProcessor(
         [gebieden_schema], 28992, tconn, local_metadata=local_metadata, truncate=True
     )
@@ -148,18 +162,17 @@ def test_event_process_nm_relation_update(
         for r in tconn.execute("SELECT * from gebieden_ggwgebieden_bestaat_uit_buurten")
     }
     assert len(records) == 3
-    assert records["03630950000015.1.AMSBI.M50e"]["begin_geldigheid"] == dtparse(
-        "2019-10-03T00:00:00.000000"
-    )
+    if use_dimension_fields:
+        assert records["03630950000015.1.AMSBI.M50e"]["begin_geldigheid"] == dtparse(
+            "2019-10-03T00:00:00.000000"
+        )
     assert (
         records["03630950000015.1.AMSBI.M50e"]["bestaat_uit_buurten_id"]
         == "03630023754008.1"
     )
 
 
-def test_event_process_nm_relation_delete(
-    here, tconn, local_metadata, transaction, gebieden_schema
-):
+def test_event_process_nm_relation_delete(here, tconn, local_metadata, gebieden_schema):
     events_rel_path = (
         here
         / "files"


### PR DESCRIPTION
Temporal dimension fields (begin_geldigheid, eind_geldigheid) were inserted to the Django models (for temporary dataset-tables) by default. However, most of the current database tables do not have these fields, because the current ndjson import does not provide these fields. The generation of dimension fields is now made configurable and switched off by default.