### PR TITLE
Fix provenancing for jsonpath

### DIFF
--- a/tests/files/data/woonplaatsen.ndjson
+++ b/tests/files/data/woonplaatsen.ndjson
@@ -1,2 +1,2 @@
-{"id": "1.1", "status": {"code": 1, "omschrijving": "status met code 1"}}
-{"id": "1.2", "status": {"omschrijving": "status zonder omschrijving"}}
+{"id": "1.1", "status": {"code": 1, "omschrijving": "status met code 1"}, "heeftDossier": {"dossier": "GV12"}}
+{"id": "1.2", "status": {"omschrijving": "status zonder omschrijving"}, "heeftDossier": null}

--- a/tests/files/woonplaatsen.json
+++ b/tests/files/woonplaatsen.json
@@ -39,6 +39,12 @@
             "type": "string",
             "provenance": "$.status.omschrijving",
             "description": "Levenscyclus van de woonplaats, Woonplaats aangewezen, Woonplaats ingetrokken. omschrijving"
+          },
+          "heeftDossier": {
+            "type": "string",
+            "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
+            "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           }
         },
         "mainGeometry": "geometrie"

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -194,3 +194,15 @@ def test_ndjson_import_with_shortnames_in_schema(here, engine, hr_schema, dbsess
         "verblijfsobjecten_identificatie": "01001",
         "verblijfsobjecten_volgnummer": 1,
     }
+
+
+def test_provenance_for_original_fieldnames(here, engine, woonplaatsen_schema, dbsession):
+    """ prove """
+    ndjson_path = here / "files" / "data" / "woonplaatsen.ndjson"
+    importer = NDJSONImporter(woonplaatsen_schema, engine)
+    importer.generate_db_objects("woonplaatsen", truncate=True, ind_extra_index=False)
+    importer.load_file(ndjson_path)
+    records = [dict(r) for r in engine.execute("SELECT * from baggob_woonplaatsen ORDER BY id")]
+    assert len(records) == 2
+    assert records[0]["heeft_dossier_id"] == "GV12"
+    assert records[1]["heeft_dossier_id"] is None

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -196,8 +196,11 @@ def test_ndjson_import_with_shortnames_in_schema(here, engine, hr_schema, dbsess
     }
 
 
-def test_provenance_for_original_fieldnames(here, engine, woonplaatsen_schema, dbsession):
-    """ prove """
+def test_provenance_for_schema_field_ids_equal_to_ndjson_keys(
+    here, engine, woonplaatsen_schema, dbsession
+):
+    """Prove that imports where the schema field is equal to the key in the imported ndjson
+    data are processed correctly."""
     ndjson_path = here / "files" / "data" / "woonplaatsen.ndjson"
     importer = NDJSONImporter(woonplaatsen_schema, engine)
     importer.generate_db_objects("woonplaatsen", truncate=True, ind_extra_index=False)


### PR DESCRIPTION
In case the schema fieldname is equal to the key used
in the ndjson import. This case was not covered yet.