### PR TITLE
Complete existing index creation (1:N relation reference)

### DIFF
--- a/schematools/__init__.py
+++ b/schematools/__init__.py
@@ -1,3 +1,4 @@
 RELATION_INDICATOR = "_"
 MAX_TABLE_LENGTH = 63  # limitation of PostgreSQL
 TMP_TABLE_POSTFIX = "_new"
+TABLE_INDEX_POSTFIX = "_idx"

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -428,6 +428,17 @@ class DatasetTableSchema(SchemaType):
             db_table_name=db_table_name,
         )
 
+    def get_fk_fields(self):
+        """Generates fields names that contain a 1:N relation to a parent table"""
+        fields_items = self["schema"]["properties"].items()
+        field_schema = (
+            DatasetFieldSchema(_name=name, _parent_table=self, **spec)
+            for name, spec in fields_items
+        )
+        for field in field_schema:
+            if field.relation:
+                yield field.name
+
 
 class DatasetFieldSchema(DatasetType):
     """ A single field (column) in a table """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.17.3",
+    version="0.17.4",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",


### PR DESCRIPTION
The index creation logic was missing the creation of a databas index based on columns in a child table that refer to a parent table. The so called foreign key contraint is not enforced in the database. Yet the relevant columns are used in the API for retreiving the data. Also it can be used by database users who query on the tables directly.