### PR TITLE
Fix index creation because of always explicit schemas

### DIFF
--- a/src/schematools/__init__.py
+++ b/src/schematools/__init__.py
@@ -7,5 +7,5 @@ MAX_TABLE_NAME_LENGTH: Final[int] = 63  # limitation of PostgreSQL
 TMP_TABLE_POSTFIX: Final[str] = "_new"
 TABLE_INDEX_POSTFIX: Final[str] = "_idx"
 DATABASE_SCHEMA_NAME_DEFAULT: Final[str] = "public"
-DEFAULT_SCHEMA_URL = "https://schemas.data.amsterdam.nl/datasets/"
-DEFAULT_PROFILE_URL = "https://schemas.data.amsterdam.nl/profiles/"
+DEFAULT_SCHEMA_URL: Final[str] = "https://schemas.data.amsterdam.nl/datasets/"
+DEFAULT_PROFILE_URL: Final[str] = "https://schemas.data.amsterdam.nl/profiles/"


### PR DESCRIPTION
Because schemas needed to be made always explicit (to avoid using wrong
db schema), the index creation was broken.

Now the db schema for index creation is also made alway-explicit.

[And fixed some type constants]