### PR TITLE
AB#22411 Remove "type" from datasets and tables

### DIFF
--- a/AUTH_PROFILES.md
+++ b/AUTH_PROFILES.md
@@ -11,7 +11,6 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Dataset Level Authorization:
 
     {
-      "type": "dataset",
       "id": "brp",
       ...
       "auth": "BRP/R"
@@ -22,13 +21,11 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Table Level Authorization:
 
     {
-      "type": "dataset",
       "id": "brp",
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
-          "type": "table",
           "auth": "BRP/R",
           "schema": {
             ...
@@ -40,13 +37,11 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Field Level Authorization:
 
     {
-      "type": "dataset",
       "id": "brp",
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
-          "type": "table",
           "schema": {
             ...,
             "properties": {
@@ -136,14 +131,12 @@ Representations will be merged in favour of highest as well. Given 2 profiles wi
 
     # dataset configuration
     {
-      "type": "dataset",
       "id": "brp",
       "auth": "BRP/R"
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
-          "type": "table",
           "schema": {
             ...,
             "properties": {

--- a/src/schematools/introspect/utils.py
+++ b/src/schematools/introspect/utils.py
@@ -1,5 +1,4 @@
 DATASET_TMPL = {
-    "type": "dataset",
     "id": None,
     "title": None,
     "status": "beschikbaar",
@@ -13,7 +12,6 @@ DATASET_TMPL = {
 # by purely inspecting the postgresql db.
 TABLE_TMPL = {
     "id": None,
-    "type": "table",
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -50,10 +50,6 @@ class SchemaType(UserDict):
     def id(self) -> str:
         return cast(str, self["id"])
 
-    @property
-    def type(self) -> str:
-        return cast(str, self["type"])
-
     def json(self) -> str:
         return json.dumps(self.data)
 
@@ -100,17 +96,16 @@ class DatasetSchema(SchemaType):
             except Exception as exc:
                 raise ValueError("Invalid Amsterdam Dataset schema file") from exc
 
-            if ds["type"] == "dataset":
-                for i, table in enumerate(ds["tables"]):
-                    if ref := table.get("$ref"):
-                        with open(Path(filename).parent / Path(ref + ".json")) as table_file:
-                            ds["tables"][i] = json.load(table_file)
+            for i, table in enumerate(ds.get("tables", ())):
+                if ref := table.get("$ref"):
+                    with open(Path(filename).parent / Path(ref + ".json")) as table_file:
+                        ds["tables"][i] = json.load(table_file)
         return cls.from_dict(ds)
 
     @classmethod
     def from_dict(cls, obj: Json) -> DatasetSchema:
         """Parses given dict and validates the given schema"""
-        if obj.get("type") != "dataset" or not isinstance(obj.get("tables"), list):
+        if not isinstance(obj.get("tables"), list):
             raise ValueError("Invalid Amsterdam Dataset schema file")
 
         return cls(obj)
@@ -227,7 +222,6 @@ class DatasetSchema(SchemaType):
             "id": sub_table_id,
             "originalID": field.name,
             "parentTableID": table.id,
-            "type": "table",
             "auth": list(field.auth | table.auth),  # pass same auth rules as field has
             "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -327,7 +321,6 @@ class DatasetSchema(SchemaType):
 
         sub_table_schema: Json = {
             "id": table_id,
-            "type": "table",
             "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object",
@@ -452,9 +445,6 @@ class DatasetTableSchema(SchemaType):
         self._parent_schema = _parent_schema
         self.nested_table = nested_table
         self.through_table = through_table
-
-        if self.get("type") != "table":
-            raise ValueError("Invalid Amsterdam schema table data")
 
         if not self["schema"].get("$schema", "").startswith("http://json-schema.org/"):
             raise ValueError("Invalid JSON-schema contents of table")

--- a/tests/files/afval.json
+++ b/tests/files/afval.json
@@ -1,13 +1,11 @@
 {
   "id": "afvalwegingen",
-  "type": "dataset",
   "title": "Afvalwegingen",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
       "id": "containers",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -55,7 +53,6 @@
     },
     {
       "id": "clusters",
-      "type": "table",
       "auth": "BAG/R",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/afvalwegingen.json
+++ b/tests/files/afvalwegingen.json
@@ -1,6 +1,5 @@
 {
   "id": "afvalwegingen",
-  "type": "dataset",
   "status": "beschikbaar",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
   "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
@@ -21,7 +20,6 @@
   "tables": [
     {
       "id": "containers",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -105,7 +103,6 @@
     },
     {
       "id": "clusters",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -161,7 +158,6 @@
     },
     {
       "id": "wegingen",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -240,7 +236,6 @@
     },
     {
       "id": "containertypes",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/afvalwegingen_clusters-table.json
+++ b/tests/files/afvalwegingen_clusters-table.json
@@ -1,6 +1,5 @@
 {
   "id": "clusters",
-  "type": "table",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/tests/files/afvalwegingen_sep_table.json
+++ b/tests/files/afvalwegingen_sep_table.json
@@ -1,6 +1,5 @@
 {
     "id": "afvalwegingen",
-    "type": "dataset",
     "status": "beschikbaar",
     "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
     "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
@@ -21,7 +20,6 @@
     "tables": [
       {
         "id": "containers",
-        "type": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",
@@ -109,7 +107,6 @@
       },
       {
         "id": "wegingen",
-        "type": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",
@@ -188,7 +185,6 @@
       },
       {
         "id": "containertypes",
-        "type": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",

--- a/tests/files/bouwblokken.json
+++ b/tests/files/bouwblokken.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -10,7 +9,6 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -55,7 +53,6 @@
     },
     {
       "id": "buurten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/brk.json
+++ b/tests/files/brk.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
@@ -10,7 +9,6 @@
   "tables": [
     {
       "id": "kadastraleobjecten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -193,7 +191,6 @@
     },
     {
       "id": "zakelijkerechten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -298,7 +295,6 @@
     },
     {
       "id": "kadastralesubjecten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesubjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -593,7 +589,6 @@
     },
     {
       "id": "tenaamstellingen",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -707,7 +702,6 @@
     },
     {
       "id": "aantekeningenrechten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenrechten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -780,7 +774,6 @@
     },
     {
       "id": "aantekeningenkadastraleobjecten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -882,7 +875,6 @@
     },
     {
       "id": "stukdelen",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/stukdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1016,7 +1008,6 @@
     },
     {
       "id": "aardzakelijkerechten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aardzakelijkerechten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1060,7 +1051,6 @@
     },
     {
       "id": "gemeentes",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/gemeentes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1101,7 +1091,6 @@
     },
     {
       "id": "meta",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/meta.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1128,7 +1117,6 @@
     },
     {
       "id": "kadastralesecties",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesecties.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1169,7 +1157,6 @@
     },
     {
       "id": "kadastralegemeentecodes",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentecodes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1206,7 +1193,6 @@
     },
     {
       "id": "kadastralegemeentes",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/brp.json
+++ b/tests/files/brp.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "brp",
   "title": "Basisregistratie Personen (BRP)",
   "status": "beschikbaar",
@@ -10,7 +9,6 @@
   "tables": [
     {
       "id": "ingeschrevenpersonen",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/gebieden.json
+++ b/tests/files/gebieden.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "bouwblokken",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -86,7 +84,6 @@
     },
     {
       "id": "buurten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -172,7 +169,6 @@
     },
     {
       "id": "wijken",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -258,7 +254,6 @@
     },
     {
       "id": "stadsdelen",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -332,7 +327,6 @@
     },
     {
       "id": "ggwgebieden",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_auth.json
+++ b/tests/files/gebieden_auth.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "auth": "LEVEL/A",
@@ -10,7 +9,6 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
-      "type": "table",
       "auth": "LEVEL/B",
       "temporal": {
         "identifier": "volgnummer",
@@ -57,7 +55,6 @@
     },
     {
       "id": "buurten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -143,7 +140,6 @@
     },
     {
       "id": "wijken",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_auth_list.json
+++ b/tests/files/gebieden_auth_list.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "auth": ["LEVEL/A1", "LEVEL/A2"],
@@ -10,7 +9,6 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
-      "type": "table",
       "auth": ["LEVEL/B1", "LEVEL/B2"],
       "temporal": {
         "identifier": "volgnummer",
@@ -57,7 +55,6 @@
     },
     {
       "id": "buurten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -143,7 +140,6 @@
     },
     {
       "id": "wijken",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_sep_tables/dataset.json
+++ b/tests/files/gebieden_sep_tables/dataset.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "dataset met losse tabellen",
   "status": "beschikbaar",

--- a/tests/files/ggwgebieden.json
+++ b/tests/files/ggwgebieden.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "buurten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -95,7 +93,6 @@
     },
     {
       "id": "wijken",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -142,7 +139,6 @@
     },
     {
       "id": "ggwgebieden",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -231,7 +227,6 @@
     },
     {
       "id": "stadsdelen",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/hr.json
+++ b/tests/files/hr.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "hr",
   "title": "hr",
   "status": "beschikbaar",
@@ -10,7 +9,6 @@
     {
       "id": "maatschappelijkeactiviteiten",
       "shortname": "activiteiten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/hr/maatschappelijke_activiteiten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -105,7 +103,6 @@
     },
     {
       "id": "sbiactiviteiten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/hr/sbiactiviteiten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/identifier_ref.json
+++ b/tests/files/identifier_ref.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "validationTest",
   "title": "PsqlIdentifierLengthValidator Validation Test",
   "status": "beschikbaar",
@@ -10,7 +9,6 @@
     {
       "id": "someTable",
       "title": "Some title",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/tests/identifier_ref.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/kadastraleobjecten.json
+++ b/tests/files/kadastraleobjecten.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
@@ -10,7 +9,6 @@
   "tables": [
     {
       "id": "kadastraleobjecten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/long_ids.json
+++ b/tests/files/long_ids.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "validationTest",
   "title": "PsqlIdentifierLengthValidator Validation Test",
   "status": "beschikbaar",
@@ -10,7 +9,6 @@
     {
       "id": "AnAbsurdlyLongIdentifierThatShouldDefinitelyTriggerPsqlIdentifierLengthValidator",
       "title": "Some title",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/tests/long_ids.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/meetbouten.json
+++ b/tests/files/meetbouten.json
@@ -1,6 +1,5 @@
 {
   "id": "meetbouten",
-  "type": "dataset",
   "status": "beschikbaar",
   "version": "2.0.0",
   "default_version": "2.0.0",
@@ -8,7 +7,6 @@
   "tables": [
     {
       "id": "meetbouten",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -55,7 +53,6 @@
     },
     {
       "id": "metingen",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/meetbouten/metingen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -95,7 +92,6 @@
     },
     {
       "id": "referentiepunten",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/meetbouten/referentiepunten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/meldingen.json
+++ b/tests/files/meldingen.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "meldingen",
   "title": "Meldingen",
   "status": "beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "statistieken",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/multirelation.json
+++ b/tests/files/multirelation.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "base",
   "title": "Base schema",
   "status": "niet_beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "hasrelations",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/parkeervakken.json
+++ b/tests/files/parkeervakken.json
@@ -1,6 +1,5 @@
 {
   "id": "parkeervakken",
-  "type": "dataset",
   "status": "beschikbaar",
   "title": "",
   "version": "0.0.1",
@@ -8,7 +7,6 @@
   "tables": [
     {
       "id": "parkeervakken",
-      "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/stadsdelen.json
+++ b/tests/files/stadsdelen.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -9,7 +8,6 @@
     {
       "id": "stadsdelen",
       "mainGeometry": "geometrie",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/verblijfsobjecten.json
+++ b/tests/files/verblijfsobjecten.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "baggob",
   "title": "bag",
   "status": "niet_beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "verblijfsobjecten",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/woningbouwplannen.json
+++ b/tests/files/woningbouwplannen.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "woningbouwplannen",
   "title": "Woningbouwplannen en Strategische ruimtes",
   "description": "Deze dataset bevat de gegevens over de te realiseren woningen in Amsterdam.",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "woningbouwplan",
-      "type": "table",
       "provenance": "wbw_woningbouwplan",
       "title": "Woningbouwplan",
       "description": "De aantallen vormen de planvoorraad. Dit zijn niet de aantallen die definitief worden gerealiseerd. Ervaring leert dat een deel van de planvoorraad wordt opgeschoven. Niet alle woningbouw initiatieven doorlopen de verschillende plaberumfasen. Met name kleinere particuliere projecten worden in de regel pas toegevoegd aan de monitor zodra er een intentieovereenkomst of afsprakenbrief is getekend.",

--- a/tests/files/woonplaatsen.json
+++ b/tests/files/woonplaatsen.json
@@ -1,5 +1,4 @@
 {
-  "type": "dataset",
   "id": "baggob",
   "title": "bag",
   "status": "niet_beschikbaar",
@@ -9,7 +8,6 @@
   "tables": [
     {
       "id": "woonplaatsen",
-      "type": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -52,7 +50,6 @@
     },
     {
       "id": "dossiers",
-      "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/dossiers.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -47,7 +47,6 @@ def test_geojson_to_table():
     assert result == [
         {
             "id": "unittest_relation",  # @id field was parsed as "relation"
-            "type": "table",
             "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object",


### PR DESCRIPTION
JSON Schema does not allow "type" with custom types, only JSON types and
"integer". Updates to amsterdam-schema to follow.