### PR TITLE
[AB#6837] add DB schema name as parameter for table creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.20.3"
+current = "0.20.4"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.20.3
+version = 0.20.4
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -154,3 +154,32 @@ def test_add_table_comment(here, engine, woningbouwplannen_schema, dbsession):
         "Met name kleinere particuliere projecten worden in de regel pas toegevoegd aan "
         "de monitor zodra er een intentieovereenkomst of afsprakenbrief is getekend."
     )
+
+
+def test_create_table_db_schema(here, engine, woningbouwplannen_schema, dbsession):
+    """Prove that a table is created in given DB schema."""
+    engine.execute("CREATE SCHEMA IF NOT EXISTS schema_foo_bar;")
+    importer = BaseImporter(woningbouwplannen_schema, engine)
+    importer.generate_db_objects(
+        "woningbouwplan", "schema_foo_bar", ind_tables=True, ind_extra_index=False
+    )
+    results = engine.execute(
+        """
+        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan'
+    """
+    )
+    record = results.fetchone()
+    assert record.schemaname == "schema_foo_bar"
+
+
+def test_create_table_no_db_schema(here, engine, woningbouwplannen_schema, dbsession):
+    """Prove that a table is created in DB schema public if no DB schema is given."""
+    importer = BaseImporter(woningbouwplannen_schema, engine)
+    importer.generate_db_objects("woningbouwplan", None, ind_tables=True, ind_extra_index=False)
+    results = engine.execute(
+        """
+        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan'
+    """
+    )
+    record = results.fetchone()
+    assert record.schemaname == "public"

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -370,71 +370,24 @@ def test_size_of_index_name(engine, db_schema):
                 assert len(index_name) <= (MAX_TABLE_NAME_LENGTH - len(TABLE_INDEX_POSTFIX))
 
 
-def test_index_creation_db_schema(engine, db_schema):
-    """Prove that identifier index is created based on DB schema specificiation """
-
-    test_data = {
-        "type": "dataset",
-        "id": "test",
-        "title": "test table",
-        "status": "beschikbaar",
-        "description": "test table",
-        "version": "0.0.1",
-        "crs": "EPSG:28992",
-        "tables": [
-            {
-                "id": "test_db_schema",
-                "type": "table",
-                "schema": {
-                    "$schema": "http://json-schema.org/draft-07/schema#",
-                    "type": "object",
-                    "additionalProperties": "false",
-                    "required": ["schema", "id"],
-                    "display": "id",
-                    "identifier": ["col1", "col2"],
-                    "properties": {
-                        "schema": {
-                            "$ref": (
-                                "https://schemas.data.amsterdam.nl/schema@v1.1.1"
-                                "#/definitions/schema"
-                            )
-                        },
-                        "id": {"type": "integer"},
-                        "geometry": {"$ref": "https://geojson.org/schema/Geometry.json"},
-                        "col1": {"type": "string"},
-                        "col2": {"type": "string"},
-                        "col3": {"type": "string"},
-                    },
-                },
-            }
-        ],
-    }
-
-    data = test_data
-    parent_schema = SchemaType(data)
-    dataset_schema = DatasetSchema(parent_schema)
-    ind_index_exists = False
-
-    for table in data["tables"]:
-        importer = BaseImporter(dataset_schema, engine)
-        # create DB schema
-        engine.execute("CREATE SCHEMA IF NOT EXISTS schema_foo_bar;")
-        # the generate_table and create index
-        importer.generate_db_objects(
-            table["id"], "schema_foo_bar", ind_tables=True, ind_extra_index=True
-        )
-
-        conn = create_engine(engine.url, client_encoding="UTF-8")
-        meta_data = MetaData(bind=conn)
-        meta_data.reflect()
-        metadata_inspector = inspect(meta_data.bind)
-        indexes = metadata_inspector.get_indexes(
-            f"{parent_schema['id']}_{table['id']}", schema="schema_foo_bar"
-        )
-        indexes_name = []
-
-        for index in indexes:
-            indexes_name.append(index["name"])
-        if any("identifier_idx" in i for i in indexes_name):
-            ind_index_exists = True
-        assert ind_index_exists
+def test_index_creation_db_schema2(engine, stadsdelen_schema):
+    """Prove that indexes are created within given database schema on table"""
+    # create DB schema
+    engine.execute("CREATE SCHEMA IF NOT EXISTS schema_foo_bar;")
+    importer = BaseImporter(stadsdelen_schema, engine)
+    importer.generate_db_objects(
+        "stadsdelen", "schema_foo_bar", ind_tables=True, ind_extra_index=True
+    )
+    meta_data = MetaData(bind=engine)
+    meta_data.reflect()
+    metadata_inspector = inspect(meta_data.bind)
+    parent_schema = SchemaType(stadsdelen_schema)
+    indexes = metadata_inspector.get_indexes(
+        f"{parent_schema['id']}_stadsdelen", schema="schema_foo_bar"
+    )
+    indexes_name = []
+    for index in indexes:
+        indexes_name.append(index["name"])
+    if any("identifier_idx" in i for i in indexes_name):
+        ind_index_exists = True
+    assert ind_index_exists


### PR DESCRIPTION
Currently in Airflow an operator is used in serval dags to create the database objects (tables) that are defined in the dataschema definition (JSON schema). It defaults to the DB schema public. 

In some dags the tables are first created in a different schema then public before moved to public. Therefor it could be necessary to create the objects in a different DB schema then public. The DB schema name is added to specify the DB target schema. When not specified it defaults to public.