### PR TITLE
Bbga/guido

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ pytest_plugins = ["tests.fixtures"]
 
 
 @pytest.fixture(scope="session")
-def db_url():
+def db_url() -> str:
     """Get the DATABASE_URL, prepend test_ to it."""
     url = os.environ.get("DATABASE_URL", "postgresql://localhost/schematools")
 

--- a/tests/files/bbga.json
+++ b/tests/files/bbga.json
@@ -1,0 +1,208 @@
+{
+  "type": "dataset",
+  "id": "bbga",
+  "title": "BBGA",
+  "status": "beschikbaar",
+  "description": "Basisbestand Gebieden Amsterdam",
+  "version": "0.0.1",
+  "crs": "EPSG:4326",
+  "tables": [
+    {
+      "id": "indicatoren definities",
+      "title": "Metedata Indicatoren en Definities",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bbga/indicatoren_definities.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "variabele",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "variabele",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "sort": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "variabele": {
+            "type": "string"
+          },
+          "begrotingsProgramma": {
+            "type": "string"
+          },
+          "thema": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "labelKort": {
+            "type": "string"
+          },
+          "definitie": {
+            "type": "string"
+          },
+          "bron": {
+            "type": "string"
+          },
+          "peildatum": {
+            "type": "string"
+          },
+          "verschijningsfrequentie": {
+            "type": "string"
+          },
+          "rekeneenheid": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "symbool": {
+            "type": "string"
+          },
+          "groep": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "berekenedeVariabelen": {
+            "type": "string"
+          },
+          "themaKerncijfertabelBevolking": {
+            "type": "string"
+          },
+          "themaKerncijfertabelPersonen": {
+            "type": "string"
+          },
+          "kleurenpalet": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "legendaCode": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "sdMinimumBevTotaal": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "sdMinimumWvoorBag": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "topicArea": {
+            "type": "string"
+          },
+          "label1": {
+            "type": "string"
+          },
+          "definition": {
+            "type": "string"
+          },
+          "referenceDate": {
+            "type": "string"
+          },
+          "frequency": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "kerncijfers",
+      "title": "Kerncijfers",
+      "description": "Kerncijfers op het niveau van de meest gebruikte gebiedsindelingen in Amsterdam: stadsdelen, de 22 gebieden van het gebiedsgericht werken, wijken, buurten, winkel- en werkgebieden, PC4 en twee alternatieve buurtindelingen van de stadsdelen.",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bbga/kerncijfers.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": ["variabele", "jaar", "gebiedcode15"],
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "variabele",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "jaar": {
+            "type": "integer",
+            "minimum": 1300,
+            "maximum": 2121
+          },
+          "gebiedcode15": {
+            "type": "string"
+          },
+          "variabele": {
+            "type": "string"
+          },
+          "waarde": {
+            "type": "integer"
+          },
+          "indicatorDefinitie": {
+            "type": "string",
+            "relation": "bbga:indicatoren definities"
+          }
+        }
+      }
+    },
+    {
+      "id": "statistieken",
+      "title": "Statistieken",
+      "description": "Stedelijke gemiddelden en standaardafwijkingen.",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bbga/statistieken.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": ["variabele", "jaar"],
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "variabele",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "jaar": {
+            "type": "integer",
+            "minimum": 1300,
+            "maximum": 2121
+          },
+          "variabele": {
+            "type": "string"
+          },
+          "gemiddelde": {
+            "type": "number"
+          },
+          "standaardafwijking": {
+            "type": "number"
+          },
+          "bron": {
+            "type": "string"
+          },
+          "indicatorDefinitie": {
+            "type": "string",
+            "relation": "bbga:indicatoren definities"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,7 +10,7 @@ HERE = Path(__file__).parent
 
 
 @pytest.fixture(scope="session")
-def here():
+def here() -> Path:
     return HERE
 
 

--- a/tests/test_create_all.py
+++ b/tests/test_create_all.py
@@ -1,0 +1,56 @@
+import operator
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+from click.testing import CliRunner
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.orm import Session
+
+from schematools.cli import create_all_objects
+
+
+def test_create_all(here: Path, db_url: str, engine: Engine, dbsession: Session) -> None:
+    # We're using the function scoped `dbsession` fixture for its side effect of automatically
+    # dropping any tables we create. Beyond that we have no need for it.
+    bbgaSchema = here / "files" / "bbga.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        create_all_objects,
+        [f"--schema-url={bbgaSchema!s}", f"--db-url={db_url}"],
+    )
+    assert result.exit_code == 0
+
+    inspector = Inspector.from_engine(engine)
+    columns: List[Dict[str, Any]] = inspector.get_columns("bbga_kerncijfers")
+    column_names = list(map(operator.itemgetter("name"), columns))
+
+    # No "--relname-from-identifier" argument specified. Each relation specific column name
+    # should have "_id! postfix.
+    assert "indicator_definitie_id" in column_names
+
+
+def test_create_all_relname_from_identifier(
+    # We're using the function scoped `dbsession` fixture for its side effect of automatically
+    # dropping any tables we create. Beyond that we have no need for it.
+    here: Path,
+    db_url: str,
+    engine: Engine,
+    dbsession: Session,
+) -> None:
+    bbgaSchema = here / "files" / "bbga.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        create_all_objects,
+        [f"--schema-url={bbgaSchema!s}", f"--db-url={db_url}", "--relname-from-identifier"],
+    )
+    assert result.exit_code == 0
+
+    inspector = Inspector.from_engine(engine)
+    columns: List[Dict[str, Any]] = inspector.get_columns("bbga_kerncijfers")
+    column_names = list(map(operator.itemgetter("name"), columns))
+
+    # "--relname-from-identifier" argument specified, hence relation specific column name should
+    # have postfix identical to value of `identifier` property in related column. In this case
+    # that is "_variabele"
+    assert "indicator_definitie_variabele" in column_names


### PR DESCRIPTION
One change in the MR:

- added the ability (behind a switch) to use `identifier` specified columns for the postfix of relationship column names (again see commit)