### PR TITLE
AB#9078 Only reference tables from datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "0.23.2"
+current = "0.23.3"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 0.23.2
+version = 0.23.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -96,10 +96,11 @@ class DatasetSchema(SchemaType):
         with open(filename) as fh:
             ds = json.load(fh)
 
-            for i, table in enumerate(ds["tables"]):
-                if ref := table.get("$ref"):
-                    with open(Path(filename).parent / Path(ref + ".json")) as table_file:
-                        ds["tables"][i] = json.load(table_file)
+            if ds["type"] == "dataset":
+                for i, table in enumerate(ds["tables"]):
+                    if ref := table.get("$ref"):
+                        with open(Path(filename).parent / Path(ref + ".json")) as table_file:
+                            ds["tables"][i] = json.load(table_file)
         return cls.from_dict(ds)
 
     @classmethod

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -91,10 +91,13 @@ class DatasetSchema(SchemaType):
         return f"<{self.__class__.__name__}: {self['id']}>"
 
     @classmethod
-    def from_file(cls, filename: str) -> DatasetSchema:
+    def from_file(cls, filename: Union[Path, str]) -> DatasetSchema:
         """Open an Amsterdam schema from a file and any table files referenced therein"""
         with open(filename) as fh:
-            ds = json.load(fh)
+            try:
+                ds = json.load(fh)
+            except Exception as exc:
+                raise ValueError("Invalid Amsterdam Dataset schema file") from exc
 
             if ds["type"] == "dataset":
                 for i, table in enumerate(ds["tables"]):
@@ -107,7 +110,7 @@ class DatasetSchema(SchemaType):
     def from_dict(cls, obj: Json) -> DatasetSchema:
         """Parses given dict and validates the given schema"""
         if obj.get("type") != "dataset" or not isinstance(obj.get("tables"), list):
-            raise ValueError("Invalid Amsterdam Schema file")
+            raise ValueError("Invalid Amsterdam Dataset schema file")
 
         return cls(obj)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ HERE = Path(__file__).parent
 
 
 @pytest.fixture()
-def here():
+def here() -> Path:
     return HERE
 
 

--- a/tests/files/not_a_json_file.txt
+++ b/tests/files/not_a_json_file.txt
@@ -1,0 +1,1 @@
+I am not a JSON file.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from schematools.types import DatasetSchema, Permission, PermissionLevel
 
 
@@ -40,6 +44,21 @@ def test_import_dataset_separate_table_files(here):
     assert len(schema.tables) == 2
     table = schema.get_table_by_id("buurten")
     assert table.main_geometry == "primaireGeometrie"
+
+
+def test_datasetschema_from_file_not_a_dataset(here: Path) -> None:
+    """Ensure a proper exception is raised when loading a file that's not a DatasetSchema."""
+
+    error_msg = "Invalid Amsterdam Dataset schema file"
+    with pytest.raises(ValueError, match=error_msg):
+        # v1.0.0.json is a DatasetRow, not a DatasetSchema.
+        DatasetSchema.from_file(
+            here / "files" / "gebieden_sep_tables" / "bouwblokken" / "v1.0.0.json"
+        )
+
+    with pytest.raises(ValueError, match=error_msg):
+        # not_a_json_file.txt is not a JSON file. We should still get our ValueError.
+        DatasetSchema.from_file(here / "files" / "not_a_json_file.txt")
 
 
 def test_profile_schema(brp_r_profile_schema):


### PR DESCRIPTION
Now that we are splitting out tables from datasets into separate JSON
files, we can't assume anymore that every JSON file is a dataset. Hence
dataset specific operations should verify they are actually dealing with
a dataset first.