### PR TITLE
Fix db_column names to source of nm relation

### DIFF
--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -218,10 +218,11 @@ class M2MRelationMaker(RelationMaker):
     def field_kwargs(self):
         kwargs = {}
         snakecased_fieldname = to_snake_case(self.field.name)
-        parent_table = to_snake_case(self.field._parent_table.id)
+        parent_table = to_snake_case(self.field._parent_table.name)
         kwargs["related_name"] = f"{snakecased_fieldname}_{parent_table}"
         kwargs["through"] = self._make_through_classname(self.dataset.id, self.field.id)
         kwargs["through_fields"] = (parent_table, snakecased_fieldname)
+
         return {**super().field_kwargs, **kwargs}
 
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -280,6 +280,7 @@ class DatasetSchema(SchemaType):
         # and not the shortnames
         left_dataset_id = to_snake_case(self.id)
         left_table_id = to_snake_case(table.id)
+        left_table_name = to_snake_case(table.name)
 
         # Both relation types can have a through table,
         # For FK relations, an extra through_table is created when
@@ -312,7 +313,7 @@ class DatasetSchema(SchemaType):
                 "required": ["schema"],
                 "properties": {
                     "schema": {"$ref": "#/definitions/schema"},
-                    left_table_id: {
+                    left_table_name: {
                         "type": "string",
                         "relation": f"{left_dataset_id}:{left_table_id}",
                     },

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -178,7 +178,7 @@ def test_model_factory_sub_objects_for_shortened_names(verblijfsobjecten_dataset
     }
 
     # Field is a related, should have 2 FKs to both sides of the relation
-    assert isinstance(fields_dict["maatschappelijkeactiviteiten"], models.ForeignKey)
+    assert isinstance(fields_dict["activiteiten"], models.ForeignKey)
     assert isinstance(fields_dict["sbi_voor_activiteit"], models.ForeignKey)
 
 
@@ -267,7 +267,7 @@ def test_dataset_has_geometry_fields(afval_dataset, hr_dataset):
 
 @pytest.mark.django_db
 def test_table_shortname(verblijfsobjecten_dataset, hr_dataset):
-    """Prove that the shortnames definition for tables and fields
+    """Prove that the shortnames definition for tables
     are showing up in the Django db_table definitions.
     We changed the table name to 'activiteiten'.
     And used a shortname for a nested and for a relation field.
@@ -286,6 +286,28 @@ def test_table_shortname(verblijfsobjecten_dataset, hr_dataset):
     }
 
     assert db_table_names == set(m._meta.db_table for m in model_dict.values())
+
+
+@pytest.mark.django_db
+def test_column_shortnames_in_nm_throughtables(verblijfsobjecten_dataset, hr_dataset):
+    """Prove that the shortnames definition for fields
+    are showing up in the Django db_table definitions.
+    We changed the table name to 'activiteiten'.
+    And used a shortname for a nested and for a relation field.
+    """
+    model_dict = {
+        cls._meta.model_name: cls
+        for cls in schema_models_factory(hr_dataset, base_app_name="dso_api.dynamic_api")
+    }
+
+    db_colnames = {"activiteiten_id", "sbi_voor_activiteit_id"}
+    assert db_colnames == set(
+        f.db_column
+        for f in model_dict[
+            "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming"
+        ]._meta.fields
+        if f.db_column is not None
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
These db_columns were not correct when the source table
was using a `shortname`, leading to SQL errors in DSO API