### PR TITLE
Decouple LooseRelationField from schema's. Pass a to_field instead.

### DIFF
--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -157,9 +157,11 @@ class LooseFKRelationMaker(RelationMaker):
 
     @property
     def field_kwargs(self):
+        target_table = self.field.related_table
         kwargs = {}
         kwargs["db_column"] = f"{to_snake_case(self.field.name)}_id"
         kwargs["relation"] = self.fk_relation
+        kwargs["to_field"] = target_table.identifier[0]  # temporal identifier
         return {**super().field_kwargs, **kwargs}
 
 
@@ -232,10 +234,6 @@ class LooseM2MRelationMaker(M2MRelationMaker):
     @property
     def field_cls(self):
         return LooseRelationManyToManyField
-
-    @property
-    def field_kwargs(self):
-        return {**super().field_kwargs, "relation": self.nm_relation}
 
 
 class FieldMaker:

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -509,15 +509,18 @@ class Profile(models.Model):
 
 
 class LooseRelationField(models.CharField):
-    def __init__(self, *args, **kwargs):
-        self.relation = kwargs.pop("relation")
+    def __init__(self, *args, relation, to_field=None, **kwargs):
         kwargs.setdefault("max_length", 254)
         super().__init__(*args, **kwargs)
+        self.relation = relation
+        self.to_field = to_field
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
         del kwargs["max_length"]
         kwargs["relation"] = self.relation
+        if self.to_field:
+            kwargs["to_field"] = self.to_field
         return name, path, args, kwargs
 
     @property
@@ -528,25 +531,7 @@ class LooseRelationField(models.CharField):
 
 
 class LooseRelationManyToManyField(models.ManyToManyField):
-    def __init__(self, *args, **kwargs):
-        self.relation = kwargs.pop("relation")
-        kwargs.setdefault("max_length", 254)
-        super().__init__(*args, **kwargs)
-
-    def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
-        del kwargs["max_length"]
-        kwargs["relation"] = self.relation
-        return name, path, args, kwargs
-
-    @property
-    def related_model(self):
-        dataset_name, table_name, *_ = [to_snake_case(part) for part in self.relation.split(":")]
-        if dataset_name in apps.all_models and table_name in apps.all_models[dataset_name]:
-            return apps.all_models[dataset_name][table_name]
-        else:
-            #  The loosely related model may not be registered yet
-            return None
+    pass
 
 
 def get_field_schema(


### PR DESCRIPTION
Sometimes I found during the fixing of temporality-listings. The loose relations M2M field doesn't really do anything loose at all. I guess the relations are created at import?

The constructor receives a 'relation' argument and 'max_length' but these are not used or don't do anything different from standard Django. The same goes for `LooseRelationManyToManyField`, which didn't do anything with the provided max_length. And the 'related_model' was not used at all either.