### PR TITLE
Get rid of warnings during test runs.

### DIFF
--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -10,6 +10,8 @@ from schematools.contrib.django.models import (
     LooseRelationManyToManyField,
 )
 
+pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
+
 
 @pytest.mark.django_db
 def test_model_factory_fields(afval_dataset) -> None:

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -56,7 +56,8 @@ def test_index_creation(engine, db_schema):
         importer.generate_db_objects(table["id"], ind_tables=True, ind_extra_index=True)
 
         conn = create_engine(engine.url, client_encoding="UTF-8")
-        meta_data = MetaData(bind=conn, reflect=True)
+        meta_data = MetaData(bind=conn)
+        meta_data.reflect()
         metadata_inspector = inspect(meta_data.bind)
         indexes = metadata_inspector.get_indexes(
             f"{parent_schema['id']}_{table['id']}", schema=None
@@ -183,7 +184,8 @@ def test_index_troughtables_creation(engine, db_schema):
         for table in dataset_table.get_through_tables_by_id():
 
             conn = create_engine(engine.url, client_encoding="UTF-8")
-            meta_data = MetaData(bind=conn, reflect=True)
+            meta_data = MetaData(bind=conn)
+            meta_data.reflect()
             metadata_inspector = inspect(meta_data.bind)
             indexes = metadata_inspector.get_indexes(table.db_name(), schema=None)
 
@@ -267,7 +269,8 @@ def test_fk_index_creation(engine, db_schema):
             importer.generate_db_objects(table["id"], ind_tables=True, ind_extra_index=True)
 
             conn = create_engine(engine.url, client_encoding="UTF-8")
-            meta_data = MetaData(bind=conn, reflect=True)
+            meta_data = MetaData(bind=conn)
+            meta_data.reflect()
             metadata_inspector = inspect(meta_data.bind)
             indexes = metadata_inspector.get_indexes(
                 f"{parent_schema['id']}_{table['id']}", schema=None
@@ -353,7 +356,8 @@ def test_size_of_index_name(engine, db_schema):
             importer.generate_db_objects(table["id"], ind_tables=True, ind_extra_index=True)
 
             conn = create_engine(engine.url, client_encoding="UTF-8")
-            meta_data = MetaData(bind=conn, reflect=True)
+            meta_data = MetaData(bind=conn)
+            meta_data.reflect()
             metadata_inspector = inspect(meta_data.bind)
             indexes = metadata_inspector.get_indexes(
                 f"{parent_schema['id']}_{table['id']}", schema=None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from collections import Callable
+
+from collections.abc import Callable
 
 import pytest
 


### PR DESCRIPTION
- Fix deprecation for MetaData.reflect()
- Fix deprecation for Callable (should be imported from collections.abc)
- Ignore the RuntimeWarning about "Model was already registered"

Beause suppressing the warnings is not threadsafe, it is not
implemented for the DSO Django code, because that could
throw away relevant warnings.