### PR TITLE
Fix performance of permission retrieval

### DIFF
--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from django.apps import apps
@@ -551,7 +552,10 @@ def _serialize_claims(schema_object) -> Optional[str]:
         return " ".join(claims)
 
 
+@lru_cache()
 def generate_permission_key(*args):
+    # As this function called many times, caching this gives huge performance wins.
+    # While the auth backend also caches, this cache also persists between requests.
     return ":".join([to_snake_case(key) for key in args])
 
 

--- a/tests_django/test_auth_backend.py
+++ b/tests_django/test_auth_backend.py
@@ -34,9 +34,9 @@ def test_active_profiles_valid(correct_auth_profile, brp_r_profile):
 
 
 @pytest.mark.django_db
-def test_get_all_permissions(correct_auth_profile, brp_dataset):
+def test_get_table_permissions(correct_auth_profile, brp_dataset):
     """Prove that all permissions can be retrieved"""
-    permissions = correct_auth_profile.get_all_permissions("brp:ingeschrevenpersonen:postcode")
+    permissions = correct_auth_profile.get_table_permissions("brp", "ingeschrevenpersonen")
     assert permissions == {"brp:ingeschrevenpersonen:bsn": "encoded"}
 
 


### PR DESCRIPTION
* generate_permission_key() is called many times, and benefits from lru_cache()
* RequestProfile.get_all_permissions() wrongly cached data.
* RequestProfile.get_all_permissions() was called per-field, with caching it
  should be per-table. Hence the name change to get_table_permissions()