### PR TITLE
AD#21442 Bugfix profile with dataset wide permission works

### DIFF
--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -211,11 +211,12 @@ class UserScopes:
             # If a profile defines "read" on the whole dataset, without explicitly
             # mentioning a table, this means the table can also be read unconditionally.
             profile_table = profile_dataset.tables.get(table_id, None)
-            if profile_table is None and (dataset_permission := profile_dataset.permissions):
-                permissions.append(dataset_permission)
+            if profile_table is None:
+                if dataset_permission := profile_dataset.permissions:
+                    permissions.append(dataset_permission)
 
             # Otherwise see if the table can be included (mandatory filters match)
-            if self._may_include_profile_table(profile_table):
+            elif self._may_include_profile_table(profile_table):
                 permissions.append(profile_table.permissions)
 
         # Datasets may a permission that also covers this table,


### PR DESCRIPTION
If a profileschema gives dataset wide permissions and no table-level
permissions a 500 was returned because of a logic error.