### PR TITLE
[DS-514] DB_NAME instance method for getting table name

### DIFF
--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -13,7 +13,6 @@ from schematools.types import (
     DatasetTableSchema,
     get_db_table_name,
 )
-from schematools import MAX_TABLE_LENGTH
 from schematools.utils import to_snake_case
 from .models import (
     FORMAT_MODELS_LOOKUP,
@@ -34,10 +33,12 @@ class FieldMaker:
     def __init__(
         self,
         field_cls: Type[models.Field],
+        table: DatasetTableSchema,
         value_getter: Callable[[DatasetSchema], Dict[str, Any]] = None,
         **kwargs,
     ):
         self.field_cls = field_cls
+        self.table = table
         self.value_getter = value_getter
         self.kwargs = kwargs
         self.modifiers = [
@@ -50,11 +51,13 @@ class FieldMaker:
         ]
         return f"{related_dataset}.{related_table}"
 
-    def _make_through_classname(self, dataset_id, left_table_id, field_name):
-        left_table = to_snake_case(left_table_id)
+    def _make_through_classname(self, dataset_id, field_name):
         snakecased_fieldname = to_snake_case(field_name)
-        through_table_id = f"{left_table}_{snakecased_fieldname}"
-        return f"{dataset_id}.{through_table_id}"[:MAX_TABLE_LENGTH]
+        through_table_id = get_db_table_name(self.table, snakecased_fieldname)
+        # dso-api expects the dataset_id seperated from the table_id by a point
+        table_id = "_".join(through_table_id.split("_")[1:])
+        dataset_id = through_table_id.split("_")[0]
+        return f"{dataset_id}.{table_id}"
 
     def handle_basic(
         self,
@@ -236,7 +239,7 @@ def model_factory(table: DatasetTableSchema, base_app_name=None) -> Type[Dynamic
             init_kwargs = {}
 
         # Generate field object
-        kls, args, kwargs = FieldMaker(base_class, **init_kwargs)(field, dataset)
+        kls, args, kwargs = FieldMaker(base_class, table, **init_kwargs)(field, dataset)
         if kls is None or kls is ObjectMarker:
             # Some fields are not mapped into classes
             continue

--- a/schematools/contrib/django/factories.py
+++ b/schematools/contrib/django/factories.py
@@ -124,9 +124,7 @@ class FieldMaker:
                 parent_table = to_snake_case(field._parent_table.id)
                 kwargs["related_name"] = f"{snakecased_fieldname}_{parent_table}"
                 # kwargs["db_constraint"] = True
-                kwargs["through"] = self._make_through_classname(
-                    dataset.id, field._parent_table.id, field.name
-                )
+                kwargs["through"] = self._make_through_classname(dataset.id, field.name)
                 kwargs["through_fields"] = (parent_table, snakecased_fieldname)
             elif field._parent_table.has_parent_table:
                 kwargs["related_name"] = field._parent_table["originalID"]

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -7,6 +7,7 @@ from collections import UserDict
 import jsonschema
 from . import RELATION_INDICATOR
 from schematools import MAX_TABLE_LENGTH, TMP_TABLE_POSTFIX
+from schematools.utils import to_snake_case
 
 
 class SchemaType(UserDict):
@@ -201,8 +202,11 @@ class DatasetSchema(SchemaType):
             to_snake_case(part) for part in field.nm_relation.split(":")[:2]
         ]
         snakecased_fieldname = to_snake_case(field.name)
+        table_id = get_db_table_name(table, snakecased_fieldname)
+        # dso-api expects the dataset_id (as prefix) not part of the table_id
+        table_id = "_".join(table_id.split("_")[1:])
         sub_table_schema = dict(
-            id=f"{left_table}_{snakecased_fieldname}",
+            id=table_id,
             type="table",
             schema={
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -405,6 +409,18 @@ class DatasetTableSchema(DatasetSchema):
     def is_through_table(self):
         """Indicates if table is an intersection table (n:m relation table) or base table"""
         return self.through_table
+
+    def db_name(self, through_table_field_name=None):
+        """Returns the database implementation name of a table.
+        TODO: Get database name from the JSON schema specification by defining 'shortname'.
+        For now using existing function that is already used in the GOB data (NDJson files)
+        """
+        if through_table_field_name:
+            # for n:m tables, use the relating field_name as part of DB table name
+            # i.e. heeft_verblijfsobjecten
+            return get_db_table_name(self, through_table_field_name)
+        else:
+            return get_db_table_name(self, None)
 
 
 class DatasetFieldSchema(DatasetType):
@@ -721,13 +737,14 @@ class ProfileTableSchema(DatasetType):
         return self.get("mandatoryFilterSets", [])
 
 
-def get_db_table_name(table: DatasetTableSchema) -> str:
+def get_db_table_name(table: DatasetTableSchema, through_table_field_name=None) -> str:
     """Generate the table name for a database schema."""
-    from schematools.utils import to_snake_case
-
     dataset = table._parent_schema
     app_label = dataset.id
     table_id = table.id
-    return to_snake_case(f"{app_label}_{table_id}")[
-        : MAX_TABLE_LENGTH - len(TMP_TABLE_POSTFIX)
-    ]
+    through_table_field_name = (
+        "_" + through_table_field_name if through_table_field_name else ""
+    )
+    return to_snake_case(f"{app_label}_{table_id}{through_table_field_name}").replace(
+        "-", "_"
+    )[: MAX_TABLE_LENGTH - len(TMP_TABLE_POSTFIX)]

--- a/tests/files/brk.json
+++ b/tests/files/brk.json
@@ -1,0 +1,1236 @@
+{
+    "type": "dataset",
+    "id": "brk",
+    "title": "brk",
+    "status": "niet_beschikbaar",
+    "version": "0.0.1",
+    "crs": "EPSG:28992",
+    "auth": "BRK/RSN",
+    "identifier": "identificatie",
+    "temporal": {
+      "identifier": "volgnummer",
+      "dimensions": {
+        "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+      }
+    },
+    "tables": [
+      {
+        "id": "kadastraleobjecten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": ["identificatie", "volgnummer"],
+          "required": ["schema", "id", "identificatie", "volgnummer"],
+          "display": "identificatie",
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "id": {
+              "type": "string",
+              "description": "Neuron ID"
+            },
+            "volgnummer": {
+              "type": "integer",
+              "description": "Uniek volgnummer van de toestand van het object."
+            },
+            "registratiedatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de toestand is geregistreerd."
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De unieke aanduiding van een Kadastraal object."
+            },
+            "kadastraleAanduiding": {
+              "type": "string",
+              "description": "De unieke aanduiding van een Kadastraal Object samengesteld uit gemeentecode, kadastrale sectie, perceelnummer, indexletter en indexnummer."
+            },
+            "perceelnummer": {
+              "type": "integer",
+              "description": "Een numerieke aanduiding van het kadastrale perceel per sectie, deel van de kadastrale aanduiding van de onroerende zaak."
+            },
+            "indexletter": {
+              "type": "string",
+              "description": "Letter Kadastraal object, dit geeft een indicatie voor het type object. G Grond perceel. A Appartementsrecht"
+            },
+            "indexnummer": {
+              "type": "integer",
+              "description": "Volgnummer van het Appartementsrecht"
+            },
+            "gemeente": {
+              "type": "string",
+              "description": ""
+            },
+            "soortGrootteCode": {
+              "type": "string",
+              "provenance": "$.soortGrootte.code",
+              "description": "Aanduiding van soort grootte code"
+            },
+            "soortGrootteOmschrijving": {
+              "type": "string",
+              "provenance": "$.soortGrootte.omschrijving",
+              "description": "Aanduiding van soort grootte omschrijving"
+            },
+            "grootte": {
+              "type": "number",
+              "description": "De grootte van een kadastraal object is de oppervlakte van het kadastrale perceel. Dit kan bij een deelperceel een geschatte grootte zijn."
+            },
+            "soortCultuurOnbebouwdCode": {
+              "type": "string",
+              "provenance": "$.soortCultuurOnbebouwd.code",
+              "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als ‘omschrijving kadastraal object’ in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
+            },
+            "soortCultuurOnbebouwdOmschrijving": {
+              "type": "string",
+              "provenance": "$.soortCultuurOnbebouwd.omschrijving",
+              "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als ‘omschrijving kadastraal object’ in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
+            },
+            "soortCultuurBebouwd": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "omschrijving": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "status": {
+              "type": "string",
+              "description": "Status van het Kadastraal Object ('B' is bestaand)"
+            },
+            "geometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de kadastrale sectie in het stelsel van de Rijksdriehoeksmeting (RD)"
+            },
+            "plaatscoordinaten": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "De aanduiding van een kaartpunt voor de weergave van de identificatie van een perceel (centroïde)"
+            },
+            "perceelnummerRotatie": {
+              "type": "number",
+              "description": "Rotatie van het perceelnummer ten behoeve van afbeelding op de kaart. Perceelnummers worden bijvoorbeeld gekanteld om in een smal perceel te passen"
+            },
+            "perceelnummerVerschuivingX": {
+              "type": "string",
+              "description": "Coördinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden x"
+            },
+            "perceelnummerVerschuivingY": {
+              "type": "string",
+              "description": "Coördinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden y"
+            },
+            "bijpijlingGeometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de bijpijling (de puur grafische lijn tussen het perceel en het perceelnummer)  in het stelsel van de Rijksdriehoeksmeting (RD)"
+            },
+            "indicatieVoorlopigeGeometrie": {
+              "type": "string",
+              "description": "Indicatie of de geometrie (kadastrale grens) voorlopig is of niet J N"
+            },
+            "koopsom": {
+              "type": "integer",
+              "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen."
+            },
+            "koopsomValutacode": {
+              "type": "string",
+              "description": "Aanduiding van de valutasoort gebruikt bij de koop"
+            },
+            "koopjaar": {
+              "type": "string",
+              "description": "Transactiejaar van de aankoop"
+            },
+            "indicatieMeerObjecten": {
+              "type": "string",
+              "description": "Indicatie dat de koopsom betrekking heeft op meer dan 1 kadastraal object"
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "inOnderzoek": {
+              "type": "string",
+              "description": "Als dit veld is gevuld geeft dit de omschrijving waarom dit gegeven in onderzoek staat (art. 7n en 7r Kadasterwet)."
+            },
+            "heeftEenRelatieMetVerblijfsobject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "baggob:verblijfsobjecten",
+              "description": "Relatie naar verblijfsobject"
+            }
+          },
+          "mainGeometry": "geometrie"
+        }
+      },
+      {
+        "id": "zakelijkerechten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/zakelijkerechten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": ["identificatie", "volgnummer"],
+          "required": ["schema", "id", "identificatie", "volgnummer"],
+          "display": "id",
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "volgnummer": {
+              "type": "integer",
+              "description": "Uniek volgnummer van de toestand van het object."
+            },
+            "registratiedatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de toestand is geregistreerd."
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De Kadaster identificatie is een door het Kadaster toegekende landelijk uniek nummer aan dit zakelijk recht binnen de kadastrale registratie."
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "isBeperktTot": {
+              "type": "integer",
+              "description": "Is beperkt tot tenaamstelling, dat wil zeggen is beperkt tot een subject"
+            },
+            "rustOpKadastraalobject": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:kadastraleobjecten",
+              "description": "Het kadastraal object en volgnummer waarop het zakelijk recht rust"
+            },
+            "appartementsrechtsplitsingidentificatie": {
+              "type": "string",
+              "description": "De identificatie van de appartementsrechtsplitsing"
+            },
+            "appartementsrechtsplitsingtypeCode": {
+              "type": "string",
+              "provenance": "$.appartementsrechtsplitsingtype.code",
+              "description": "Het type appartementsrechtsplitsing. De mogelijke waarden zijn: hoofdsplitsing of ondersplitsing of splitsing afkoop erfpacht. code"
+            },
+            "appartementsrechtsplitsingtypeOmschrijving": {
+              "type": "string",
+              "provenance": "$.appartementsrechtsplitsingtype.omschrijving",
+              "description": "Het type appartementsrechtsplitsing. De mogelijke waarden zijn: hoofdsplitsing of ondersplitsing of splitsing afkoop erfpacht. omschrijving"
+            },
+            "einddatumAppartementsrechtsplitsing": {
+              "type": "string",
+              "description": "Einddatum van de appartementsrechtsplitsing"
+            },
+            "indicatieActueelAppartementsrechtsplitsing": {
+              "type": "string",
+              "description": "Indicatie van de actualiteit van de appartementsrechtsplitsing"
+            },
+            "aardZakelijkRechtCode": {
+              "type": "string",
+              "provenance": "$.aardZakelijkRecht.code",
+              "description": "De aard van het zakelijk recht code"
+            },
+            "aardZakelijkRechtOmschrijving": {
+              "type": "string",
+              "provenance": "$.aardZakelijkRecht.omschrijving",
+              "description": "De aard van het zakelijk recht omschrijving"
+            },
+            "akrAardZakelijkRecht": {
+              "type": "string",
+              "description": "De AKR code van de aard van het zakelijk recht"
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            }
+          }
+        }
+      },
+      {
+        "id": "kadastralesubjecten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesubjecten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "Het aan dit subject toegekende landelijk unieke nummer"
+            },
+            "typeSubject": {
+              "type": "string",
+              "description": "Afgeleid gegeven. Is het subject een natuurlijk persoon of een niet-natuurlijk persoon"
+            },
+            "beschikkingsbevoegdheidCode": {
+              "provenance": "$.beschikkingsbevoegdheid.code",
+              "type": "string",
+              "description": "Aanduiding van de beschikkingsbevoegdheid van een persoon. code"
+            },
+            "beschikkingsbevoegdheidOmschrijving": {
+              "type": "string",
+              "provenance": "$.beschikkingsbevoegdheid.omschrijving",
+              "description": "Aanduiding van de beschikkingsbevoegdheid van een persoon. omschrijving"
+            },
+            "heeftBsnVoor": {
+              "type": "string",
+              "$comment": "relation brp:personen",
+              "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer."
+            },
+            "voornamen": {
+              "type": "string",
+              "description": "Voornamen van het subject"
+            },
+            "voorvoegsels": {
+              "type": "string",
+              "description": "Voorvoegsels bij de geslachtsnaam"
+            },
+            "geslachtsnaam": {
+              "type": "string",
+              "description": "Geslachtsnaam van de geregistreerde persoon"
+            },
+            "geslachtCode": {
+              "type": "string",
+              "provenance": "$.geslacht.code",
+              "description": "Geslacht van het geregistreerd persoon. Dit kenmerk kent een domein voor als de persoon in de BRP voorkomt en een domein voor als de persoon niet in de BRP voorkomt. code"
+            },
+            "geslachtOmschrijving": {
+              "type": "string",
+              "provenance": "$.geslacht.omschrijving",
+              "description": "Geslacht van het geregistreerd persoon. Dit kenmerk kent een domein voor als de persoon in de BRP voorkomt en een domein voor als de persoon niet in de BRP voorkomt. omschrijving"
+            },
+            "naamGebruikCode": {
+              "type": "string",
+              "provenance": "$.naamGebruik.code",
+              "description": "Aanduiding naam gebruik code"
+            },
+            "naamGebruikOmschrijving": {
+              "type": "string",
+              "provenance": "$.naamGebruik.omschrijving",
+              "description": "Aanduiding naam gebruik omschrijving"
+            },
+            "geboortedatum": {
+              "type": "string",
+              "format": "date",
+              "description": "De datum waarop een natuurlijk persoon is geboren. Deze datum kan onvolledig zijn (alleen jaar, of alleen jaar en maand bekend)."
+            },
+            "geboorteplaats": {
+              "type": "string",
+              "description": "De geboorteplaats is een plaatsaanduiding, die aangeeft waar de natuurlijke persoon geboren is."
+            },
+            "geboortelandCode": {
+              "provenance": "$.geboorteland.code",
+              "type": "string",
+              "description": "Geboorteland is een aanduiding van het land waar de natuurlijke persoon geboren is. code"
+            },
+            "geboortelandOmschrijving": {
+              "type": "string",
+              "provenance": "$.geboorteland.omschrijving",
+              "description": "Geboorteland is een aanduiding van het land waar de natuurlijke persoon geboren is. omschrijving"
+            },
+            "datumOverlijden": {
+              "type": "string",
+              "description": "De overlijdensdatum is de datum waarop een natuurlijk persoon is overleden."
+            },
+            "indicatieOverleden": {
+              "type": "string",
+              "description": "Indicatie of de persoon al dan niet overleden is. De datum van overlijden is soms niet bekend, maar wel dat iemand overleden is. Dat is uit dit attribuut af te leiden."
+            },
+            "voornamenPartner": {
+              "type": "string",
+              "description": "Voorna(a)m(en) van de gerigstreerde partner"
+            },
+            "voorvoegselsPartner": {
+              "type": "string",
+              "description": "Voorvoegsel van de geregistreerde partner"
+            },
+            "geslachtsnaamPartner": {
+              "type": "string",
+              "description": "Geslachtsna(a)m(en) van de geregistreerde partner"
+            },
+            "heeftRsinVoor": {
+              "type": "string",
+              "$comment": "relation hr:nietnatuurlijkepersonen *stringify*",
+              "description": "Het Rechtspersonen Samenwerking Identificatie Nummer uit het Handelsregister."
+            },
+            "heeftKvknummerVoor": {
+              "type": "string",
+              "$comment": "relation hr:maatschappelijkeactiviteiten *stringify*",
+              "description": "Het KvK-nummer uit het Handelsregister."
+            },
+            "rechtsvormCode": {
+              "type": "string",
+              "provenance": "$.rechtsvorm.code",
+              "description": "De juridische vorm van een niet-natuurlijk persoon. code"
+            },
+            "rechtsvormOmschrijving": {
+              "type": "string",
+              "provenance": "$.rechtsvorm.omschrijving",
+              "description": "De juridische vorm van een niet-natuurlijk persoon. omschrijving"
+            },
+            "statutaireNaam": {
+              "type": "string",
+              "description": "De naam van de rechtspersoon. Het betreft de naam die is opgenomen in de oprichtingsakte."
+            },
+            "statutaireZetel": {
+              "type": "string",
+              "description": "De statutaire plaats van vestiging."
+            },
+            "woonadresAdresseerbaarObject": {
+              "type": "string",
+              "provenance": "$.woonadres.adresseerbaarObject",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats adresseerbaar_object"
+            },
+            "woonadresOpenbareRuimte": {
+              "type": "string",
+              "provenance": "$.woonadres.openbareRuimte",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats openbare_ruimte"
+            },
+            "woonadresHuisnummer": {
+              "type": "integer",
+              "provenance": "$.woonadres.huisnummer",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats huisnummer"
+            },
+            "woonadresHuisletter": {
+              "type": "string",
+              "provenance": "$.woonadres.huisletter",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats huisletter"
+            },
+            "woonadresHuisnummerToevoeging": {
+              "type": "string",
+              "provenance": "$.woonadres.huisnummerToevoeging",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats huisnummer_toevoeging"
+            },
+            "woonadresPostcode": {
+              "type": "string",
+              "provenance": "$.woonadres.postcode",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats postcode"
+            },
+            "woonadresWoonplaats": {
+              "type": "string",
+              "provenance": "$.woonadres.woonplaats",
+              "description": "BAG: Verblijfsobject / Standplaats / Ligplaats woonplaats"
+            },
+            "landWaarnaarVertrokkenCode": {
+              "provenance": "$.landWaarnaarVertrokken.code",
+              "type": "string",
+              "description": "Land waar naar vertrokken code"
+            },
+            "landWaarnaarVertrokkenOmschrijving": {
+              "type": "string",
+              "provenance": "$.landWaarnaarVertrokken.omschrijving",
+              "description": "Land waar naar vertrokken omschrijving"
+            },
+            "woonadresBuitenlandAdres": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.adres",
+              "description": "Buitenlands adres adres"
+            },
+            "woonadresBuitenlandWoonplaats": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.woonplaats",
+              "description": "Buitenlands adres woonplaats"
+            },
+            "woonadresBuitenlandRegio": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.regio",
+              "description": "Buitenlands adres regio"
+            },
+            "woonadresBuitenlandNaam": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.naam",
+              "description": "Buitenlands adres naam"
+            },
+            "woonadresBuitenlandCode": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.code",
+              "description": "Buitenlands adres code"
+            },
+            "woonadresBuitenlandOmschrijving": {
+              "type": "string",
+              "provenance": "$.woonadresBuitenland.omschrijving",
+              "description": "Buitenlands adres omschrijving"
+            },
+            "postadresAdresseerbaarObject": {
+              "type": "string",
+              "provenance": "$.postadres.adresseerbaarObject",
+              "description": "adresseerbaar_object"
+            },
+            "postadresOpenbareRuimte": {
+              "type": "string",
+              "provenance": "$.postadres.openbareRuimte",
+              "description": "openbare_ruimte"
+            },
+            "postadresHuisnummer": {
+              "type": "integer",
+              "provenance": "$.postadres.huisnummer",
+              "description": "huisnummer"
+            },
+            "postadresHuisletter": {
+              "type": "string",
+              "provenance": "$.postadres.huisletter",
+              "description": "huisletter"
+            },
+            "postadresHuisnummerToevoeging": {
+              "type": "string",
+              "provenance": "$.postadres.huisnummerToevoeging",
+              "description": "huisnummer_toevoeging"
+            },
+            "postadresPostcode": {
+              "type": "string",
+              "provenance": "$.postadres.postcode",
+              "description": "postcode"
+            },
+            "postadresWoonplaats": {
+              "type": "string",
+              "provenance": "$.postadres.woonplaats",
+              "description": "woonplaats"
+            },
+            "postadresBuitenlandAdres": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.adres",
+              "description": "adres"
+            },
+            "postadresBuitenlandWoonplaats": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.woonplaats",
+              "description": "woonplaats"
+            },
+            "postadresBuitenlandRegio": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.regio",
+              "description": "regio"
+            },
+            "postadresBuitenlandNaam": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.naam",
+              "description": "naam"
+            },
+            "postadresBuitenlandCode": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.code",
+              "description": "code"
+            },
+            "postadresBuitenlandOmschrijving": {
+              "type": "string",
+              "provenance": "$.postadresBuitenland.omschrijving",
+              "description": "omschrijving"
+            },
+            "postadresPostbusNummer": {
+              "type": "string",
+              "provenance": "$.postadresPostbus.nummer",
+              "description": "nummer"
+            },
+            "postadresPostbusPostcode": {
+              "type": "string",
+              "provenance": "$.postadresPostbus.postcode",
+              "description": "postcode"
+            },
+            "postadresPostbusWoonplaatsnaam": {
+              "type": "string",
+              "provenance": "$.postadresPostbus.woonplaatsnaam",
+              "description": "woonplaatsnaam"
+            }
+          }
+        }
+      },
+      {
+        "id": "tenaamstellingen",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": ["identificatie", "volgnummer"],
+          "required": ["schema", "volgnummer", "identificatie"],
+          "display": "identificatie",
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De identificatie is een uniek nummer aan deze tenaamstelling binnen de kadastrale registratie."
+            },
+            "volgnummer": {
+              "type": "integer",
+              "description": ""
+            },
+            "vanKadastraalsubject": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:kadastralesubjecten",
+              "description": "Het Subject waarvoor deze tenaamstelling geldt."
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "aandeelTeller": {
+              "type": "integer",
+              "provenance": "$.aandeel.teller",
+              "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht teller"
+            },
+            "aandeelNoemer": {
+              "type": "integer",
+              "provenance": "$.aandeel.noemer",
+              "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht noemer"
+            },
+            "geldtVoorTeller": {
+              "type": "integer",
+              "provenance": "$.geldtVoor.teller",
+              "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). teller"
+            },
+            "geldtVoorNoemer": {
+              "type": "integer",
+              "provenance": "$.geldtVoor.noemer",
+              "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). noemer"
+            },
+            "burgerlijkeStaatTenTijdeVanVerkrijgingCode": {
+              "type": "string",
+              "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.code",
+              "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. code"
+            },
+            "burgerlijkeStaatTenTijdeVanVerkrijgingOmschrijving": {
+              "type": "string",
+              "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.omschrijving",
+              "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. omschrijving"
+            },
+            "verkregenNamensSamenwerkingsverbandCode": {
+              "type": "string",
+              "provenance": "$.verkregenNamensSamenwerkingsverband.code",
+              "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. code"
+            },
+            "verkregenNamensSamenwerkingsverbandOmschrijving": {
+              "type": "string",
+              "provenance": "$.verkregenNamensSamenwerkingsverband.omschrijving",
+              "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. omschrijving"
+            },
+            "inOnderzoek": {
+              "type": "string",
+              "description": ""
+            },
+            "vanZakelijkrecht": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:zakelijkerechten",
+              "description": "Het Zakelijk recht waarover deze tenaamstelling gaat."
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            }
+          }
+        }
+      },
+      {
+        "id": "aantekeningenrechten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenrechten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "id",
+          "required": ["schema", "id", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "id": {
+              "type": "string",
+              "description": "Neuron ID"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
+            },
+            "aardCode": {
+              "type": "string",
+              "provenance": "$.aard.code",
+              "description": "De aard van de aantekening. code"
+            },
+            "aardOmschrijving": {
+              "type": "string",
+              "provenance": "$.aard.omschrijving",
+              "description": "De aard van de aantekening. omschrijving"
+            },
+            "omschrijving": {
+              "type": "string",
+              "description": "Omschrijving bij de aantekening"
+            },
+            "betrokkenTenaamstelling": {
+              "type": "string",
+              "relation": "brk:tenaamstellingen",
+              "description": "Identificatie van de betrokken tenaamstelling"
+            },
+            "heeftBetrokkenPersoon": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "brk:kadastralesubjecten",
+              "description": "Identificatie van het betrokken subject"
+            },
+            "isGebaseerdOpStukdeel": {
+              "type": "string",
+              "relation": "brk:stukdelen",
+              "description": "Identificatie van het betrokken stukdeel"
+            },
+            "einddatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            }
+          }
+        }
+      },
+      {
+        "id": "aantekeningenkadastraleobjecten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenkadastraleobjecten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": ["identificatie", "volgnummer"],
+          "required": ["schema", "identificatie", "volgnummer"],
+          "display": "id",
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "volgnummer": {
+              "type": "integer",
+              "description": "Uniek volgnummer van de toestand van het object."
+            },
+            "registratiedatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de toestand is geregistreerd."
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": ""
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "Het door het Kadaster toegekende landelijk unieke nummer aan deze aantekening."
+            },
+            "aardCode": {
+              "type": "string",
+              "provenance": "$.aard.code",
+              "description": "De aard van de aantekening code"
+            },
+            "aardOmschrijving": {
+              "type": "string",
+              "provenance": "$.aard.omschrijving",
+              "description": "De aard van de aantekening omschrijving"
+            },
+            "omschrijving": {
+              "type": "string",
+              "description": "Omschrijving bij de aantekening"
+            },
+            "heeftBetrokkenPersoon": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "brk:kadastralesubjecten",
+              "description": "Identificatie van het betrokken subject"
+            },
+            "heeftBetrekkingOpKadastraalObject": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:kadastraleobjecten",
+              "description": "Identificatie van het kadastrale object (onroerende zaak)"
+            },
+            "isGebaseerdOpStukdeel": {
+              "type": "string",
+              "relation": "brk:stukdelen",
+              "description": "Identificatie van het betrokken stukdeel"
+            },
+            "einddatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            }
+          }
+        }
+      },
+      {
+        "id": "stukdelen",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/stukdelen.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stukdeel."
+            },
+            "aardCode": {
+              "type": "string",
+              "provenance": "$.aard.code",
+              "description": "Aanduiding voor de aard van een deel van het ter inschrijving aangeboden stuk (rechtsfeit). code"
+            },
+            "aardOmschrijving": {
+              "type": "string",
+              "provenance": "$.aard.omschrijving",
+              "description": "Aanduiding voor de aard van een deel van het ter inschrijving aangeboden stuk (rechtsfeit). omschrijving"
+            },
+            "bedragTransactieBedrag": {
+              "type": "integer",
+              "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. bedrag"
+            },
+            "bedragTransactieValuta": {
+              "type": "string",
+              "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. valuta"
+            },
+            "isBronVoorAantekeningKadastraalObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "brk:aantekeningenkadastraleobjecten",
+              "description": "Geeft weer welke aantekening kadastraal object is ontstaan op basis van dit stukdeel"
+            },
+            "isBronVoorAantekeningRecht": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "brk:aantekeningenrechten",
+              "description": "Geeft weer welke aantekening recht is ontstaan op basis van dit stukdeel"
+            },
+            "isBronVoorZakelijkRecht": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "string"
+                  }
+                }
+              },
+              "relation": "brk:zakelijkerechten",
+              "description": "Geeft weer welk zakelijk recht is ontstaan op basis van dit stukdeel."
+            },
+            "stukidentificatie": {
+              "type": "string",
+              "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stuk."
+            },
+            "portefeuillenummerAkr": {
+              "type": "string",
+              "description": "Portefeuillenummer toegekend aan het stuk in het AKR-systeem."
+            },
+            "tijdstipAanbiedingStuk": {
+              "type": "string",
+              "description": "Het tijdstip waarop een ter inschrijving aangeboden stuk is ontvangen met inachtneming van de openingstijden en -dagen van het Kadaster. Als tijdstip van inschrijving geldt het tijdstip van aanbieding van de voor de inschrijving vereiste stukken."
+            },
+            "reeks": {
+              "type": "string",
+              "description": "Verwijzing naar de oorspronkelijke (mogelijk tussentijds vervallen) Kadastervestiging waar het stuk oorspronkelijk is ingeschreven."
+            },
+            "volgnummerStuk": {
+              "type": "integer",
+              "description": "Volgnummer van het stuk."
+            },
+            "registercodeStukCode": {
+              "type": "string",
+              "provenance": "$.registercodeStuk.code",
+              "description": "Het soort register, aangeduid met een code. code"
+            },
+            "registercodeStukOmschrijving": {
+              "type": "string",
+              "provenance": "$.registercodeStuk.omschrijving",
+              "description": "Het soort register, aangeduid met een code. omschrijving"
+            },
+            "soortRegisterStukCode": {
+              "type": "string",
+              "provenance": "$.soortRegisterStuk.code",
+              "description": "Het register waarvan een ter inschrijving aangeboden stuk deel uitmaakt. code"
+            },
+            "soortRegisterStukOmschrijving": {
+              "provenance": "$.soortRegisterStuk.omschrijving",
+              "type": "string",
+              "description": "Het register waarvan een ter inschrijving aangeboden stuk deel uitmaakt. omschrijving"
+            },
+            "deelSoortStuk": {
+              "type": "string",
+              "description": "Identificatie van het stuk binnen zijn soort."
+            },
+            "toestandsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+            }
+          }
+        }
+      },
+      {
+        "id": "aardzakelijkerechten",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/aardzakelijkerechten.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "code",
+          "required": ["schema", "code", "identificatie"],
+          "display": "code",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "code": {
+              "type": "integer",
+              "description": "De aard zakelijk recht code"
+            },
+            "waarde": {
+              "type": "string",
+              "description": "Beschrijving van dit aard zakelijk recht"
+            },
+            "datumVanaf": {
+              "type": "string",
+              "format": "date",
+              "description": "De datum vanaf wanneer dit aard zakelijk recht in gebruik genomen is"
+            },
+            "datumTot": {
+              "type": "string",
+              "format": "date",
+              "description": "De datum tot wanneer dit aard zakelijk recht in gebruik geweest is"
+            },
+            "toelichting": {
+              "type": "string",
+              "description": "Toelichting op het gebruik van dit aard zakelijk recht"
+            },
+            "akrCode": {
+              "type": "string",
+              "description": "De AKR Code van dit aard zakelijk recht"
+            }
+          }
+        }
+      },
+      {
+        "id": "gemeentes",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/gemeentes.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De unieke aanduiding van een gemeente."
+            },
+            "naam": {
+              "type": "string",
+              "description": "De officiële vastgestelde gemeentenaam."
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de gemeente is ontstaan."
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time",
+              "description": "De datum waarop de gemeente is opgeheven."
+            },
+            "geometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de gemeentegrens in het stelsel van de Rijksdriehoekmeting (RD)."
+            }
+          },
+          "mainGeometry": "geometrie"
+        }
+      },
+      {
+        "id": "meta",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/meta.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "id",
+          "required": ["schema", "id"],
+          "display": "id",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "id": {
+              "type": "integer",
+              "description": ""
+            },
+            "kennisgevingsdatum": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Toestandsdatum, d.i. de laatste aanmaakdatum van de BRK-berichten in de naar DIVA gerepliceerde BRK-levering."
+            }
+          }
+        }
+      },
+      {
+        "id": "kadastralesecties",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesecties.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De unieke aanduiding van een Kadastrale sectie."
+            },
+            "code": {
+              "type": "string",
+              "description": "Een alfanumerieke aanduiding van de kadastrale sectie, deel van de kadastrale aanduiding van de onroerende zaak."
+            },
+            "isOnderdeelVanKadastralegemeentecode": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:kadastralegemeentecodes",
+              "description": "Een alfanumerieke aanduiding van de kadastrale gemeentecode, deel van de kadastrale aanduiding van de onroerende zaak. (bv. ASD02)."
+            },
+            "geometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de kadastrale sectie in het stelsel van de Rijksdriehoekmeting (RD)."
+            }
+          },
+          "mainGeometry": "geometrie"
+        }
+      },
+      {
+        "id": "kadastralegemeentecodes",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentecodes.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De unieke aanduiding van een Kadastrale gemeentecode."
+            },
+            "isOnderdeelVanKadastralegemeente": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:kadastralegemeentes",
+              "description": "De kadastrale gemeente waar de kadastrale gemeentecode onderdeel van is (bv. Sloten)."
+            },
+            "geometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de kadastrale gemeentecode in het stelsel van de Rijksdriehoekmeting (RD)."
+            }
+          },
+          "mainGeometry": "geometrie"
+        }
+      },
+      {
+        "id": "kadastralegemeentes",
+        "type": "table",
+        "schema": {
+          "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentes.json",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "additionalProperties": false,
+          "identifier": "identificatie",
+          "required": ["schema", "identificatie"],
+          "display": "identificatie",
+          "isTemporal": false,
+          "properties": {
+            "schema": {
+              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+            },
+            "identificatie": {
+              "type": "string",
+              "description": "De unieke aanduiding van een Kadastrale gemeente."
+            },
+            "ligtInGemeente": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              },
+              "relation": "brk:gemeentes",
+              "description": "De burgelijke gemeente waarin de kadastrale gemeente ligt."
+            },
+            "geometrie": {
+              "$ref": "https://geojson.org/schema/Geometry.json",
+              "description": "Vorm en ligging van de kadastrale gemeente in het stelsel van de Rijksdriehoekmeting (RD)."
+            }
+          },
+          "mainGeometry": "geometrie"
+        }
+      }
+    ]
+  }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -96,3 +96,8 @@ def brp_r_profile_schema(here) -> ProfileSchema:
     """A downloaded profile schema definition"""
     path = here / "files/profiles/BRP_R.json"
     return ProfileSchema.from_file(path)
+
+
+@pytest.fixture()
+def brk_schema(schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(schema_json("brk.json"))

--- a/tests_django/test_models.py
+++ b/tests_django/test_models.py
@@ -153,3 +153,23 @@ def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_schema):
     model_cls = model_dict["woningbouwplan"]
     meta = model_cls._meta
     assert isinstance(meta.get_field("buurten"), LooseRelationManyToManyField)
+
+
+def test_table_name_creation_n_m_relation(brk_schema):
+    """Prove that through table name is looking at instance method db_name
+    of the datasettableschema class to define it's name.
+    Note: Adjust this test after db_name is getting value from Amsterdam schema
+    specification.
+    """
+    model_dict = {
+        cls._meta.model_name: cls
+        for cls in schema_models_factory(
+            brk_schema, base_app_name="dso_api.dynamic_api"
+        )
+    }
+    # The through table is created
+    # beware! the letter 't' is missing in the table name on purpose
+    # currently the table name is maxed to 63 karakters minus 4 karakters
+    # (because of the temp table which adde the postfix _new to the table name)
+    through_table_name = "kadastraleobjecten_heeft_een_relatie_met_verblijfsobjec"
+    assert through_table_name in model_dict


### PR DESCRIPTION
In types.py a DB_NAME instance method is used for getting the DB name of a table.
In the future, it can be used to look up the SHORTNAME in the Amsterdam Schema definition
to accomodate table names that can exceed the Postgres DB limit of 63 characters.
    
The DB_NAME instance method must also deal with n:m tables (through tables).
The Index name creation on n:m tables uses the DB_NAME method to look up the table name to apply its index.
    
Defining the DB_NAME instance method in types.py on - at first - class DatasetTableSchema, set a placeholder for a the Amsterdam Schema look up in the near future.
For now, it uses an existing function that defines the table name which is also used in the baggob data processing.
