### PR TITLE
Fix types in typing.py

### DIFF
--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -85,7 +85,7 @@ class RelationMaker:
             raise ValueError(f"Cannot find temporal fields of table {related_table.id}")
 
         if field.is_array_of_objects:
-            properties = field.items["properties"]
+            properties = field.field_items["properties"]
         elif field.is_object:
             properties = field["properties"]
         else:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -15,8 +15,10 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import jsonschema
@@ -50,7 +52,7 @@ class SchemaType(UserDict):
         return self.data
 
     @classmethod
-    def from_dict(cls, obj: Dict[str, Any]) -> SchemaType:
+    def from_dict(cls: Type[ST], obj: Dict[str, Any]) -> ST:
         return cls(obj)
 
 
@@ -819,7 +821,7 @@ class DatasetFieldSchema(DatasetType):
         if not dataset_table.is_temporal:
             return {}
 
-        return dataset_table.temporal.dimensions
+        return cast(Dict[str, List[str]], dataset_table.temporal.dimensions)
 
     @property
     def sub_fields(self) -> Iterator[DatasetFieldSchema]:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -426,6 +426,15 @@ class DatasetTableSchema(SchemaType):
         if not self["schema"].get("$schema", "").startswith("http://json-schema.org/"):
             raise ValueError("Invalid JSON-schema contents of table")
 
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]) -> DatasetTableSchema:
+        """Create tableschema from a dict.
+
+        When this factory function is used, the _parent_schema argument is missing
+        and will be set to an empty DatasetSchema.
+        """
+        return cls(DatasetSchema({"id": "parent", "type": "dataset"}), obj)
+
     @property
     def name(self) -> str:
         return self.get("shortname", self.id)
@@ -678,6 +687,17 @@ class DatasetFieldSchema(DatasetType):
         self._parent_field = _parent_field
         self._required = _required
         self._temporal = _temporal
+
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]) -> DatasetFieldSchema:
+        """Create fieldschema from a dict.
+
+        When this factory function is used, the _id and _parent_table arguments are missing
+        and will be set to the "id" of the obj argument and an empty DatasetSchema.
+        """
+        return cls(
+            obj["id"], DatasetTableSchema(DatasetSchema({"id": "parent", "type": "dataset"})), obj
+        )
 
     @property
     def table(self) -> DatasetTableSchema:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -536,7 +536,7 @@ class DatasetTableSchema(SchemaType):
         if temporal_config.get("identifier") is None or temporal_config.get("dimensions") is None:
             raise ValueError("Invalid temporal data")
 
-        dimensions = {}
+        dimensions: Dict[str, Tuple[str, str]] = {}
         for key, [start_field, end_field] in temporal_config.get("dimensions").items():
             dimensions[key] = (
                 to_snake_case(start_field),
@@ -566,7 +566,7 @@ class DatasetTableSchema(SchemaType):
         # Convert identifier to a list, to be backwards compatible with older schemas
         if not isinstance(identifier, list):
             identifier = [identifier]
-        return list(identifier)  # mypy pleaser
+        return cast(list, identifier)  # mypy pleaser
 
     @property
     def has_compound_key(self) -> bool:
@@ -626,7 +626,7 @@ class DatasetTableSchema(SchemaType):
         model_name = self.id
         if self.dataset.version is not None and not self.dataset.is_default_version:
             model_name = f"{model_name}_{self.dataset.version}"
-        return str(to_snake_case(model_name))  # mypy pleaser
+        return cast(str, to_snake_case(model_name))  # mypy pleaser
 
     def db_name(self) -> str:
         """Returns the tablename for the database, prefixed with the schemaname.
@@ -801,7 +801,7 @@ class DatasetFieldSchema(DatasetType):
 
     def get_dimension_fieldnames_for_relation(
         self, relation: Optional[str], nm_relation: Optional[str]
-    ) -> Dict[str, List[str]]:
+    ) -> Dict[str, Tuple[str, str]]:
         """Gets the dimension fieldnames."""
         if relation is None and nm_relation is None:
             return {}
@@ -821,7 +821,9 @@ class DatasetFieldSchema(DatasetType):
         if not dataset_table.is_temporal:
             return {}
 
-        return cast(Dict[str, List[str]], dataset_table.temporal.dimensions)
+        # Seems that mypy cannot infer the type from the assignment
+        dimensions: Dict[str, Tuple[str, str]] = dataset_table.temporal.dimensions
+        return dimensions if dimensions is not None else {}
 
     @property
     def sub_fields(self) -> Iterator[DatasetFieldSchema]:
@@ -1072,4 +1074,4 @@ class Temporal:
     """
 
     identifier: str
-    dimensions: Dict[Tuple[str]] = field(default_factory=dict)
+    dimensions: Dict[str, Tuple[str, str]] = field(default_factory=dict)

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -34,10 +34,10 @@ def schema_defs_from_url(
             dataset_id=dataset_name,
             prefetch_related=prefetch_related,
         )
-        return {dataset_name: cast(types.DatasetSchema, schema)}
+        return {dataset_name: schema}
 
     return {
-        ds_name: cast(types.DatasetSchema, ds_schema)
+        ds_name: ds_schema
         for ds_name, ds_schema in defs_from_url(
             base_url=schemas_url, data_type=types.DatasetSchema
         ).items()
@@ -50,14 +50,11 @@ def schema_def_from_url(
     prefetch_related: bool = False,
 ) -> types.DatasetSchema:
     """Fetch schema definition from a remote file."""
-    return cast(
-        types.DatasetSchema,
-        def_from_url(
-            base_url=schemas_url,
-            data_type=types.DatasetSchema,
-            dataset_id=dataset_name,
-            prefetch_related=prefetch_related,
-        ),
+    return def_from_url(
+        base_url=schemas_url,
+        data_type=types.DatasetSchema,
+        dataset_id=dataset_name,
+        prefetch_related=prefetch_related,
     )
 
 
@@ -68,21 +65,19 @@ def profile_defs_from_url(profiles_url: Union[URL, str]) -> Dict[str, types.Prof
     The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
     """
     return {
-        p_name: cast(types.ProfileSchema, p_schema)
+        p_name: p_schema
         for p_name, p_schema in defs_from_url(
             base_url=profiles_url, data_type=types.ProfileSchema
         ).items()
     }
 
 
-def defs_from_url(
-    base_url: Union[URL, str], data_type: Type[types.SchemaType]
-) -> Dict[str, types.SchemaType]:
+def defs_from_url(base_url: Union[URL, str], data_type: Type[types.ST]) -> Dict[str, types.ST]:
     """Fetch all schema definitions from a remote file.
 
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
     """
-    schema_lookup: Dict[str, types.SchemaType] = {}
+    schema_lookup: Dict[str, types.ST] = {}
     base_url = URL(base_url)
 
     with requests.Session() as connection:
@@ -108,7 +103,7 @@ def def_from_url(
     data_type: Type[types.ST],
     dataset_id: str,
     prefetch_related: bool = False,
-) -> types.SchemaType:
+) -> types.ST:
     """Fetch schema definitions from a remote file for a single dataset.
 
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
@@ -124,7 +119,7 @@ def def_from_url(
         response = connection.get(base_url / index[dataset_id])
         response.raise_for_status()
 
-        dataset_schema: types.SchemaType = data_type.from_dict(response.json())
+        dataset_schema: types.ST = data_type.from_dict(response.json())
 
     # For this recursive call, we set prefetch_related=False
     # to avoid deep/endless recursion

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -36,12 +36,7 @@ def schema_defs_from_url(
         )
         return {dataset_name: schema}
 
-    return {
-        ds_name: ds_schema
-        for ds_name, ds_schema in defs_from_url(
-            base_url=schemas_url, data_type=types.DatasetSchema
-        ).items()
-    }
+    return defs_from_url(base_url=schemas_url, data_type=types.DatasetSchema)
 
 
 def schema_def_from_url(
@@ -64,12 +59,8 @@ def profile_defs_from_url(profiles_url: Union[URL, str]) -> Dict[str, types.Prof
 
     The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
     """
-    return {
-        p_name: p_schema
-        for p_name, p_schema in defs_from_url(
-            base_url=profiles_url, data_type=types.ProfileSchema
-        ).items()
-    }
+
+    return defs_from_url(base_url=profiles_url, data_type=types.ProfileSchema)
 
 
 def defs_from_url(base_url: Union[URL, str], data_type: Type[types.ST]) -> Dict[str, types.ST]:


### PR DESCRIPTION
Separate commit to fix the typings in types.py (and utils.py).

Changed some optional parameters (id, parent) for table and field to mandatory (non-keyword) parameters,
because the parameters are always needed anyway. This simplified the `mypy pleasing` quite a bit.