### PR TITLE
Add special case to rowclass for provenance with `id` field

### DIFF
--- a/tests/test_rowclass.py
+++ b/tests/test_rowclass.py
@@ -1,0 +1,36 @@
+from schematools.importer.base import Row
+
+
+def test_row_plain():
+    """Prove that a regular dict just work as is."""
+    row = Row({"colname1": 12, "colname2": "test"})
+    assert row["colname1"] == 12
+    assert row["colname2"] == "test"
+
+
+def test_row_with_simple_provenance():
+    """Prove that a simple provenance mapping a fieldname to another fieldname works."""
+    row = Row({"colname1": 12, "colname2": "test"}, fields_provenances={"colname1": "provColname"})
+    assert row["provColname"] == 12
+    assert row["colname2"] == "test"
+
+
+def test_row_with_jsonpath_provenance():
+    """Prove that a provenance based on json path works."""
+    row = Row(
+        {"colname1": 12, "colname2": {"sub": "test"}},
+        fields_provenances={"$.colname2.sub": "colname2"},
+    )
+    assert row["colname1"] == 12
+    assert row["colname2"] == "test"
+
+
+def test_row_with_id_special_casing():
+    """Prove that the special casing for the id field works."""
+    row = Row(
+        {"id": 12},
+        fields_provenances={"id": "neuronId"},
+    )
+    row["id"] = "012.3"
+    assert row["neuronId"] == 12
+    assert row["id"] == "012.3"


### PR DESCRIPTION
When the `id` field in incoming data is used in a provenance,
special care needs to be taken because in some situations
an `id` field is autogenerated to provide the singular PK value
that Django needs.

So, the original value needs to be retained (it would otherwise
be overwritten with the generated `id` field).

And, when asking for the provenanced field, the provenancing
mechanism should *not* to be applied.

So, in this example, the schema fragment is:

	"neuronId": {
		"type": "string",
		"provenance": "id"
	}

The incoming json contains an `id` field that need to become
available as `neuronId`.

Without precautions, the autogenerated `id`, e.g. having a value
of "012.5" would be put in the place of the `neuronId` field
and the original value would be lost.