### PR TITLE
Fix: check max ident length for indices.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.22.1"
+current = "0.22.2"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.22.1
+version = 0.22.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -613,9 +613,10 @@ def index_factory(
                     logger.log_error(f"{e.__str__} on {dataset_table.id}.{identifier_column}")
                     continue
 
-        indexes_to_create.append(
-            Index(f"{db_table_name}_identifier_idx", *identifier_column_snaked)
-        )
+        index_name = f"{db_table_name}_identifier_idx"
+        if len(index_name) > MAX_TABLE_NAME_LENGTH:
+            index_name = make_hash_value(index_name)
+        indexes_to_create.append(Index(index_name, *identifier_column_snaked))
 
         # add Index objects to create
         index[db_table_name] = indexes_to_create


### PR DESCRIPTION
The check was done for foreign keys, but not for indices. This corrects
that.