### PR TITLE
Jan/diff schemas

### DIFF
--- a/schematools/types.py
+++ b/schematools/types.py
@@ -139,7 +139,9 @@ class DatasetSchema(SchemaType):
     def get_table_by_id(
         self, table_id: str, include_nested=True, include_through=True
     ) -> DatasetTableSchema:
-        for table in self.get_tables(include_nested=include_nested):
+        for table in self.get_tables(
+            include_nested=include_nested, include_through=include_through
+        ):
             if table.id == table_id:
                 return table
 
@@ -309,7 +311,7 @@ class DatasetTableSchema(DatasetSchema):
             if field.name in set(field_names):
                 yield field
 
-    def get_field_by_id(self, field_name) -> DatasetFieldSchema:
+    def get_field_by_id(self, field_name) -> typing.Optional[DatasetFieldSchema]:
         for field_schema in self.fields:
             if field_schema.name == field_name:
                 return field_schema
@@ -453,7 +455,7 @@ class DatasetFieldSchema(DatasetType):
         return self._parent_field
 
     @property
-    def name(self) -> str:
+    def name(self) -> typing.Optional[str]:
         return self._name
 
     @property
@@ -461,7 +463,7 @@ class DatasetFieldSchema(DatasetType):
         return self.get("description")
 
     @property
-    def required(self) -> bool:
+    def required(self) -> typing.Optional[bool]:
         return self._required
 
     @property
@@ -740,6 +742,7 @@ def get_db_table_name(table: DatasetTableSchema, through_table_field_name=None) 
     """Generate the table name for a database schema."""
     # import within function to avoid a circular import with utils.py
     from schematools.utils import to_snake_case
+
     dataset = table._parent_schema
     app_label = dataset.id
     table_id = table.id

--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -17,7 +17,7 @@ re_camel_case = re.compile(
 )
 
 
-@ttl_cache(ttl=16)
+@ttl_cache(ttl=16)  # type: ignore
 def schema_defs_from_url(schemas_url) -> Dict[str, types.DatasetSchema]:
     """Fetch all schema definitions from a remote file.
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
@@ -36,7 +36,7 @@ def schema_def_from_url(schemas_url, schema_name):
         ) from None
 
 
-@ttl_cache(ttl=16)
+@ttl_cache(ttl=16)  # type: ignore
 def profile_defs_from_url(profiles_url) -> Dict[str, types.ProfileSchema]:
     """Fetch all profile definitions from a remote file.
     The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
@@ -74,7 +74,7 @@ def schema_def_from_file(filename) -> Dict[str, types.DatasetSchema]:
         return {schema_info["id"]: types.DatasetSchema.from_dict(schema_info)}
 
 
-def profile_def_from_file(filename) -> Dict[str, types.ProfileSchemaSchema]:
+def profile_def_from_file(filename) -> Dict[str, types.DatasetSchema]:
     """Read a profile from a file on local drive."""
     with open(filename, "r") as file_handler:
         schema_info = json.load(file_handler)
@@ -105,7 +105,7 @@ def toCamelCase(name):
     return "".join(w.lower() if i == 0 else w.title() for i, w in enumerate(words))
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=256)  # type: ignore
 def to_snake_case(name):
     """
     Convert field/column/dataset name from Space separated/Snake Case/Camel case

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "psycopg2",
         "pg-grant",
         "click",
+        "deepdiff",
         "jsonschema",
         "ndjson>=0.3.0",
         "shapely",


### PR DESCRIPTION
Add cli command to diff two sets of schemas. Mainly to quickly detect the diff of the schemas deployed tot ACC/PRD.
(bit of a 'scratch-you-own-itch feature)
It compares the schemas at SCHEMA_URL to the schemas at `<schema-url>` on the command-line.

Useage:
`schema diff all <schema-url>`