### PR TITLE
AB#17588 Datasets with table refs load from file

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -6,6 +6,7 @@ from collections import UserDict
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import cached_property, total_ordering
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -92,9 +93,15 @@ class DatasetSchema(SchemaType):
 
     @classmethod
     def from_file(cls, filename: str) -> DatasetSchema:
-        """Open an Amsterdam schema from a file."""
+        """Open an Amsterdam schema from a file and any table files referenced therein"""
         with open(filename) as fh:
-            return cls.from_dict(json.load(fh))
+            ds = json.load(fh)
+
+            for i, table in enumerate(ds["tables"]):
+                if ref := table.get("$ref"):
+                    with open(Path(filename).parent / Path(ref + ".json")) as table_file:
+                        ds["tables"][i] = json.load(table_file)
+        return cls.from_dict(ds)
 
     @classmethod
     def from_dict(cls, obj: Json) -> DatasetSchema:

--- a/tests/files/gebieden_sep_tables/bouwblokken/v1.0.0.json
+++ b/tests/files/gebieden_sep_tables/bouwblokken/v1.0.0.json
@@ -1,0 +1,47 @@
+{
+    "id": "bouwblokken",
+    "mainGeometry": "geometrie",
+    "type": "table",
+    "version": "1.0.0",
+    "temporal": {
+      "identifier": "volgnummer",
+      "dimensions": {
+        "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+      }
+    },
+    "schema": {
+      "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false,
+      "identifier": ["id"],
+      "required": ["schema", "id"],
+      "display": "id",
+      "properties": {
+        "schema": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unieke identificatie voor dit object, inclusief volgnummer"
+        },
+        "beginGeldigheid": {
+          "type": "string",
+          "format": "date",
+          "description": "De datum waarop het object is gecreëerd."
+        },
+        "eindGeldigheid": {
+          "type": "string",
+          "format": "date",
+          "description": "De datum waarop het object is komen te vervallen.",
+          "provenance": "eindgeldigheid"
+        },
+        "ligtInBuurt": {
+          "type": "string",
+          "relation": "gebieden:buurten",
+          "provenance": "ligtinbuurt",
+          "description": "De buurt waar het bouwblok in ligt."
+        }
+      }
+    }
+  }

--- a/tests/files/gebieden_sep_tables/buurten/v1.0.0.json
+++ b/tests/files/gebieden_sep_tables/buurten/v1.0.0.json
@@ -1,0 +1,40 @@
+{
+    "id": "buurten",
+    "type": "table",
+    "schema": {
+      "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false,
+      "mainGeometry": "primaireGeometrie",
+      "identifier": "identificatie",
+      "required": ["schema", "identificatie", "volgnummer"],
+      "display": "id",
+      "properties": {
+        "schema": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        },
+        "registratiedatum": {
+          "type": "string",
+          "format": "date-time",
+          "description": "De datum waarop de toestand is geregistreerd."
+        },
+        "identificatie": {
+          "type": "string",
+          "description": "Unieke identificatie van het object."
+        },
+        "naam": {
+          "type": "string",
+          "description": "De naam van het object."
+        },
+        "code": {
+          "type": "string",
+          "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+        },
+        "primaireGeometrie": {
+          "$ref": "https://geojson.org/schema/Geometry.json",
+          "description": "Geometrische beschrijving van een object."
+        }
+      }
+    }
+}

--- a/tests/files/gebieden_sep_tables/dataset.json
+++ b/tests/files/gebieden_sep_tables/dataset.json
@@ -1,0 +1,18 @@
+{
+  "type": "dataset",
+  "id": "gebieden",
+  "title": "dataset met losse tabellen",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "$ref": "bouwblokken/v1.0.0",
+      "id": "bouwblokken"
+  },
+    {
+      "$ref": "buurten/v1.0.0",
+      "id": "buurten"
+  }
+  ]
+}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -34,6 +34,14 @@ def test_geo_and_id_when_not_configured(here):
     assert id_field.is_primary
 
 
+def test_import_dataset_separate_table_files(here):
+    """Prove that datasets with tables in separate files are created correctly."""
+    schema = DatasetSchema.from_file(here / "files" / "gebieden_sep_tables" / "dataset.json")
+    assert len(schema.tables) == 2
+    table = schema.get_table_by_id("buurten")
+    assert table.main_geometry == "primaireGeometrie"
+
+
 def test_profile_schema(brp_r_profile_schema):
     """Prove that the profile files are properly read,
     and have their fields access the JSON data.


### PR DESCRIPTION
Bugfix Datasets with tables in separate files (table references)
load correctly when read from a local file.

Dit zorgt dat `schema validate` op lokale datasets met losse tabellen werkt.