### PR TITLE
Table and column comments for creating table based on schema

### DIFF
--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -378,6 +378,7 @@ def table_factory(
     """
     if db_table_name is None:
         db_table_name = dataset_table.db_name()
+    db_table_description = dataset_table.description
 
     metadata = metadata or MetaData()
     sub_tables = {}
@@ -387,6 +388,7 @@ def table_factory(
         if field.type.endswith("#/definitions/schema"):
             continue
         field_name = to_snake_case(field.name)
+        field_description = field.description
         sub_columns = []
 
         try:
@@ -461,10 +463,12 @@ def table_factory(
             col_kwargs["autoincrement"] = False
 
         id_postfix = "_id" if field.relation else ""
-        columns.append(Column(f"{field_name}{id_postfix}", col_type, **col_kwargs))
+        columns.append(
+            Column(f"{field_name}{id_postfix}", col_type, comment=field_description, **col_kwargs)
+        )
 
     return {
-        db_table_name: Table(db_table_name, metadata, *columns),
+        db_table_name: Table(db_table_name, metadata, comment=db_table_description, *columns),
         **sub_tables,
     }
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -353,6 +353,11 @@ class DatasetTableSchema(SchemaType):
         return self._parent_schema
 
     @property
+    def description(self) -> Optional[DatasetSchema]:
+        """The description of the table as stated in the schema."""
+        return self.get("description")
+
+    @property
     def fields(self) -> Iterator[DatasetFieldSchema]:
         required = set(self["schema"]["required"])
         for id_, spec in self["schema"]["properties"].items():


### PR DESCRIPTION
On request of datateam ruimte the descriptions of tables and fields in the schema definition are used as comment values in the database for tables and columns.