### PR TITLE
AD#5018 Dataset Subpath's

### DIFF
--- a/schematools/contrib/django/management/commands/create_tables.py
+++ b/schematools/contrib/django/management/commands/create_tables.py
@@ -41,7 +41,7 @@ def create_tables(
         if not dataset.enable_db or dataset.name in to_be_skipped:
             continue  # in case create_tables() is called by import_schemas
 
-        models.extend(schema_models_factory(dataset.schema, base_app_name="dso_api.dynamic_api"))
+        models.extend(schema_models_factory(dataset, base_app_name="dso_api.dynamic_api"))
 
     # Create all tables
     with connection.schema_editor() as schema_editor:

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -133,6 +133,7 @@ class DynamicModel(models.Model):
 
     @classmethod
     def get_dataset_id(cls) -> str:
+        """Give access to the original dataset ID that this model is part of."""
         return cls._dataset.schema.id
 
     @classmethod

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -212,6 +212,7 @@ class Dataset(models.Model):
             name=to_snake_case(schema.id),
             schema_data=schema.json_data(),
             auth=_serialize_claims(schema),
+            url_prefix=schema.url_prefix,
         )
 
     def save_for_schema(self, schema: DatasetSchema):

--- a/schematools/contrib/django/models.py
+++ b/schematools/contrib/django/models.py
@@ -109,6 +109,7 @@ class DynamicModel(models.Model):
     """Base class to tag and detect dynamically generated models."""
 
     #: Overwritten by subclasses / factory
+    _dataset: Dataset = None
     _table_schema: DatasetTableSchema = None
     _display_field = None
 
@@ -125,20 +126,24 @@ class DynamicModel(models.Model):
 
     # These classmethods could have been a 'classproperty',
     # but this ensures the names don't conflict with fields from the schema.
+    @classmethod
+    def get_dataset(cls) -> Dataset:
+        """Give access to the original dataset that this models is part of."""
+        return cls._dataset
+
+    @classmethod
+    def get_dataset_id(cls) -> str:
+        return cls._dataset.schema.id
 
     @classmethod
     def get_dataset_schema(cls) -> DatasetSchema:
         """Give access to the original dataset schema that this model is a part of."""
-        return cls._table_schema._parent_schema
+        return cls._dataset.schema
 
     @classmethod
     def table_schema(cls) -> DatasetTableSchema:
         """Give access to the original table_schema that this model implements."""
         return cls._table_schema
-
-    @classmethod
-    def get_dataset_id(cls) -> str:
-        return cls._table_schema.dataset.id
 
     @classmethod
     def get_table_id(cls) -> str:
@@ -304,7 +309,7 @@ class Dataset(models.Model):
         if not self.enable_db:
             return []
         else:
-            return schema_models_factory(self.schema)
+            return schema_models_factory(self)
 
 
 class DatasetTable(models.Model):

--- a/schematools/types.py
+++ b/schematools/types.py
@@ -87,6 +87,11 @@ class DatasetSchema(SchemaType):
         return self.get("description")
 
     @property
+    def url_prefix(self) -> str:
+        """Dataset URL prefix"""
+        return self.get("url_prefix")
+
+    @property
     def identifier(self):
         """Which fields acts as identifier. (default is Django "pk" field)"""
         return self.get("identifier", "pk")

--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -10,7 +10,7 @@ from cachetools.func import lru_cache, ttl_cache
 from string_utils import slugify
 
 from schematools import MAX_TABLE_NAME_LENGTH, RELATION_INDICATOR, TMP_TABLE_POSTFIX
-from schematools.types import ST, DatasetSchema, ProfileSchema
+from schematools import types
 
 RE_CAMEL_CASE: Final[Pattern[str]] = re.compile(
     r"(((?<=[^A-Z])[A-Z])|([A-Z](?![A-Z]))|((?<=[a-z])[0-9])|(?<=[0-9])[a-z])"
@@ -27,19 +27,19 @@ def schema_defs_from_url(
     if dataset_name:
         schema = def_from_url(
             base_url=schemas_url,
-            data_type=DatasetSchema,
-            dataset_name=dataset_name,
+            data_type=types.DatasetSchema,
+            dataset_id=dataset_name,
         )
         return {dataset_name: schema}
 
-    return defs_from_url(base_url=schemas_url, data_type=DatasetSchema)
+    return defs_from_url(base_url=schemas_url, data_type=types.DatasetSchema)
 
 
 def schema_def_from_url(schemas_url: str, dataset_name: str) -> DatasetSchema:
     return def_from_url(
         base_url=schemas_url,
-        data_type=DatasetSchema,
-        dataset_name=dataset_name,
+        data_type=types.DatasetSchema,
+        dataset_id=dataset_name,
     )
 
 
@@ -48,14 +48,14 @@ def profile_defs_from_url(profiles_url: str) -> Dict[str, ProfileSchema]:
     """Fetch all profile definitions from a remote file.
     The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
     """
-    return defs_from_url(base_url=profiles_url, data_type=ProfileSchema)
+    return defs_from_url(base_url=profiles_url, data_type=types.ProfileSchema)
 
 
-def defs_from_url(base_url: str, data_type: Type[ST]) -> Dict[str, ST]:
+def defs_from_url(base_url: str, data_type: Type[types.ST]) -> Dict[str, types.ST]:
     """Fetch all schema definitions from a remote file.
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
     """
-    schema_lookup: Dict[str, ST] = {}
+    schema_lookup: Dict[str, types.ST] = {}
     if not base_url.endswith("/"):
         base_url = f"{base_url}/"
 
@@ -64,16 +64,20 @@ def defs_from_url(base_url: str, data_type: Type[ST]) -> Dict[str, ST]:
         response.raise_for_status()
         response_data = response.json()
 
-        for dataset_name, dataset_path in response_data.items():
+        for dataset_id, dataset_path in response_data.items():
             response = connection.get(f"{base_url}{dataset_path}")
             response.raise_for_status()
+            response_data = response.json()
+            response_data["url_prefix"] = get_dataset_prefix_from_path(
+                dataset_path=dataset_path,
+                dataset_id=response_data["id"])
 
-            schema_lookup[dataset_name] = data_type.from_dict(response.json())
+            schema_lookup[dataset_id] = data_type.from_dict(response_data)
 
     return schema_lookup
 
 
-def def_from_url(base_url: str, data_type: Type[ST], dataset_name: str) -> ST:
+def def_from_url(base_url: str, data_type: Type[types.ST], dataset_id: str) -> types.ST:
     """Fetch schema definitions from a remote file for a single dataset
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
     """
@@ -81,29 +85,33 @@ def def_from_url(base_url: str, data_type: Type[ST], dataset_name: str) -> ST:
     if not base_url.endswith("/"):
         base_url = f"{base_url}/"
 
-    dataset_path = f"{dataset_name}/{dataset_name}"
+    dataset_path = f"{dataset_id}/{dataset_id}"
 
     with requests.Session() as connection:
-        response = connection.get(f"{base_url}{dataset_path}")
+        index_response = connection.get(f"{base_url}index.json")
+        index_response.raise_for_status()
+        index = index_response.json()
+
+        response = connection.get(f"{base_url}{index[dataset_id]}")
         response.raise_for_status()
 
-        schema_lookup[dataset_name] = data_type.from_dict(response.json())
+        schema_lookup[dataset_id] = data_type.from_dict(response.json())
 
-    return schema_lookup[dataset_name]
+    return schema_lookup[dataset_id]
 
 
 def schema_def_from_file(filename: Union[Path, str]) -> Dict[str, DatasetSchema]:
     """Read schema definitions from a file on local drive."""
     with open(filename, "r") as file_handler:
         schema_info = json.load(file_handler)
-        return {schema_info["id"]: DatasetSchema.from_dict(schema_info)}
+        return {schema_info["id"]: types.DatasetSchema.from_dict(schema_info)}
 
 
 def profile_def_from_file(filename: Union[Path, str]) -> Dict[str, DatasetSchema]:
     """Read a profile from a file on local drive."""
     with open(filename, "r") as file_handler:
         schema_info = json.load(file_handler)
-        return {schema_info["name"]: DatasetSchema.from_dict(schema_info)}
+        return {schema_info["name"]: types.DatasetSchema.from_dict(schema_info)}
 
 
 def schema_fetch_url_file(schema_url_file: str) -> Dict[str, Any]:
@@ -224,3 +232,11 @@ def get_through_table_name(prefix_length: int, table_name: str, through_name: st
 def shorten_name(db_table_name: str) -> str:
     """ Utility function to shorten names to safe length for postgresql """
     return db_table_name[: MAX_TABLE_NAME_LENGTH - len(TMP_TABLE_POSTFIX)]
+
+
+def get_dataset_prefix_from_path(dataset_path, dataset_id):
+    """ Extract dataset prefix from dataset path """
+    dataset_parts = dataset_path.split("/")[:-1]
+    if dataset_parts[-1] == dataset_id:
+        dataset_parts.pop()
+    return "/".join(dataset_parts)

--- a/schematools/utils.py
+++ b/schematools/utils.py
@@ -234,7 +234,7 @@ def shorten_name(db_table_name: str) -> str:
     return db_table_name[: MAX_TABLE_NAME_LENGTH - len(TMP_TABLE_POSTFIX)]
 
 
-def get_dataset_prefix_from_path(dataset_path, dataset_id):
+def get_dataset_prefix_from_path(dataset_path: str, dataset_id: str) -> str:
     """ Extract dataset prefix from dataset path """
     dataset_parts = dataset_path.split("/")[:-1]
     if dataset_parts[-1] == dataset_id:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename: Union[Path, str]) -> str:
 
 setup(
     name="amsterdam-schema-tools",
-    version="0.17.11",
+    version="0.18.0",
     url="https://github.com/amsterdam/schema-tools",
     license="Mozilla Public 2.0",
     author="Amsterdam Data en Informatie",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_get_dataset_prefix_from_path():
     - belastingen/reclame => belastingen
     - bag/bag => ""  # AKA old behaviour
     """
-    assert get_dataset_prefix_from_path("belastingen/precario/terrassen/terrassen", "terrassen") == "belastingen/precario"
-    assert get_dataset_prefix_from_path("belastingen/precario/terrassen", "terrassen") == "belastingen/precario"
-    assert get_dataset_prefix_from_path("belastingen/reclame", "reclame") == "belastingen"
-    assert get_dataset_prefix_from_path("bag/bag", "bag") == ""
+    assert get_dataset_prefix_from_path("belastingen/precario/terrassen/terrassen.json", "terrassen") == "belastingen/precario"
+    assert get_dataset_prefix_from_path("belastingen/precario/terrassen.json", "terrassen") == "belastingen/precario"
+    assert get_dataset_prefix_from_path("belastingen/reclame.json", "reclame") == "belastingen"
+    assert get_dataset_prefix_from_path("bag/bag.json", "bag") == ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from schematools.utils import to_snake_case, toCamelCase
+from schematools.utils import get_dataset_prefix_from_path, to_snake_case, toCamelCase
 
 
 def test_toCamelCase():
@@ -41,3 +41,15 @@ def test_to_snake_case():
 
     with pytest.raises(ValueError):
         to_snake_case("")
+
+def test_get_dataset_prefix_from_path():
+    """Confirm that dataset prefix can be extracted from URLs such asL
+    - belastingen/precario/terrassen/terrassen => belastingen/precario
+    - belastingen/precario/terrassen => belastingen/precario
+    - belastingen/reclame => belastingen
+    - bag/bag => ""  # AKA old behaviour
+    """
+    assert get_dataset_prefix_from_path("belastingen/precario/terrassen/terrassen", "terrassen") == "belastingen/precario"
+    assert get_dataset_prefix_from_path("belastingen/precario/terrassen", "terrassen") == "belastingen/precario"
+    assert get_dataset_prefix_from_path("belastingen/reclame", "reclame") == "belastingen"
+    assert get_dataset_prefix_from_path("bag/bag", "bag") == ""


### PR DESCRIPTION
This PR does:
 - add `get_dataset()` method to `DynamicModel` class, allowing connection between `Dataset` and `DynamicModel` models.
 - parses subfolders and uses path as `Dataset.url_prefix` for future reuse in urls.