### PR TITLE
AB#4378 Add id column for through tables

### DIFF
--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -160,12 +160,15 @@ class DataSplitter:
                 nm_row_data[f"{name_prefix}{fn}"] = fv
 
             # id for source side of relation
-            nm_row_data.update({snaked_source_table_id: id_value})
+            nm_row_data[snaked_source_table_id] = id_value
 
             # id for target side of relation
-            nm_row_data[f"{snaked_field_id}_id"] = ".".join(
-                (str(row_data[fn]) for fn in target_identifier_fields)
-            )
+            target_id_value = ".".join((str(row_data[fn]) for fn in target_identifier_fields))
+            nm_row_data[f"{snaked_field_id}_id"] = target_id_value
+
+            # PK field, needed by Django
+            nm_row_data["id"] = f"{id_value}{target_id_value}"
+
             nm_rows.append(nm_row_data)
 
         self.junction_table_rows[snaked_field_id] = nm_rows

--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -7,7 +7,18 @@ from typing import Dict, Optional
 
 from jsonpath_rw import parse
 from more_itertools import first
-from sqlalchemy import Column, ForeignKey, Index, Integer, MetaData, String, Table, exc, inspect
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    exc,
+    inspect,
+)
 
 from schematools import MAX_TABLE_NAME_LENGTH, TABLE_INDEX_POSTFIX
 from schematools.types import DatasetSchema, DatasetTableSchema
@@ -437,6 +448,10 @@ def table_factory(
 
                     # We need a 'through' table for the n-m relation
                     sub_columns = [
+                        Column(
+                            "id",
+                            Text,
+                        ),
                         Column(
                             f"{dataset_table_name}_id",
                             String,

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -153,6 +153,7 @@ class NDJSONImporter(BaseImporter):
                                     through_row_record[full_through_field_name] = value[
                                         through_field_name
                                     ]
+                            through_row_record["id"] = f"{from_fk}.{to_fk}"
                             through_row_record[f"{field_name}_id"] = to_fk
 
                             through_row_records.append(through_row_record)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -321,9 +321,12 @@ class DatasetSchema(SchemaType):
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["schema"],
+                "required": ["schema", "id"],
                 "properties": {
                     "schema": {"$ref": "#/definitions/schema"},
+                    "id": {
+                        "type": "string",
+                    },
                     left_table_name: {
                         "type": "string",
                         "relation": f"{left_dataset_id}:{left_table_id}",

--- a/tests/test_events_full.py
+++ b/tests/test_events_full.py
@@ -75,6 +75,7 @@ def test_event_process_1n_relation_insert(here, tconn, local_metadata, gebieden_
     assert through_records[0]["ligt_in_buurt_id"] == "03630000000707.2"
 
     available_columns = {
+        "id",
         "bouwblokken_id",
         "ligt_in_buurt_id",
         "bouwblokken_identificatie",
@@ -125,6 +126,7 @@ def test_event_process_nm_relation_insert(
     assert records[0]["eind_geldigheid"] is None
 
     available_columns = {
+        "id",
         "ggwgebieden_id",
         "bestaat_uit_buurten_id",
         "ggwgebieden_identificatie",

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -51,6 +51,7 @@ def test_ndjson_import_nm_compound_keys(here, engine, ggwgebieden_schema, dbsess
     assert len(records) == 3
     # Also the temporal fields are present in the database
     columns = {
+        "id",
         "ggwgebieden_id",
         "bestaatuitbuurten_id",
         "ggwgebieden_volgnummer",
@@ -79,6 +80,7 @@ def test_ndjson_import_nm_compound_keys_with_geldigheid(here, engine, gebieden_s
     assert len(records) == 3
     # Also the temporal fields are present in the database
     columns = {
+        "id",
         "ggwgebieden_id",
         "bestaat_uit_buurten_id",
         "ggwgebieden_volgnummer",
@@ -90,6 +92,7 @@ def test_ndjson_import_nm_compound_keys_with_geldigheid(here, engine, gebieden_s
     }
 
     assert records[0] == {
+        "id": "03630950000000.1.03630023753960.1",
         "ggwgebieden_id": "03630950000000.1",
         "bestaat_uit_buurten_id": "03630023753960.1",
         "ggwgebieden_identificatie": "03630950000000",
@@ -125,6 +128,7 @@ def test_ndjson_import_nm_compound_selfreferencing_keys(
     assert len(records) == 1
     assert sorted((n, v) for n, v in records[0].items()) == (
         [
+            ("id", "KAD.001.1.KAD.002.1"),
             ("is_ontstaan_uit_kadastraalobject_id", "KAD.002.1"),
             ("is_ontstaan_uit_kadastraalobject_identificatie", "KAD.002"),
             ("is_ontstaan_uit_kadastraalobject_volgnummer", "1"),
@@ -221,6 +225,7 @@ def test_ndjson_import_with_shortnames_in_schema(
     ]
     assert len(records) == 1
     assert records[0] == {
+        "id": "90004213.01131",
         "activiteiten_id": "90004213",
         "sbi_voor_activiteit_id": "01131",
         "sbi_voor_activiteit_sbi_activiteit_nummer": 1131,
@@ -229,6 +234,7 @@ def test_ndjson_import_with_shortnames_in_schema(
     records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten_verblijfsobjecten")]
     assert len(records) == 1
     assert records[0] == {
+        "id": "90004213.01001.1",
         "activiteiten_id": "90004213",
         "verblijfsobjecten_id": "01001.1",
         "verblijfsobjecten_identificatie": "01001",


### PR DESCRIPTION
The temporal fields for "geldigheid" need to be taken from
the through table. However, to be able to query for these fields
in DSO API, this through table needs to have a non-compound primary key.

This PR adds such a PK field and adjusts the imports to give this
PK field the value of the concatenation of both sides of the relation.