### PR TITLE
AB#20011 Change `field.sub_fields` to not add prefixes

### DIFF
--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -147,7 +147,6 @@ class NDJSONImporter(BaseImporter):
                         row["id"] = id_value
 
                 for rel_field in relation_field_info:
-
                     relation_field_name = rel_field.name
                     # Only process relation if data is available in incoming row
                     if rel_field.id not in row:
@@ -155,7 +154,7 @@ class NDJSONImporter(BaseImporter):
                     relation_field_value = row[rel_field.id]
                     if rel_field.is_object:
                         fk_value_parts = []
-                        for sub_field in rel_field.sub_fields:
+                        for sub_field in rel_field.get_sub_fields(add_prefixes=True):
                             # Ignore temporal fields
                             if sub_field.is_temporal:
                                 continue


### PR DESCRIPTION
The implementation of `field.sub_fields` was adding prefixes
to fieldnames. These prefixes are for a special use-case,
where the `sub_fields` method is used to generate extra fields
describing the components of a compound foreign key.

However, adding these prefixes should not be the default behaviour of `sub_fields`.

This has been fixed. The property fields `sub_fields`
has now been converted into a function `get_sub_fields`
with an extra parameter `add_prefixes`.

The property `sub_fields` is still available and implements
the default use-case, generating fields without prefixes.