### PR TITLE
Guido/ab4367 notify source owners failed import

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,46 +2,57 @@
 # Supported hooks: https://pre-commit.com/hooks.html
 # Running "make format" fixes most issues for you
 repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.8.0
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
       - id: black
-        language_version: python3.8
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
         exclude: migrations/
         additional_dependencies:
-          - flake8-blind-except == 0.1.1
-          - flake8-debugger == 3.2.1
-          - flake8-colors == 0.1.6
-          - flake8-raise == 0.0.5
+          - flake8-colors  # ANSI colors highlight for Flake8
+          - flake8-raise  # Find improvements for raise statements
+          - flake8-bandit  # Security checks
+          - flake8-bugbear  # Assorted opinionated checks
+          - flake8-builtins  # Check for name collision with builtins
+          - flake8-comprehensions # Write better list/set/dict comprehensions.
+          - flake8-docstrings  # Uses pydocstyle to check docstrings
+          - flake8-implicit-str-concat  #
+          - flake8-print  # Check for Print statements in python files
+          - flake8-rst  # Allows run flake8 on code snippets in docstrings or rst files
+          - flake8-string-format  # str.format checker
+          - flake8-logging-format  # Validate logging format strings
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
-      - id: check-json
-      - id: check-merge-conflict
-      - id: check-toml
-      - id: check-yaml
-      - id: debug-statements
-      - id: detect-private-key
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
+      - id: check-json  # Checks json files for parseable syntax
+      - id: check-merge-conflict  # Check for files that contain merge conflict strings
+      - id: check-toml  # Checks toml files for parseable syntax
+      - id: check-yaml  # Checks yaml files for parseable syntax
+      - id: debug-statements  # Check for debugger imports and py37+ `breakpoint()` calls
+      - id: detect-private-key  # Detects the presence of private keys
+      - id: end-of-file-fixer  # Ensures that a file is either empty, or ends with one newline
+      - id: trailing-whitespace  # trims trailing whitespace
         args: [--markdown-linebreak-ext=md]
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.812
-  #   hooks:
-  #     - id: mypy
-  #       language_version: python3
-  - repo: https://github.com/pycqa/isort
-    rev: 5.7.0
+      - id: check-docstring-first  # Checks a common error of defining a docstring after code
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
     hooks:
-      - id: isort
-        args: ["--filter-files"]
-
-#  - repo: https://github.com/prettier/prettier
-#    rev: "1.19.1"
-#    hooks:
-#      - id: prettier
-#        files: '\.(js|ts|jsx|tsx|scss|css|yml|yaml|json)$'
+      - id: mypy
+        language_version: python3
+  -   repo: https://github.com/pre-commit/pygrep-hooks
+      rev: v1.8.0  # Use the ref you want to point at
+      hooks:
+        - id: python-check-blanket-noqa  # Enforce that noqa annotations always occur with specific codes
+        - id: python-no-eval  # A quick check for the eval() built-in function
+        - id: python-no-log-warn  # A quick check for the deprecated .warn() method of python loggers
+        - id: rst-backticks  # Detect common mistake of using single backticks when writing rst
+        - id: rst-directive-colons  # Detect mistake of rst directive not ending with double colon
+        - id: rst-inline-touching-normal  # Detect mistake of inline code touching normal text in rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     jsonpath-rw
     pg-grant
     simple-singleton
+    more-ds
 tests_require=
     pytest
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,15 +61,18 @@ where = src
 tests =
     mypy
     flake8
-    flake8-bandit  # security checks
-    flake8-bugbear  # assorted opinionated checks
-    flake8-builtins  # check for name collision with builtins
-    flake8-comprehensions
-    flake8-docstrings
-    flake8-implicit-str-concat
-    flake8-print
+    flake8-colors  # ANSI colors highlight for Flake8
+    flake8-raise  # Find improvements for raise statements
+    flake8-bandit  # Security checks
+    flake8-bugbear  # Assorted opinionated checks
+    flake8-builtins  # Check for name collision with builtins
+    flake8-comprehensions # Write better list/set/dict comprehensions.
+    flake8-docstrings  # Uses pydocstyle to check docstrings
+    flake8-implicit-str-concat  #
+    flake8-print  # Check for Print statements in python files
     flake8-rst  # Allows run flake8 on code snippets in docstrings or rst files
-    flake8-string-format
+    flake8-string-format  # str.format checker
+    flake8-logging-format  # Validate logging format strings
     pytest
     pytest-cov
     pytest-django
@@ -113,7 +116,7 @@ log_cli = False
 [flake8]
 # A = builtins
 # B = bugbear
-# C = comprehensions
+# C4 = comprehensions
 # D = docstrings
 # E = pycodestyle errors, rst
 # F = flake8 pyflakes, rst
@@ -127,13 +130,9 @@ log_cli = False
 # ISC = implicit-str-concat
 ban-relative-imports = True
 max-line-length = 99
-statistics=True
-# We should be using the following `select` line
-# but as that generates way too many warnings we
-# start with a smaller subset. However we should be gradually
-# moving to more and strict checks.
-# select = A, B, C, D, E, F, G, P, RST, S, T, W, B9, ISC
-select = B, C, D, E, F, G, RST, W, B9, ISC
+docstring-convention = google
+statistics = True
+select = A, B, C4, D, E, F, G, P, RST, S, T, W, B9, ISC
 doctests = True
 ignore=
     E203  # Black may add spaces in slice[func(v) : end] syntax

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,23 +134,32 @@ docstring-convention = google
 statistics = True
 select = A, B, C4, D, E, F, G, P, RST, S, T, W, B9, ISC
 doctests = True
-ignore=
-    E203  # Black may add spaces in slice[func(v) : end] syntax
-    E231  # Black leaves commas after combining lines
-    F403  # Allow import * (for settings)
-    F405  # Allow import * (for settings)
-    E731  # Allow lambdas:
-    W503  # line break before binary operator (incompatible with black):
-    R102  # Allow raise Exception()
-exclude=
-    .git
-    **/migrations/*
-    docs
-    scripts
-    .cache
-    .eggs
-    __pycache__
-    build
-    dist
-    .venv
+ignore =
+    # D100  Missing docstring in public module
+    D100,
+    # E203  Black may add spaces in slice[func(v) : end] syntax
+    E203,
+    # E231  Black leaves commas after combining lines
+    E231,
+    # F403  Allow import * (for settings)
+    F403,
+    # F405  Allow import * (for settings)
+    F405,
+    # E731  Allow lambdas:
+    E731,
+    # W503  line break before binary operator (incompatible with black):
+    W503,
+    # R102  Allow raise Exception()
+    R102
+exclude =
+    .git,
+    **/migrations/*,
+    docs,
+    scripts,
+    .cache,
+    .eggs,
+    __pycache__,
+    build,
+    dist,
+    .venv,
     venv


### PR DESCRIPTION
Changed all `schematools.utils` function to also accept a `URL` in addition to a `str` for URLs.

While manually running MyPy on the module I noticed that there was a [typing issue](https://github.com/Amsterdam/schema-tools/pull/146/files/2a1fd8cccd622fb6621485e12da7d7b02bce79b9#r642109753) in it that could lead to an `AttributeError` at runtime. Puzzled as to why the MyPy pre-commit hook hadn't catched that, I noticed that hook had been disabled in commit 32a47f1fdf50618ea23820afee0f1b88d2f41a66. Though it wasn't document in that commit as to why it had been turned off (hint, hint), I happen remember it was done as it generated many errors and warning that were deemed an hindrance. However balancing the hindrance aspect compared to that of less actual errors in code I really prefer the latter. Hence I have re-enabled the MyPy commit hook. 

In addition I have added additional flake8 warnings (our code is not really consistent) and have to modify the `[flake8]` setion in `setup.cfg`. It turns out, after a lot of debugging, that flake8 doesn't like inline comments, though setuptools and pytest are seemingly fine with it.