### PR TITLE
Guido/fix to camel case empty string

### DIFF
--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -190,14 +190,25 @@ def toCamelCase(ident: str) -> str:
 
 
 @lru_cache(maxsize=500)
-def to_snake_case(name: str) -> str:
+def to_snake_case(ident: str) -> str:
+    """Convert an identifier to snake_case format.
+
+    Empty strings are not allowed. They will raise an :exc:`ValueError` exception.
+
+    Args:
+        ident: The identifier to be converted.
+
+    Returns:
+        The identifier in snake_case foramt.
+
+    Raises:
+        ValueError: If ``ident`` is an empty string.
     """
-    Convert field/column/dataset name from Space separated/Snake Case/Camel case
-    to snake_case.
-    """
+    if ident == "":
+        raise ValueError("Parameter `ident` cannot be an empty string.")
     # Convert to field name, avoiding snake_case to snake_case issues.
     # Also preserve RELATION_INDICATOR in names (RELATION_INDICATOR are used for object relations)
-    name_parts = [toCamelCase(part) for part in name.split(RELATION_INDICATOR)]
+    name_parts = [toCamelCase(part) for part in ident.split(RELATION_INDICATOR)]
     return RELATION_INDICATOR.join(
         slugify(RE_CAMEL_CASE.sub(r" \1", part).strip(), separator="_") for part in name_parts
     )

--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -146,6 +146,8 @@ def toCamelCase(ident: str) -> str:
 
     A camelCased identifier, when it starts with a letter, it will start with a lower cased letter.
 
+    Empty strings are not allowed. They will raise an :exc:`ValueError` exception.
+
     Examples:
 
         >>> toCamelCase("dataset_table_schema")
@@ -162,10 +164,13 @@ def toCamelCase(ident: str) -> str:
         '33FuBar'
 
     Args:
-        ident: The identifier to be converted
+        ident: The identifier to be converted.
 
     Returns:
-        The identifier in camelCase format
+        The identifier in camelCase format.
+
+    Raises:
+        ValueError: If ``indent`` is an empty string.
 
     """
 
@@ -177,6 +182,8 @@ def toCamelCase(ident: str) -> str:
         # explicit test.
         return "".join(s.upper() for s in m.groups() if s)
 
+    if ident == "":
+        raise ValueError("Parameter `ident` cannot be an empty string.")
     result = _CAMEL_CASE_REPLACE_PAT.sub(replacement, ident)
     # The first letter of camelCase identifier is always lower case
     return result[0].lower() + result[1:]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename: Union[Path, str]) -> str:
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.17.10",
+    version="0.17.11",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Amsterdam Data en Informatie",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from schematools.utils import to_snake_case, toCamelCase
 
 
@@ -16,6 +18,9 @@ def test_toCamelCase():
     # mind the lower case "i" after "33". It should be made upper case
     assert toCamelCase("numbers33inTheMiddle44") == "numbers33InTheMiddle44"
     assert toCamelCase("per_jaar_per_m2") == "perJaarPerM2"
+
+    with pytest.raises(ValueError):
+        toCamelCase("")
 
 
 def test_to_snake_case():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,3 +38,6 @@ def test_to_snake_case():
     assert to_snake_case("verlengingSluitingstijd1") == "verlenging_sluitingstijd_1"
     assert to_snake_case("numbers33inTheMiddle44") == "numbers_33_in_the_middle_44"
     assert to_snake_case("perJaarPerM2") == "per_jaar_per_m2"
+
+    with pytest.raises(ValueError):
+        to_snake_case("")


### PR DESCRIPTION
* Better error reporting for `toCamelCase` (raise `ValueError` in case of empty string)
* Version bump