### PR TITLE
explicit database schema default when None

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "2.3.3"
+current = "3.0.1"
 regex = '''
   (?P<major>\d+)
   \.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "2.3.2"
+current = "2.3.3"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 2.3.2
+version = 2.3.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 2.3.3
+version = 3.0.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/__init__.py
+++ b/src/schematools/__init__.py
@@ -4,4 +4,4 @@ RELATION_INDICATOR: Final[str] = "_"
 MAX_TABLE_NAME_LENGTH: Final[int] = 63  # limitation of PostgreSQL
 TMP_TABLE_POSTFIX: Final[str] = "_new"
 TABLE_INDEX_POSTFIX: Final[str] = "_idx"
-DATABASE_SCHEMA_NAME_DEFAULT: Final[str] = "PUBLIC"
+DATABASE_SCHEMA_NAME_DEFAULT: Final[str] = "public"

--- a/src/schematools/__init__.py
+++ b/src/schematools/__init__.py
@@ -4,3 +4,4 @@ RELATION_INDICATOR: Final[str] = "_"
 MAX_TABLE_NAME_LENGTH: Final[int] = 63  # limitation of PostgreSQL
 TMP_TABLE_POSTFIX: Final[str] = "_new"
 TABLE_INDEX_POSTFIX: Final[str] = "_idx"
+DATABASE_SCHEMA_NAME_DEFAULT: Final[str] = "PUBLIC"

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -55,7 +55,11 @@ def tables_factory(
             postfix = TMP_TABLE_POSTFIX if has_postfix else None
             db_table_name = dataset_table.db_name(postfix=postfix)
 
-        db_schema_name = (db_schema_names or {}).get(dataset_table.id)
+        # If schema is None, default to Public. Leave it to None will have a risk that
+        # the DB schema that is currently in use will be used to create the table in
+        # leading to unwanted/unexepected results
+        if (db_schema_name := (db_schema_names or {}).get(dataset_table.id)) is None:
+            db_schema_name = 'public'
         columns = []
         for field in dataset_table.fields:
 

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Set
 
 from sqlalchemy import Column, MetaData, Table
 
-from schematools import TMP_TABLE_POSTFIX
+from schematools import TMP_TABLE_POSTFIX, DATABASE_SCHEMA_NAME_DEFAULT
 from schematools.importer import fetch_col_type
 from schematools.types import DatasetSchema
 from schematools.utils import to_snake_case
@@ -59,7 +59,7 @@ def tables_factory(
         # the DB schema that is currently in use will be used to create the table in
         # leading to unwanted/unexepected results
         if (db_schema_name := (db_schema_names or {}).get(dataset_table.id)) is None:
-            db_schema_name = 'public'
+            db_schema_name = DATABASE_SCHEMA_NAME_DEFAULT
         columns = []
         for field in dataset_table.fields:
 


### PR DESCRIPTION
The method tables_factory retrieves database schema if defined as a parameter when creating a database table. If schema is None, it now defaults to Public. Leave it to None will have a risk that the DB schema that is currently in use will be used to create the table in leading to unwanted/unexepected results.