### PR TITLE
Added bigint as datatype

### DIFF
--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -59,8 +59,7 @@ def fetch_srid(dataset: DatasetSchema, field: DatasetFieldSchema) -> Dict[str, A
 
 JSON_TYPE_TO_DJANGO = {
     "string": (UnlimitedCharField, None),
-    "integer": (models.IntegerField, None),
-    "biginteger": (models.BigIntegerField, None),
+    "integer": (models.BigIntegerField, None),
     "integer/autoincrement": (models.AutoField, None),
     "date": (models.DateField, None),
     "datetime": (models.DateTimeField, None),

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -17,12 +17,7 @@ from django.utils.translation import gettext_lazy as _
 from django_postgres_unlimited_varchar import UnlimitedCharField
 from gisserver.types import CRS
 
-from schematools.types import (
-    DatasetFieldSchema,
-    DatasetSchema,
-    DatasetTableSchema,
-    ProfileSchema,
-)
+from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema, ProfileSchema
 from schematools.utils import to_snake_case
 
 from . import managers
@@ -65,6 +60,7 @@ def fetch_srid(dataset: DatasetSchema, field: DatasetFieldSchema) -> Dict[str, A
 JSON_TYPE_TO_DJANGO = {
     "string": (UnlimitedCharField, None),
     "integer": (models.IntegerField, None),
+    "biginteger": (models.BigIntegerField, None),
     "integer/autoincrement": (models.AutoField, None),
     "date": (models.DateField, None),
     "datetime": (models.DateTimeField, None),

--- a/schematools/importer/__init__.py
+++ b/schematools/importer/__init__.py
@@ -2,7 +2,7 @@ import numbers
 from decimal import Decimal
 
 from geoalchemy2 import Geometry
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Integer, Numeric, String, Time
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Numeric, String, Time
 from sqlalchemy.types import ARRAY
 
 from schematools.types import DatasetTableSchema
@@ -19,8 +19,7 @@ JSON_TYPE_TO_PG = {
     "string": String,
     "object": String,
     "boolean": Boolean,
-    "integer": Integer,
-    "biginteger": BigInteger,
+    "integer": BigInteger,
     "number": Float,
     "array": ARRAY(String),
     "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/id": String,

--- a/schematools/importer/__init__.py
+++ b/schematools/importer/__init__.py
@@ -2,7 +2,7 @@ import numbers
 from decimal import Decimal
 
 from geoalchemy2 import Geometry
-from sqlalchemy import Boolean, Date, DateTime, Float, Integer, Numeric, String, Time
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Integer, Numeric, String, Time
 from sqlalchemy.types import ARRAY
 
 from schematools.types import DatasetTableSchema
@@ -20,6 +20,7 @@ JSON_TYPE_TO_PG = {
     "object": String,
     "boolean": Boolean,
     "integer": Integer,
+    "biginteger": BigInteger,
     "number": Float,
     "array": ARRAY(String),
     "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/id": String,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename: Union[Path, str]) -> str:
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.17.5",
+    version="0.17.6",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Jan Murre",

--- a/tests/files/woningbouwplannen.json
+++ b/tests/files/woningbouwplannen.json
@@ -26,10 +26,6 @@
             "description": "Unieke id van het object",
             "provenance": "wbw_woningbouwplan_id"
           },
-          "idBig": {
-            "type": "biginteger",
-            "description": "Id van het object in biginteger"
-          },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },

--- a/tests/files/woningbouwplannen.json
+++ b/tests/files/woningbouwplannen.json
@@ -26,6 +26,10 @@
             "description": "Unieke id van het object",
             "provenance": "wbw_woningbouwplan_id"
           },
+          "idBig": {
+            "type": "biginteger",
+            "description": "Id van het object in biginteger"
+          },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -103,18 +103,15 @@ def test_biginteger_datatype(here, engine, woningbouwplannen_schema, dbsession):
     in the database is set to datatype int(8) instead of int(4)"""
     importer = BaseImporter(woningbouwplannen_schema, engine)
     importer.generate_db_objects("woningbouwplan", ind_tables=True, ind_extra_index=True)
-    record = [
-        dict(r)
-        for r in engine.execute(
-            """
-                                                SELECT data_type, numeric_precision
-                                                FROM information_schema.columns
-                                                WHERE 1=1
-                                                AND table_schema = 'public'
-                                                AND table_name = 'woningbouwplannen_woningbouwplan'
-                                                AND column_name = 'id_big';
-                                                """
-        )
-    ]
-    assert record[0]["data_type"] == "bigint"
-    assert record[0]["numeric_precision"] == 64
+    results = engine.execute(
+        """
+        SELECT data_type, numeric_precision
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'woningbouwplannen_woningbouwplan'
+          AND column_name = 'id_big';
+    """
+    )
+    record = results.fetchone()
+    assert record.data_type == "bigint"
+    assert record.numeric_precision == 64

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -108,8 +108,8 @@ def test_biginteger_datatype(here, engine, woningbouwplannen_schema, dbsession):
         SELECT data_type, numeric_precision
         FROM information_schema.columns
         WHERE table_schema = 'public'
-          AND table_name = 'woningbouwplannen_woningbouwplan'
-          AND column_name = 'id_big';
+        AND table_name = 'woningbouwplannen_woningbouwplan'
+        AND column_name = 'id';
     """
     )
     record = results.fetchone()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -96,3 +96,25 @@ def test_invalid_numeric_datatype_scale(here, engine, woningbouwplannen_schema, 
     assert not record[0]["numeric_scale"]
     assert record[1]["data_type"] == "numeric"
     assert not record[1]["numeric_scale"]
+
+
+def test_biginteger_datatype(here, engine, woningbouwplannen_schema, dbsession):
+    """Prove that when biginter is used as datatype in schema, the datatype
+    in the database is set to datatype int(8) instead of int(4)"""
+    importer = BaseImporter(woningbouwplannen_schema, engine)
+    importer.generate_db_objects("woningbouwplan", ind_tables=True, ind_extra_index=True)
+    record = [
+        dict(r)
+        for r in engine.execute(
+            """
+                                                SELECT data_type, numeric_precision
+                                                FROM information_schema.columns
+                                                WHERE 1=1
+                                                AND table_schema = 'public'
+                                                AND table_name = 'woningbouwplannen_woningbouwplan'
+                                                AND column_name = 'id_big';
+                                                """
+        )
+    ]
+    assert record[0]["data_type"] == "bigint"
+    assert record[0]["numeric_precision"] == 64


### PR DESCRIPTION
Some sources provide us with an own id value. The value size of these source id's can exceed the maxinum of 32 bytes of the standard int(4) datatype in the database. During data load processing data from source into target table, the flow in Airflow can crash. Therefore the is a support added for bigint. Returing a 64 bytes int(8) datatype in the database.