### PR TITLE
Temporary name as table name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.20.4"
+current = "0.20.5"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.20.4
+version = 0.20.5
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -186,7 +186,7 @@ def test_create_table_no_db_schema(here, engine, woningbouwplannen_schema, dbses
 
 
 def test_create_table_temp_name(engine, woningbouwplannen_schema):
-    """Prove that a table is created in DB schema with temporary name
+    """Prove that a table is created in DB schema with the temporary name
     as definied in a dictionary."""
     table_temp_name = {"woningbouwplannen_woningbouwplan": "foo_bar"}
     importer = BaseImporter(woningbouwplannen_schema, engine)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -183,3 +183,23 @@ def test_create_table_no_db_schema(here, engine, woningbouwplannen_schema, dbses
     )
     record = results.fetchone()
     assert record.schemaname == "public"
+
+
+def test_create_table_temp_name(engine, woningbouwplannen_schema):
+    """Prove that a table is created in DB schema with temporary name
+    as definied in a dictionary."""
+    table_temp_name = {"woningbouwplannen_woningbouwplan": "foo_bar"}
+    importer = BaseImporter(woningbouwplannen_schema, engine)
+    importer.generate_db_objects(
+        "woningbouwplan",
+        db_table_temp_name=table_temp_name,
+        ind_tables=True,
+        ind_extra_index=False,
+    )
+    results = engine.execute(
+        """
+        SELECT tablename FROM pg_tables WHERE tablename = 'foo_bar'
+    """
+    )
+    record = results.fetchone()
+    assert record.tablename == "foo_bar"


### PR DESCRIPTION
Some data processing flows are using temporary table to store data before merging or inserting the data into the target table. In any case it the schema definition should be the source for the table creation, enforcing the defined structure into the database as defined in the data schema. Also preventing structure differences or extra manual steps to create the temporary tables i.e. [table_name]_new.
