### PR TITLE
Fix bug in missing dataset at cache miss

### DIFF
--- a/src/schematools/datasetcollection.py
+++ b/src/schematools/datasetcollection.py
@@ -53,3 +53,4 @@ class DatasetCollection(metaclass=Singleton):
             if dataset is None:
                 raise ValueError(f"Dataset {dataset_id} is missing.") from None
             self.add_dataset(dataset)
+            return dataset


### PR DESCRIPTION
At a cache miss when trying to load a dataset from DatasetCollection,
the freshly loaded missing dataset was not returned.