### PR TITLE
Rename DynamicModel.get_dataset into DynamicModel.get_dataset_schema for clarity

### DIFF
--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -128,7 +128,7 @@ class DynamicModel(models.Model):
 
     @classmethod
     def get_dataset_schema(cls) -> DatasetSchema:
-        """Give access to the original dataset that this model is a part of."""
+        """Give access to the original dataset schema that this model is a part of."""
         return cls._table_schema._parent_schema
 
     @classmethod

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -127,7 +127,7 @@ class DynamicModel(models.Model):
     # but this ensures the names don't conflict with fields from the schema.
 
     @classmethod
-    def get_dataset(cls) -> DatasetSchema:
+    def get_dataset_schema(cls) -> DatasetSchema:
         """Give access to the original dataset that this model is a part of."""
         return cls._table_schema._parent_schema
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename: Union[Path, str]) -> str:
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.17.9",
+    version="0.17.10",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Amsterdam Data en Informatie",


### PR DESCRIPTION
Renaming confusing method name in order to give more clarity (and allow `get_dataset` method to be added in future).