### PR TITLE
Fix casing-issues for shortnames on datasettable

### DIFF
--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -104,6 +104,7 @@ class NDJSONImporter(BaseImporter):
                                 continue
                             sub_field_name = to_snake_case(sub_field.name)
                             nested_row_record[sub_field_name] = nested_row.get(sub_field.name)
+
                         nested_row_records.append(nested_row_record)
 
                     sub_table_id = f"{db_table_name}_{field_name}"[:MAX_TABLE_NAME_LENGTH]


### PR DESCRIPTION
Team BK introduced a camelcased shortname for a table
(hr.maatschappelijkeactiviteiten).
This was not handled correctly in ndjson importer
and has been fixed by this commit.