### PR TITLE
Optimize toCamelCase

### DIFF
--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import StringIO
 import json
 import re
 from typing import Dict, Final, Pattern
@@ -117,14 +118,28 @@ def schema_fetch_url_file(schema_url_file):
 
 
 @lru_cache(maxsize=500)  # type: ignore
-def toCamelCase(name):
+def toCamelCase(name: str) -> str:
     """
     Unify field/column/dataset name from Space separated/Snake Case/Camel case
     to camelCase.
     """
-    name = " ".join(name.split("_"))
-    words = RE_CAMEL_CASE.sub(r" \1", name).strip().lower().split(" ")
-    return "".join(w.lower() if i == 0 else w.title() for i, w in enumerate(words))
+    out = StringIO()
+    next_upper = False
+    first = True
+
+    for char in name:
+        if char == "_" or char.isspace():
+            next_upper = True
+            continue
+        if first:
+            char = char.lower()
+            first = False
+        elif next_upper:
+            char = char.upper()
+            next_upper = False
+        out.write(char)
+
+    return out.getvalue()
 
 
 @lru_cache(maxsize=500)  # type: ignore

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,8 @@ def test_toCamelCase():
     assert toCamelCase("testNameMagic") == "testNameMagic"
     assert toCamelCase("TestNameMagic") == "testNameMagic"
     assert toCamelCase("test_name_magic") == "testNameMagic"
+    assert toCamelCase("numbers_33_in_the_middle_44") == "numbers33InTheMiddle44"
+    assert toCamelCase("per_jaar_per_m2") == "perJaarPerM2"
 
 
 def test_to_snake_case():


### PR DESCRIPTION
Given

    >>> s = 'a_pretty_long_identifier_in_snake_case'

I get the following timeit results. Current implementation, with the @lru_cache decorator removed:

    >>> %timeit toCamelCase(s)
    10.4 µs ± 18.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

New version:

    >>> %timeit toCamelCase(s)
    4.88 µs ± 15.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

The LRU decorator is still there, since this is still a factor two below cache lookup speed:

    >>> %timeit toCamelCase(s)
    2.29 µs ± 21.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)