### PR TITLE
Fix edge case with in profile loading process

### DIFF
--- a/src/schematools/contrib/django/management/commands/import_profiles.py
+++ b/src/schematools/contrib/django/management/commands/import_profiles.py
@@ -13,11 +13,15 @@ class Command(BaseCommand):
     help = "Import all known profiles from Amsterdam schema files."
     requires_system_checks = False
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser) -> None:
         parser.add_argument("profile", nargs="*", help="Local profile files to import")
-        parser.add_argument("--schema-url", default=settings.PROFILES_URL)
+        parser.add_argument(
+            "--schema-url",
+            default=settings.PROFILES_URL,
+            help=f"Schema URL (default: {settings.PROFILES_URL})",
+        )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options) -> None:
         if options["profile"]:
             profiles = self.import_from_files(options["profile"])
         else:
@@ -29,17 +33,18 @@ class Command(BaseCommand):
         else:
             self.stdout.write("No new profiles imported.")
 
-    def import_from_files(self, profile_files) -> List[Profile]:
+    def import_from_files(self, profile_files: List[str]) -> List[Profile]:
         profiles = []
         for filename in profile_files:
             self.stdout.write(f"Loading profile from {filename}")
             schema = ProfileSchema.from_file(filename)
             profile = self.import_schema(schema.name, schema)
-            profiles.append(profile)
+            if profile is not None:
+                profiles.append(profile)
 
         return profiles
 
-    def import_from_url(self, schema_url) -> List[Profile]:
+    def import_from_url(self, schema_url: str) -> List[Profile]:
         """Import all schema definitions from an URL"""
         self.stdout.write(f"Loading profiles from {schema_url}")
         profiles = []

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -269,6 +269,7 @@ def get_dataset_prefix_from_path(dataset_path: str, dataset_data: dict) -> str:
         dataset_path = dataset_path.split(version)[0]
 
     dataset_parts = dataset_path.split("/")[:-1]
-    if to_snake_case(dataset_parts[-1]) == to_snake_case(dataset_data["id"]):
-        dataset_parts.pop()
+    if len(dataset_parts):
+        if to_snake_case(dataset_parts[-1]) == to_snake_case(dataset_data["id"]):
+            dataset_parts.pop()
     return "/".join(dataset_parts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,3 +128,16 @@ def test_get_dataset_prefix_from_path_with_camel_case_id() -> None:
         )
         == "kaarten"
     )
+
+
+def test_get_dataset_prefix_from_path_using_filename() -> None:
+    """Confirm that dataset prefix can be extracted from URLs when dataset_path is filename
+    - beheerkaart_cbs_grid.json => ""
+    """
+    dataset = {"id": "beheerkaartCbsGrid", "version": "0.0.1"}
+    assert (
+        get_dataset_prefix_from_path(
+            dataset_path="beheerkaart_cbs_grid.json", dataset_data=dataset
+        )
+        == ""
+    )


### PR DESCRIPTION
Allow `dataset`/`profile` path to have no subpaths.