### PR TITLE
Make the `id` column for through table a PK

### DIFF
--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -448,10 +448,7 @@ def table_factory(
 
                     # We need a 'through' table for the n-m relation
                     sub_columns = [
-                        Column(
-                            "id",
-                            Text,
-                        ),
+                        Column("id", Text, primary_key=True),
                         Column(
                             f"{dataset_table_name}_id",
                             String,


### PR DESCRIPTION
An extra singular `id` field has been added as PK to the through tables. For efficiency, an index need