### PR TITLE
Replace DatasetFieldSchema.sub_fields by subfields

### DIFF
--- a/src/schematools/events/export.py
+++ b/src/schematools/events/export.py
@@ -30,7 +30,7 @@ class ComplexFieldAttrs:
     is_many: Optional[bool] = None
     relation_ds: Optional[str] = None
     identifier_names: List[str] = field(default_factory=list)
-    sub_field_names: List[str] = field(default_factory=list)
+    subfield_names: List[str] = field(default_factory=list)
 
 
 def fetch_complex_fields_metadata(dataset_table: DatasetTableSchema) -> List[ComplexFieldAttrs]:
@@ -63,7 +63,7 @@ def fetch_complex_fields_metadata(dataset_table: DatasetTableSchema) -> List[Com
                     is_many=is_many,
                     relation_ds=relation_ds,
                     identifier_names=dataset_table.identifier,
-                    sub_field_names=[to_snake_case(sf) for sf in properties.keys()],
+                    subfield_names=[to_snake_case(sf) for sf in properties.keys()],
                 )
             )
 
@@ -90,7 +90,7 @@ def collect_nm_embed_rows(
                 )
 
                 stripped_row = {}
-                for sfn in field_metadata.sub_field_names:
+                for sfn in field_metadata.subfield_names:
                     stripped_row[sfn] = row_dict[f"{field_metadata.field_name}_{sfn}"]
                 nm_embeds[table_id][id_value].append(stripped_row)
     return dict(nm_embeds)
@@ -121,8 +121,8 @@ def fetch_1n_embeds(
     for field_metadata in complex_fields_metadata:
         if not field_metadata.is_many:
             embed_obj = {}
-            for sub_field_name in field_metadata.sub_field_names:
-                embed_obj[sub_field_name] = row[f"{field_metadata.field_name}_{sub_field_name}"]
+            for subfield_name in field_metadata.subfield_names:
+                embed_obj[subfield_name] = row[f"{field_metadata.field_name}_{subfield_name}"]
             embeddable_objs[field_metadata.field_name] = embed_obj
     return embeddable_objs
 

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -148,11 +148,11 @@ class DataSplitter:
 
             # relation fields for source side
             # XXX add support for shortnames!
-            for sub_field_schema in self.dataset_table.get_fields_by_id(
+            for subfield_schema in self.dataset_table.get_fields_by_id(
                 *self.dataset_table.identifier
             ):
-                sub_field_id = f"{self.table_id}_{sub_field_schema.id}"
-                nm_row_data[sub_field_id] = id_part_values[sub_field_schema.id]
+                subfield_id = f"{self.table_id}_{subfield_schema.id}"
+                nm_row_data[subfield_id] = id_part_values[subfield_schema.id]
 
             # relation fields for target side
             for fn, fv in row_data.items():

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -154,18 +154,18 @@ class NDJSONImporter(BaseImporter):
                     relation_field_value = row[rel_field.id]
                     if rel_field.is_object:
                         fk_value_parts = []
-                        for sub_field in rel_field.get_sub_fields(add_prefixes=True):
+                        for subfield in rel_field.get_subfields(add_prefixes=True):
                             # Ignore temporal fields
-                            if sub_field.is_temporal:
+                            if subfield.is_temporal:
                                 continue
 
-                            sub_field_id = sub_field.id.rsplit(RELATION_INDICATOR, 1)[1]
+                            subfield_id = subfield.id.rsplit(RELATION_INDICATOR, 1)[1]
                             if relation_field_value is None:
-                                sub_field_value = None
+                                subfield_value = None
                             else:
-                                sub_field_value = relation_field_value[sub_field_id]
-                                fk_value_parts.append(sub_field_value)
-                            row[sub_field.name] = sub_field_value
+                                subfield_value = relation_field_value[subfield_id]
+                                fk_value_parts.append(subfield_value)
+                            row[subfield.name] = subfield_value
                         # empty fk_value_parts should result in None value
                         relation_field_value = ".".join([str(p) for p in fk_value_parts]) or None
                     row[f"{relation_field_name}_id"] = relation_field_value
@@ -185,11 +185,11 @@ class NDJSONImporter(BaseImporter):
                         id_field_name = "id" if len(id_fields) > 1 else id_fields[0]
                         nested_row_record = {}
                         nested_row_record["parent_id"] = row[id_field_name]
-                        for sub_field in n_field.sub_fields:
-                            if sub_field.is_temporal:
+                        for subfield in n_field.subfields:
+                            if subfield.is_temporal:
                                 continue
-                            sub_field_name = to_snake_case(sub_field.name)
-                            nested_row_record[sub_field_name] = nested_row.get(sub_field.name)
+                            subfield_name = to_snake_case(subfield.name)
+                            nested_row_record[subfield_name] = nested_row.get(subfield.name)
 
                         nested_row_records.append(nested_row_record)
 
@@ -227,7 +227,7 @@ class NDJSONImporter(BaseImporter):
                             if nm_field.is_through_table:
                                 through_field_metas = [
                                     (f.id.split(RELATION_INDICATOR)[-1], f.is_temporal)
-                                    for f in nm_field.sub_fields
+                                    for f in nm_field.subfields
                                 ]
                                 to_fk = ".".join(
                                     str(value[fn])

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -447,7 +447,7 @@ class DatasetSchema(SchemaType):
 
         related_ids = []
         for table in self.tables:
-            for field in table.get_fields(include_sub_fields=False):
+            for field in table.get_fields(include_subfields=False):
                 a_relation = field.relation or field.nm_relation
                 if a_relation is not None:
                     dataset_id, table_id = a_relation.split(":")
@@ -523,11 +523,11 @@ class DatasetTableSchema(SchemaType):
         """The description of the table as stated in the schema."""
         return self.get("description")
 
-    def get_fields(self, include_sub_fields: bool = False) -> Iterator[DatasetFieldSchema]:
+    def get_fields(self, include_subfields: bool = False) -> Iterator[DatasetFieldSchema]:
         """Get the fields for this table.
 
         Args:
-            include_sub_fields: Merge the sub fields of an FK relation into the fields
+            include_subfields: Merge the subfields of an FK relation into the fields
             of this table. The ids of these fields need to be prefixed
             (usually with the `id` of the relation field) to avoid name collisions.
         """
@@ -542,12 +542,12 @@ class DatasetTableSchema(SchemaType):
             # Add extra fields for relations of type object
             # These fields are added to identify the different
             # components of a compound FK to a another table
-            if field_schema.relation is not None and field_schema.is_object and include_sub_fields:
-                for sub_field in field_schema.get_sub_fields(add_prefixes=True):
+            if field_schema.relation is not None and field_schema.is_object and include_subfields:
+                for subfield in field_schema.get_subfields(add_prefixes=True):
                     # We exclude temporal fields, they need not to be merged into the table fields
-                    if sub_field.is_temporal:
+                    if subfield.is_temporal:
                         continue
-                    yield sub_field
+                    yield subfield
             yield field_schema
 
         # If compound key, add PK field
@@ -557,7 +557,7 @@ class DatasetTableSchema(SchemaType):
 
     @cached_property
     def fields(self) -> List[DatasetFieldSchema]:
-        return list(self.get_fields(include_sub_fields=True))
+        return list(self.get_fields(include_subfields=True))
 
     @lru_cache()  # type: ignore[misc]
     def get_fields_by_id(self, *field_ids: str) -> List[DatasetFieldSchema]:
@@ -995,17 +995,17 @@ class DatasetFieldSchema(DatasetType):
         return dataset_table.temporal.dimensions
 
     @cached_property
-    def sub_fields(self) -> List[DatasetFieldSchema]:
-        """Return the sub fields for a nested structure.
+    def subfields(self) -> List[DatasetFieldSchema]:
+        """Return the subfields for a nested structure.
 
-        Calls the `get_sub_fields` method without argument,
+        Calls the `get_subfields` method without argument,
         so no prefixes are added to the field ids.
         This is the default situation.
         """
-        return list(self.get_sub_fields())
+        return list(self.get_subfields())
 
-    def get_sub_fields(self, add_prefixes=False) -> Iterator[DatasetFieldSchema]:
-        """Return the sub fields for a nested structure.
+    def get_subfields(self, add_prefixes=False) -> Iterator[DatasetFieldSchema]:
+        """Return the subfields for a nested structure.
 
         Args:
             add_prefixes: Add prefixes to the ids of the subfields.
@@ -1018,13 +1018,15 @@ class DatasetFieldSchema(DatasetType):
         those subfields need to be prefixed with the name of the relation field.
         However, this is not the case for the so-called `dimension` fields
         of a temporal relation (e.g. `beginGeldigheid` and `eindGeldigheid`).
+
+        If self is not an object or array, the return value is an empty iterator.
         """
         from schematools.utils import toCamelCase
 
         field_name_prefix = ""
 
         if self.is_object:
-            # Field has direct sub fields (type=object)
+            # Field has direct subfields (type=object)
             required = set(self.get("required", []))
             properties = self["properties"]
         elif self.is_array_of_objects and self.field_items is not None:
@@ -1032,7 +1034,7 @@ class DatasetFieldSchema(DatasetType):
             required = set(self.field_items.get("required") or ())
             properties = self.field_items["properties"]
         else:
-            raise ValueError("Subfields are only possible for 'object' or 'array' fields.")
+            return ()
 
         relation = self.relation
         nm_relation = self.nm_relation
@@ -1041,9 +1043,7 @@ class DatasetFieldSchema(DatasetType):
 
         combined_dimension_fieldnames: Set[str] = set()
         for (_dimension, field_names) in self.get_dimension_fieldnames().items():
-            combined_dimension_fieldnames |= set(
-                toCamelCase(fieldname) for fieldname in field_names
-            )
+            combined_dimension_fieldnames |= {toCamelCase(fieldname) for fieldname in field_names}
 
         for id_, spec in properties.items():
             needs_prefix = add_prefixes and id_ not in combined_dimension_fieldnames

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
+    Iterable,
     Iterator,
     List,
     NamedTuple,
@@ -523,7 +524,7 @@ class DatasetTableSchema(SchemaType):
         """The description of the table as stated in the schema."""
         return self.get("description")
 
-    def get_fields(self, include_subfields: bool = False) -> Iterator[DatasetFieldSchema]:
+    def get_fields(self, include_subfields: bool = False) -> Iterable[DatasetFieldSchema]:
         """Get the fields for this table.
 
         Args:


### PR DESCRIPTION
This is the proper spelling.

More importantly, I wanted to change the semantics of the method and property, and renaming it seemed the easiest option to break any code that relied on the old behavior and force reconsideration.

The new method and property return an empty iterator/list for an array or object instead of raising a `ValueError`. A use site in DSO-API caught the `ValueError`, but as a result also caught unrelated errors, causing a bug in production and tests successes where failures were appropriate (Amsterdam/dso-api#402). It looks like the only other call site performs a custom type check and should not be affected.