### PR TITLE
[4390] fix reload_schemas issue

### DIFF
--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -259,7 +259,7 @@ class Dataset(models.Model):
             return
 
         new_definitions = {
-            to_snake_case(t.id): t for t in self.schema.get_tables(include_nested=True)
+            to_snake_case(t.name): t for t in self.schema.get_tables(include_nested=True)
         }
         new_names = set(new_definitions.keys())
         existing_models = {t.name: t for t in self.tables.all()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ pytest_plugins = ["tests.fixtures"]
 # https://github.com/toirl/pytest-sqlalchemy/blob/master/pytest_sqlalchemy.py
 
 
+@pytest.fixture()
+def here():
+    return HERE
+
+
 @pytest.fixture(scope="session")
 def db_url():
     """Get the DATABASE_URL, prepend test_ to it."""


### PR DESCRIPTION
The shortnames possibily for tables created a subtle bug
when reloading schemas with the `reload_schemas` mgm command.