### PR TITLE
Guido/fix to camel case

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ norecursedirs = .tox .git
 filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
+addopts = --doctest-modules

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import json
 from collections import UserDict
-from typing import Any, Callable, Dict, Iterator, List, NoReturn, Optional, Union
+from typing import Any, Callable, Dict, Iterator, List, NoReturn, Optional, TypeVar, Union
 
 import jsonschema
 
 from schematools import RELATION_INDICATOR
 from schematools.datasetcollection import DatasetCollection
+
+ST = TypeVar("ST", bound="SchemaType")
 
 
 class SchemaType(UserDict):
@@ -31,6 +33,10 @@ class SchemaType(UserDict):
 
     def json_data(self) -> Dict[str, Any]:
         return self.data
+
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]) -> ST:
+        return cls(obj)
 
 
 class DatasetType(UserDict):
@@ -163,7 +169,7 @@ class DatasetSchema(SchemaType):
         self, table: DatasetTableSchema, field: DatasetFieldSchema
     ) -> DatasetTableSchema:
         # Map Arrays into tables.
-        from schematools.utils import to_snake_case, get_through_table_name
+        from schematools.utils import get_through_table_name, to_snake_case
 
         snakecased_fieldname = to_snake_case(field.name)
         sub_table_id = get_through_table_name(len(self.id) + 1, table.name, snakecased_fieldname)
@@ -190,7 +196,7 @@ class DatasetSchema(SchemaType):
     def build_through_table(
         self, table: DatasetTableSchema, field: DatasetFieldSchema
     ) -> DatasetTableSchema:
-        from schematools.utils import to_snake_case, get_through_table_name
+        from schematools.utils import get_through_table_name, to_snake_case
 
         # Build the through_table for n-m relation
         # For relations, we have to use the real ids of the tables

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,8 @@ def test_toCamelCase():
     assert toCamelCase("TestNameMagic") == "testNameMagic"
     assert toCamelCase("test_name_magic") == "testNameMagic"
     assert toCamelCase("numbers_33_in_the_middle_44") == "numbers33InTheMiddle44"
+    # mind the lower case "i" after "33". It should be made upper case
+    assert toCamelCase("numbers33inTheMiddle44") == "numbers33InTheMiddle44"
     assert toCamelCase("per_jaar_per_m2") == "perJaarPerM2"
 
 


### PR DESCRIPTION
Fix toCamelCase to titlecase words following numbers.

It previously didn't handle titlecasing words following numbers. Eg it didn't handle `fu33bar` correctly to become `fu33Bar`. Now it does.

In addition I changed the implementation to one based on a regex. A proof-of-concept regex version I had developed originally was 3x faster than the for loop. To handle additional cases I simply iterated on the proof-of-concept. It now is 3 µs slower that the for loop based one that does not handle the `fu33bar` case. If the for loop one starts handling that case it will likely loose its 3 µs edge.

In addition type annotated the entire module. Doing so surfaced a bug in function `schema_defs_from_url`, that is now fixed.