### PR TITLE
Only return surrogate pk for schemas with compound pk if schema does not define `id`

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -552,8 +552,7 @@ class DatasetTableSchema(SchemaType):
             yield field_schema
 
         # If compound key, add PK field
-        # XXX we should check for an existing "id" field, avoid collisions
-        if self.has_compound_key:
+        if self.has_compound_key and "id" not in self["schema"]["properties"]:
             yield DatasetFieldSchema(_parent_table=self, _required=True, type="string", id="id")
 
     @cached_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,6 +308,11 @@ def profile_brk_read_id_schema(here) -> ProfileSchema:
     return ProfileSchema.from_file(here / "files/profiles/BRK_RID.json")
 
 
+@pytest.fixture()
+def compound_key_schema(here) -> ProfileSchema:
+    return DatasetSchema.from_file(here / "files/compound_key.json")
+
+
 @pytest.fixture
 def profile_verkeer_medewerker_schema() -> ProfileSchema:
     return ProfileSchema.from_dict(

--- a/tests/files/compound_key.json
+++ b/tests/files/compound_key.json
@@ -17,7 +17,7 @@
         }
       },
       "schema": {
-        "$id": "https://github.com/Amsterdam/schemas/afracnswallows",
+        "$id": "https://github.com/Amsterdam/schemas/africanswallows",
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,

--- a/tests/files/compound_key.json
+++ b/tests/files/compound_key.json
@@ -1,0 +1,55 @@
+{
+  "type": "dataset",
+  "id": "theholygrail",
+  "title": "The Holy Grail",
+  "status": "niet_beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "africanswallows",
+      "type": "table",
+      "version": "0.0.1",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/afracnswallows",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["id", "identificatie", "volgnummer"],
+        "display": "identificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "string",
+            "description": "id"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Landelijke identificerende sleutel."
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -82,3 +82,36 @@ def test_fetching_of_related_schema_ids(here):
     """Prove that ids of related dataset schemas are properly collected."""
     schema = DatasetSchema.from_file(here / "files" / "multirelation.json")
     assert set(schema.related_dataset_schema_ids) == {"gebieden", "meetbouten"}
+
+
+def test_dataset_schema_get_fields_with_surrogate_pk(
+    compound_key_schema: DatasetSchema, verblijfsobjecten_schema: DatasetSchema
+):
+    """Prove that the surrogate 'id' key is returned once for schemas with a
+    compound key, regardless of whether the surrogate key is already defined
+    by the schema or generated"""
+
+    verblijfsobjecten = verblijfsobjecten_schema.tables[0]
+    compound_key_schema = compound_key_schema.tables[0]
+
+    # this schema gets a generated 'id'
+    assert sorted([x.id for x in verblijfsobjecten.get_fields(include_subfields=False)]) == [
+        "beginGeldigheid",
+        "eindGeldigheid",
+        "gebruiksdoel",
+        "id",
+        "identificatie",
+        "ligtInBuurt",
+        "schema",
+        "volgnummer",
+    ]
+
+    # this schema defines an 'id'
+    assert sorted([x.name for x in compound_key_schema.get_fields(include_subfields=False)]) == [
+        "beginGeldigheid",
+        "eindGeldigheid",
+        "id",
+        "identificatie",
+        "schema",
+        "volgnummer",
+    ]


### PR DESCRIPTION
`get_fields()` now returns `id` twice for for example the verblijfsobjecten dataset