### PR TITLE
Dataset has cached property has_geometry_fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.21.1"
+current = "0.21.2"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ django =
     django-gisserver >= 0.5
     django-environ
 dev =
-    tbump  # Bumping version number and Git tagging
+    tbump == 6.3.1  # Bumping version number and Git tagging
     build  # PEP5127 package builder (recommended by PYPA)
     twine  # Submmitting package to PYPI
 kafka =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.21.1
+version = 0.21.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -323,6 +323,14 @@ class Dataset(models.Model):
 
         return DatasetSchema.from_dict(self.schema_data)
 
+    @cached_property
+    def has_geometry_fields(self) -> bool:
+        return any(
+            field.is_geo
+            for table in self.schema.tables
+            for field in table.fields
+        )
+
     def schema_data_changed(self):
         """Check whether the schema_data attribute changed"""
         return (

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -244,6 +244,15 @@ def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_dataset, 
 
 
 @pytest.mark.django_db
+def test_dataset_has_geometry_fields(afval_dataset, hr_dataset):
+    """Prove that has_geometry_fields property is true if
+    and only if a geometry field exists
+    """
+    assert afval_dataset.has_geometry_fields
+    assert not hr_dataset.has_geometry_fields
+
+
+@pytest.mark.django_db
 def test_table_shortname(hr_dataset, verblijfsobjecten_dataset):
     """Prove that the shortnames definition for tables and fields
     are showing up in the Django db_table definitions.


### PR DESCRIPTION
Added the cached property `has_geometry_fields` to Dataset. This is just a copy of the `dataset_has_geometry_fields` function currently in dso-api wfs view, and should replace it. The functionality is needed in multiple locations so I moved it here.