### PR TITLE
Use the identifier from the table for temporality

### DIFF
--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -72,7 +72,8 @@ class RelationMaker:
         # So, target-side of relation is temporal
         # Determine fieldnames used for temporal
         sequence_identifier = related_table.temporal.identifier
-        identifier = related_dataset.identifier
+        # Table identifier is mandatory and always contains at least one field
+        identifier = related_table.identifier[0]
 
         # If temporal, this implicates that the type is not a scalar
         # but needs to be more complex (object) or array_of_objects
@@ -82,6 +83,7 @@ class RelationMaker:
         sequence_field = related_table.get_field_by_id(sequence_identifier)
         identifier_field = related_table.get_field_by_id(identifier)
         if sequence_field is None or identifier_field is None:
+
             raise ValueError(f"Cannot find temporal fields of table {related_table.id}")
 
         if field.is_array_of_objects:

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -120,10 +120,7 @@ class DataSplitter:
         dataset_id, table_id = relation.split(":")
         target_dataset = self.events_processor.datasets[dataset_id]
         target_dataset_table = target_dataset.get_table_by_id(table_id)
-        field_names = target_dataset_table.identifier
-        # Use step value to reverse list if needed
-        step = 1 if target_dataset.identifier == field_names[0] else -1
-        return target_dataset_table.identifier[::step]
+        return target_dataset_table.identifier
 
     def _fetch_source_id_info(self):
         # id info for source side of relation (for updates/deletes)


### PR DESCRIPTION
Temporal information has been moved down from dataset to table.
However, the main identifier (usually "identificatie") was still
obtained from the dataset. Thas been now been corrected.