### PR TITLE
AB#22411 reinstate "type" as "schematype"

### DIFF
--- a/AUTH_PROFILES.md
+++ b/AUTH_PROFILES.md
@@ -11,6 +11,7 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Dataset Level Authorization:
 
     {
+      "schemaType": "dataset",
       "id": "brp",
       ...
       "auth": "BRP/R"
@@ -21,11 +22,13 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Table Level Authorization:
 
     {
+      "schemaType": "dataset",
       "id": "brp",
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
+          "schemaType": "table",
           "auth": "BRP/R",
           "schema": {
             ...
@@ -37,11 +40,13 @@ This is done via `auth` parameter on each level respectively.
 ### Example of Field Level Authorization:
 
     {
+      "schemaType": "dataset",
       "id": "brp",
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
+          "schemaType": "table",
           "schema": {
             ...,
             "properties": {
@@ -131,12 +136,14 @@ Representations will be merged in favour of highest as well. Given 2 profiles wi
 
     # dataset configuration
     {
+      "schemaType": "dataset",
       "id": "brp",
       "auth": "BRP/R"
       ...
       "tables": [
         {
           "id": "ingeschrevenpersonen",
+          "schemaType": "table",
           "schema": {
             ...,
             "properties": {

--- a/src/schematools/introspect/utils.py
+++ b/src/schematools/introspect/utils.py
@@ -1,4 +1,5 @@
 DATASET_TMPL = {
+    "schemaType": "dataset",
     "id": None,
     "title": None,
     "status": "beschikbaar",
@@ -12,6 +13,7 @@ DATASET_TMPL = {
 # by purely inspecting the postgresql db.
 TABLE_TMPL = {
     "id": None,
+    "schemaType": "table",
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/afval.json
+++ b/tests/files/afval.json
@@ -1,11 +1,13 @@
 {
   "id": "afvalwegingen",
+  "schemaType": "dataset",
   "title": "Afvalwegingen",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
       "id": "containers",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -53,6 +55,7 @@
     },
     {
       "id": "clusters",
+      "schemaType": "table",
       "auth": "BAG/R",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/afvalwegingen.json
+++ b/tests/files/afvalwegingen.json
@@ -1,5 +1,6 @@
 {
   "id": "afvalwegingen",
+  "schemaType": "dataset",
   "status": "beschikbaar",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
   "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
@@ -20,6 +21,7 @@
   "tables": [
     {
       "id": "containers",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -103,6 +105,7 @@
     },
     {
       "id": "clusters",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -158,6 +161,7 @@
     },
     {
       "id": "wegingen",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -236,6 +240,7 @@
     },
     {
       "id": "containertypes",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/afvalwegingen_clusters-table.json
+++ b/tests/files/afvalwegingen_clusters-table.json
@@ -1,5 +1,6 @@
 {
   "id": "clusters",
+  "schemaType": "table",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/tests/files/afvalwegingen_sep_table.json
+++ b/tests/files/afvalwegingen_sep_table.json
@@ -1,5 +1,6 @@
 {
     "id": "afvalwegingen",
+    "schemaType": "dataset",
     "status": "beschikbaar",
     "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
     "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
@@ -20,6 +21,7 @@
     "tables": [
       {
         "id": "containers",
+        "schemaType": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",
@@ -107,6 +109,7 @@
       },
       {
         "id": "wegingen",
+        "schemaType": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",
@@ -185,6 +188,7 @@
       },
       {
         "id": "containertypes",
+        "schemaType": "table",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",

--- a/tests/files/bouwblokken.json
+++ b/tests/files/bouwblokken.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -9,6 +10,7 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -53,6 +55,7 @@
     },
     {
       "id": "buurten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/brk.json
+++ b/tests/files/brk.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
@@ -9,6 +10,7 @@
   "tables": [
     {
       "id": "kadastraleobjecten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -191,6 +193,7 @@
     },
     {
       "id": "zakelijkerechten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -295,6 +298,7 @@
     },
     {
       "id": "kadastralesubjecten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesubjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -589,6 +593,7 @@
     },
     {
       "id": "tenaamstellingen",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -702,6 +707,7 @@
     },
     {
       "id": "aantekeningenrechten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenrechten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -774,6 +780,7 @@
     },
     {
       "id": "aantekeningenkadastraleobjecten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -875,6 +882,7 @@
     },
     {
       "id": "stukdelen",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/stukdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1008,6 +1016,7 @@
     },
     {
       "id": "aardzakelijkerechten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aardzakelijkerechten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1051,6 +1060,7 @@
     },
     {
       "id": "gemeentes",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/gemeentes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1091,6 +1101,7 @@
     },
     {
       "id": "meta",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/meta.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1117,6 +1128,7 @@
     },
     {
       "id": "kadastralesecties",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralesecties.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1157,6 +1169,7 @@
     },
     {
       "id": "kadastralegemeentecodes",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentecodes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1193,6 +1206,7 @@
     },
     {
       "id": "kadastralegemeentes",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastralegemeentes.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/brp.json
+++ b/tests/files/brp.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "brp",
   "title": "Basisregistratie Personen (BRP)",
   "status": "beschikbaar",
@@ -9,6 +10,7 @@
   "tables": [
     {
       "id": "ingeschrevenpersonen",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/gebieden.json
+++ b/tests/files/gebieden.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "bouwblokken",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -84,6 +86,7 @@
     },
     {
       "id": "buurten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -169,6 +172,7 @@
     },
     {
       "id": "wijken",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -254,6 +258,7 @@
     },
     {
       "id": "stadsdelen",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -327,6 +332,7 @@
     },
     {
       "id": "ggwgebieden",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_auth.json
+++ b/tests/files/gebieden_auth.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "auth": "LEVEL/A",
@@ -9,6 +10,7 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
+      "schemaType": "table",
       "auth": "LEVEL/B",
       "temporal": {
         "identifier": "volgnummer",
@@ -55,6 +57,7 @@
     },
     {
       "id": "buurten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -140,6 +143,7 @@
     },
     {
       "id": "wijken",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_auth_list.json
+++ b/tests/files/gebieden_auth_list.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "auth": ["LEVEL/A1", "LEVEL/A2"],
@@ -9,6 +10,7 @@
     {
       "id": "bouwblokken",
       "mainGeometry": "geometrie",
+      "schemaType": "table",
       "auth": ["LEVEL/B1", "LEVEL/B2"],
       "temporal": {
         "identifier": "volgnummer",
@@ -55,6 +57,7 @@
     },
     {
       "id": "buurten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -140,6 +143,7 @@
     },
     {
       "id": "wijken",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/gebieden_sep_tables/dataset.json
+++ b/tests/files/gebieden_sep_tables/dataset.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "dataset met losse tabellen",
   "status": "beschikbaar",

--- a/tests/files/ggwgebieden.json
+++ b/tests/files/ggwgebieden.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "buurten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -93,6 +95,7 @@
     },
     {
       "id": "wijken",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -139,6 +142,7 @@
     },
     {
       "id": "ggwgebieden",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -227,6 +231,7 @@
     },
     {
       "id": "stadsdelen",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/hr.json
+++ b/tests/files/hr.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "hr",
   "title": "hr",
   "status": "beschikbaar",
@@ -9,6 +10,7 @@
     {
       "id": "maatschappelijkeactiviteiten",
       "shortname": "activiteiten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/hr/maatschappelijke_activiteiten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -103,6 +105,7 @@
     },
     {
       "id": "sbiactiviteiten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/hr/sbiactiviteiten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/identifier_ref.json
+++ b/tests/files/identifier_ref.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "validationTest",
   "title": "PsqlIdentifierLengthValidator Validation Test",
   "status": "beschikbaar",
@@ -9,6 +10,7 @@
     {
       "id": "someTable",
       "title": "Some title",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/tests/identifier_ref.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/kadastraleobjecten.json
+++ b/tests/files/kadastraleobjecten.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
@@ -9,6 +10,7 @@
   "tables": [
     {
       "id": "kadastraleobjecten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/long_ids.json
+++ b/tests/files/long_ids.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "validationTest",
   "title": "PsqlIdentifierLengthValidator Validation Test",
   "status": "beschikbaar",
@@ -9,6 +10,7 @@
     {
       "id": "AnAbsurdlyLongIdentifierThatShouldDefinitelyTriggerPsqlIdentifierLengthValidator",
       "title": "Some title",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/tests/long_ids.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/meetbouten.json
+++ b/tests/files/meetbouten.json
@@ -1,5 +1,6 @@
 {
   "id": "meetbouten",
+  "schemaType": "dataset",
   "status": "beschikbaar",
   "version": "2.0.0",
   "default_version": "2.0.0",
@@ -7,6 +8,7 @@
   "tables": [
     {
       "id": "meetbouten",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -53,6 +55,7 @@
     },
     {
       "id": "metingen",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/meetbouten/metingen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -92,6 +95,7 @@
     },
     {
       "id": "referentiepunten",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/meetbouten/referentiepunten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/meldingen.json
+++ b/tests/files/meldingen.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "meldingen",
   "title": "Meldingen",
   "status": "beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "statistieken",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/multirelation.json
+++ b/tests/files/multirelation.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "base",
   "title": "Base schema",
   "status": "niet_beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "hasrelations",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/parkeervakken.json
+++ b/tests/files/parkeervakken.json
@@ -1,5 +1,6 @@
 {
   "id": "parkeervakken",
+  "schemaType": "dataset",
   "status": "beschikbaar",
   "title": "",
   "version": "0.0.1",
@@ -7,6 +8,7 @@
   "tables": [
     {
       "id": "parkeervakken",
+      "schemaType": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/tests/files/stadsdelen.json
+++ b/tests/files/stadsdelen.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
@@ -8,6 +9,7 @@
     {
       "id": "stadsdelen",
       "mainGeometry": "geometrie",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/files/verblijfsobjecten.json
+++ b/tests/files/verblijfsobjecten.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "baggob",
   "title": "bag",
   "status": "niet_beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "verblijfsobjecten",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/tests/files/woningbouwplannen.json
+++ b/tests/files/woningbouwplannen.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "woningbouwplannen",
   "title": "Woningbouwplannen en Strategische ruimtes",
   "description": "Deze dataset bevat de gegevens over de te realiseren woningen in Amsterdam.",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "woningbouwplan",
+      "schemaType": "table",
       "provenance": "wbw_woningbouwplan",
       "title": "Woningbouwplan",
       "description": "De aantallen vormen de planvoorraad. Dit zijn niet de aantallen die definitief worden gerealiseerd. Ervaring leert dat een deel van de planvoorraad wordt opgeschoven. Niet alle woningbouw initiatieven doorlopen de verschillende plaberumfasen. Met name kleinere particuliere projecten worden in de regel pas toegevoegd aan de monitor zodra er een intentieovereenkomst of afsprakenbrief is getekend.",

--- a/tests/files/woonplaatsen.json
+++ b/tests/files/woonplaatsen.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "dataset",
   "id": "baggob",
   "title": "bag",
   "status": "niet_beschikbaar",
@@ -8,6 +9,7 @@
   "tables": [
     {
       "id": "woonplaatsen",
+      "schemaType": "table",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -50,6 +52,7 @@
     },
     {
       "id": "dossiers",
+      "schemaType": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/dossiers.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -47,6 +47,7 @@ def test_geojson_to_table():
     assert result == [
         {
             "id": "unittest_relation",  # @id field was parsed as "relation"
+            "schemaType": "table",
             "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object",


### PR DESCRIPTION
This reverts commit 5371fb8961a5f8716310a3d4e6615d416517c8e2. Turns out we do need the `"type"` thingy to validate schemas against the metaschema. We just need to call it something else. The `SchemaType.type` method has been restored.