### PR TITLE
[PERMISSIONS] add posibility to set DB permissions for single dataset

### DIFF
--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -18,9 +18,7 @@ re_camel_case = re.compile(
 
 
 @ttl_cache(ttl=16)  # type: ignore
-def schema_defs_from_url(
-    schemas_url, dataset_name=None
-) -> Dict[str, types.DatasetSchema]:
+def schema_defs_from_url(schemas_url, dataset_name=None) -> Dict[str, types.DatasetSchema]:
     """Fetch all schema definitions from a remote file (or single dataset if specified).
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
     """
@@ -92,7 +90,7 @@ def def_from_url(base_url, data_type, dataset_name):
 
         schema_lookup[dataset_name] = data_type.from_dict(response.json())
 
-    return schema_lookup
+    return schema_lookup[dataset_name]
 
 
 def schema_def_from_file(filename) -> Dict[str, types.DatasetSchema]:


### PR DESCRIPTION
In order to use the permissions as an operator in Airflow, the permissions logic should take a single dataset schema and set the permissions for the underling objects.

Because data processing in Airflow can make objects to drop, the set permissions are also deleted. DB users are effected by this. One of the solutions is the grant the privileges again. To use it sparingly, the permissions can be set on one single dataset (and it's underling objects).