### PR TITLE
Yrob/ab4388 temporaliteit naar tabel niveau

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,9 @@ ENV/
 # vim
 *.swp
 
+# VSCode
+.vscode/
+
 #
 /scratch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.21.3"
+current = "0.21.4"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.21.3
+version = 0.21.4
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -71,7 +71,7 @@ class RelationMaker:
 
         # So, target-side of relation is temporal
         # Determine fieldnames used for temporal
-        sequence_identifier = related_table.temporal["identifier"]
+        sequence_identifier = related_table.temporal.identifier
         identifier = related_dataset.identifier
 
         # If temporal, this implicates that the type is not a scalar

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -490,14 +490,9 @@ class DatasetTableSchema(SchemaType):
         return self._parent_schema.use_dimension_fields
 
     @property
-    def temporal(
-        self, field_modifier: Optional[Callable] = None
-    ) -> Optional[Dict[str, Union[str, Dict[str, List[str]]]]]:
+    def temporal(self) -> Optional[Dict[str, Union[str, Dict[str, List[str]]]]]:
         """Return the temporal info"""
         from schematools.utils import to_snake_case
-
-        if field_modifier is None:
-            field_modifier = to_snake_case
 
         temporal_configuration = self["schema"].get("temporal", None)
         if temporal_configuration is None:
@@ -505,8 +500,8 @@ class DatasetTableSchema(SchemaType):
 
         for key, [start_field, end_field] in temporal_configuration.get("dimensions", {}).items():
             temporal_configuration["dimensions"][key] = [
-                field_modifier(start_field),
-                field_modifier(end_field),
+                to_snake_case(start_field),
+                to_snake_case(end_field),
             ]
 
         return temporal_configuration

--- a/tests/files/bouwblokken.json
+++ b/tests/files/bouwblokken.json
@@ -6,12 +6,6 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "bouwblokken",
@@ -25,6 +19,12 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -65,7 +65,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/bouwblokken.json
+++ b/tests/files/bouwblokken.json
@@ -11,6 +11,12 @@
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/brk.json
+++ b/tests/files/brk.json
@@ -11,6 +11,12 @@
     {
       "id": "kadastraleobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "identificatie",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -194,6 +194,12 @@
     {
       "id": "zakelijkerechten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/zakelijkerechten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -202,12 +208,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -594,6 +594,12 @@
     {
       "id": "tenaamstellingen",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -602,12 +608,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "volgnummer", "identificatie"],
         "display": "identificatie",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -781,6 +781,12 @@
     {
       "id": "aantekeningenkadastraleobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenkadastraleobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,12 +795,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/brk.json
+++ b/tests/files/brk.json
@@ -7,12 +7,6 @@
   "crs": "EPSG:28992",
   "auth": "BRK/RSN",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "kadastraleobjecten",
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "identificatie",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -202,6 +202,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -301,7 +307,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -597,6 +602,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "volgnummer", "identificatie"],
         "display": "identificatie",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -705,7 +716,6 @@
         "identifier": "id",
         "required": ["schema", "id", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -779,6 +789,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -875,7 +891,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1010,7 +1025,6 @@
         "identifier": "code",
         "required": ["schema", "code", "identificatie"],
         "display": "code",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1055,7 +1069,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1097,7 +1110,6 @@
         "identifier": "id",
         "required": ["schema", "id"],
         "display": "id",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1125,7 +1137,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1167,7 +1178,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -1205,7 +1215,6 @@
         "identifier": "identificatie",
         "required": ["schema", "identificatie"],
         "display": "identificatie",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden.json
+++ b/tests/files/gebieden.json
@@ -5,12 +5,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "crs": "EPSG:28992",
   "tables": [
     {
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -96,6 +96,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -176,6 +182,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -256,6 +268,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -324,6 +342,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden.json
+++ b/tests/files/gebieden.json
@@ -10,6 +10,12 @@
     {
       "id": "bouwblokken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -87,6 +87,12 @@
     {
       "id": "buurten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -96,12 +102,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -173,6 +173,12 @@
     {
       "id": "wijken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -182,12 +188,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -259,6 +259,12 @@
     {
       "id": "stadsdelen",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -268,12 +274,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -333,6 +333,12 @@
     {
       "id": "ggwgebieden",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -342,12 +348,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden_auth.json
+++ b/tests/files/gebieden_auth.json
@@ -6,12 +6,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "bouwblokken",
@@ -26,6 +20,12 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -67,6 +67,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -147,6 +153,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden_auth.json
+++ b/tests/files/gebieden_auth.json
@@ -12,6 +12,12 @@
       "mainGeometry": "geometrie",
       "type": "table",
       "auth": "LEVEL/B",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -20,12 +26,6 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -58,6 +58,12 @@
     {
       "id": "buurten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -67,12 +73,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -144,6 +144,12 @@
     {
       "id": "wijken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -153,12 +159,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden_auth_list.json
+++ b/tests/files/gebieden_auth_list.json
@@ -6,12 +6,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "bouwblokken",
@@ -26,6 +20,12 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -67,6 +67,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -147,6 +153,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/gebieden_auth_list.json
+++ b/tests/files/gebieden_auth_list.json
@@ -12,6 +12,12 @@
       "mainGeometry": "geometrie",
       "type": "table",
       "auth": ["LEVEL/B1", "LEVEL/B2"],
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -20,12 +26,6 @@
         "identifier": ["id"],
         "required": ["schema", "id"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -58,6 +58,12 @@
     {
       "id": "buurten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -67,12 +73,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -144,6 +144,12 @@
     {
       "id": "wijken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -153,12 +159,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/ggwgebieden.json
+++ b/tests/files/ggwgebieden.json
@@ -10,6 +10,12 @@
     {
       "id": "buurten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -96,6 +96,12 @@
     {
       "id": "wijken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -105,12 +111,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -143,6 +143,12 @@
     {
       "id": "ggwgebieden",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -151,12 +157,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -232,6 +232,12 @@
     {
       "id": "stadsdelen",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -241,12 +247,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/ggwgebieden.json
+++ b/tests/files/ggwgebieden.json
@@ -5,12 +5,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "crs": "EPSG:28992",
   "tables": [
     {
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -105,6 +105,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -145,6 +151,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -229,6 +241,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/kadastraleobjecten.json
+++ b/tests/files/kadastraleobjecten.json
@@ -7,12 +7,6 @@
   "crs": "EPSG:28992",
   "auth": "BRK/RSN",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "kadastraleobjecten",
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "identificatie",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/kadastraleobjecten.json
+++ b/tests/files/kadastraleobjecten.json
@@ -11,6 +11,12 @@
     {
       "id": "kadastraleobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "identificatie",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/multirelation.json
+++ b/tests/files/multirelation.json
@@ -10,6 +10,12 @@
     {
       "id": "hasrelations",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/woonplaatsen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -17,12 +23,6 @@
         "additionalProperties": false,
         "required": "id",
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/multirelation.json
+++ b/tests/files/multirelation.json
@@ -6,12 +6,6 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "hasrelations",
@@ -23,6 +17,12 @@
         "additionalProperties": false,
         "required": "id",
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/verblijfsobjecten.json
+++ b/tests/files/verblijfsobjecten.json
@@ -6,12 +6,6 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "verblijfsobjecten",
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "identificatie",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/verblijfsobjecten.json
+++ b/tests/files/verblijfsobjecten.json
@@ -10,6 +10,12 @@
     {
       "id": "verblijfsobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/verblijfsobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "identificatie",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/woonplaatsen.json
+++ b/tests/files/woonplaatsen.json
@@ -10,6 +10,12 @@
     {
       "id": "woonplaatsen",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/woonplaatsen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -17,12 +23,6 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/files/woonplaatsen.json
+++ b/tests/files/woonplaatsen.json
@@ -6,12 +6,6 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "woonplaatsen",
@@ -23,6 +17,12 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -61,7 +61,6 @@
         "identifier": "dossier",
         "required": ["schema", "dossier"],
         "display": "dossier",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -6,8 +6,7 @@ from schematools.types import DatasetSchema, SchemaType
 
 
 def test_index_creation(engine, db_schema):
-    """Prove that identifier index is created based on schema specificiation"""
-
+    """Prove that identifier index is created based on schema specificiation."""
     test_data = {
         "type": "dataset",
         "id": "test",
@@ -75,8 +74,8 @@ def test_index_troughtables_creation(engine, db_schema):
     """Prove that many-to-many table indexes are created based on schema specification.
 
     A NM relation with a very long name has deliberatly added. The truncation of index
-    names should avoid failing tests."""
-
+    names should avoid failing tests.
+    """
     test_data = {
         "type": "dataset",
         "id": "test",
@@ -86,10 +85,6 @@ def test_index_troughtables_creation(engine, db_schema):
         "is_default_version": "true",
         "crs": "EPSG:28992",
         "identifier": "identificatie",
-        "temporal": {
-            "identifier": "volgnummer",
-            "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
-        },
         "tables": [
             {
                 "id": "test_1",
@@ -100,6 +95,10 @@ def test_index_troughtables_creation(engine, db_schema):
                     "identifier": ["identificatie", "volgnummer"],
                     "required": ["schema", "id", "identificatie", "volgnummer"],
                     "display": "id",
+                    "temporal": {
+                        "identifier": "volgnummer",
+                        "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
+                    },
                     "properties": {
                         "schema": {
                             "$ref": (
@@ -146,6 +145,10 @@ def test_index_troughtables_creation(engine, db_schema):
                     "identifier": ["identificatie", "volgnummer"],
                     "required": ["schema", "id", "identificatie", "volgnummer"],
                     "display": "id",
+                    "temporal": {
+                        "identifier": "volgnummer",
+                        "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
+                    },
                     "properties": {
                         "schema": {
                             "$ref": (
@@ -201,7 +204,6 @@ def test_index_troughtables_creation(engine, db_schema):
 
 def test_fk_index_creation(engine, db_schema):
     """Prove that index is created on 1:N relational columns based on schema specificiation."""
-
     test_data = {
         "type": "dataset",
         "id": "test",
@@ -291,7 +293,6 @@ def test_size_of_index_name(engine, db_schema):
     It should not exeed the size for Postgres database object names
     as defined in MAX_TABLE_NAME_LENGTH plus TABLE_INDEX_POSTFIX.
     """
-
     test_data = {
         "type": "dataset",
         "id": "test",
@@ -374,7 +375,7 @@ def test_size_of_index_name(engine, db_schema):
 
 
 def test_index_creation_db_schema2(engine, stadsdelen_schema):
-    """Prove that indexes are created within given database schema on table"""
+    """Prove that indexes are created within given database schema on table."""
     # create DB schema
     engine.execute("CREATE SCHEMA IF NOT EXISTS schema_foo_bar;")
     importer = BaseImporter(stadsdelen_schema, engine)

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -89,16 +89,16 @@ def test_index_troughtables_creation(engine, db_schema):
             {
                 "id": "test_1",
                 "type": "table",
+                "temporal": {
+                    "identifier": "volgnummer",
+                    "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
+                },
                 "schema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "identifier": ["identificatie", "volgnummer"],
                     "required": ["schema", "id", "identificatie", "volgnummer"],
                     "display": "id",
-                    "temporal": {
-                        "identifier": "volgnummer",
-                        "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
-                    },
                     "properties": {
                         "schema": {
                             "$ref": (
@@ -139,16 +139,16 @@ def test_index_troughtables_creation(engine, db_schema):
             {
                 "id": "test_2",
                 "type": "table",
+                "temporal": {
+                    "identifier": "volgnummer",
+                    "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
+                },
                 "schema": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "identifier": ["identificatie", "volgnummer"],
                     "required": ["schema", "id", "identificatie", "volgnummer"],
                     "display": "id",
-                    "temporal": {
-                        "identifier": "volgnummer",
-                        "dimensions": {"geldigOp": ["beginGeldigheid", "eindGeldigheid"]},
-                    },
                     "properties": {
                         "schema": {
                             "$ref": (


### PR DESCRIPTION
Nu temporaliteit in amsterdam-schema naar tabel niveau is verplaatst (https://github.com/Amsterdam/amsterdam-schema/pull/229). Moet dat ook hier gebeuren. 