### PR TITLE
Hide the reverse relation for unmentioned M2M relations

### DIFF
--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -549,7 +549,9 @@ class LooseRelationManyToManyField(models.ManyToManyField):
             return None
 
 
-def get_field_schema(model_field: models.Field) -> DatasetFieldSchema:
+def get_field_schema(
+    model_field: Union[models.Field, models.ForeignObjectRel]
+) -> DatasetFieldSchema:
     """Provide access to the underlying amsterdam schema field that created the model field."""
     if isinstance(model_field, models.ForeignObjectRel):
         # created by 'related_name' setting

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections import UserDict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -618,6 +619,22 @@ class DatasetTableSchema(SchemaType):
     @property
     def has_parent_table(self) -> bool:
         return "parentTableID" in self
+
+    @property
+    def filters(self):
+        warnings.warn(
+            "Using DatasetTableSchema.filters is deprecated, use additional_filters instead.",
+            DeprecationWarning,
+        )
+        return dict(self["schema"].get("additionalFilters", {}))
+
+    @property
+    def relations(self):
+        warnings.warn(
+            "Using DatasetTableSchema.relations is deprecated, use additional_relations instead.",
+            DeprecationWarning,
+        )
+        return dict(self["schema"].get("additionalRelations", {}))
 
     @property
     def additional_filters(self) -> Dict[str, Dict[str, str]]:


### PR DESCRIPTION
Also rewrote how additional_relations is parsed and used for reverse relations

Relations can be resolved now thanks to the DatasetCollection. This removes the need for parsing code that resolves relations, as the schema types can now provide this information:

* Added `field.related_table`
* Added `field.reverse_relation`
* Added `table.get_reverse_relation()`
* Replaced `table.relations` -> `table.additional_relations` which returns a Python object instead of raw schema dict data.