### PR TITLE
AB#25070 Fix throughtable for loose 1-N relation

### DIFF
--- a/tests/files/meetbouten.json
+++ b/tests/files/meetbouten.json
@@ -31,7 +31,7 @@
                 "type": "string"
               },
               "volgnummer": {
-                "type": "string"
+                "type": "integer"
               },
               "beginGeldigheid": {
                 "type": "string",

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -36,6 +36,17 @@ def test_ndjson_import_separate_relations_target_compound(
     records = [
         dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_ligt_in_buurt")
     ]
+    assert records == [
+        {
+            "id": 1,
+            "meetbouten_id": "25281132",
+            "ligt_in_buurt_identificatie": "03630023753951",
+            "ligt_in_buurt_volgnummer": 1,
+            "ligt_in_buurt_id": "03630023753951.1",
+            "begin_geldigheid": datetime.date(2015, 1, 1),
+            "eind_geldigheid": None,
+        },
+    ]
 
 
 def test_ndjson_import_separate_relations_both_compound(
@@ -50,6 +61,18 @@ def test_ndjson_import_separate_relations_both_compound(
     importer.load_file(ndjson_path, is_through_table=True)
     records = [
         dict(r) for r in engine.execute("SELECT * from gebieden_ggwgebieden_bestaatuitbuurten")
+    ]
+
+    assert records == [
+        {
+            "id": 1,
+            "ggwgebieden_identificatie": "012",
+            "ggwgebieden_volgnummer": 1,
+            "ggwgebieden_id": "012.1",
+            "bestaatuitbuurten_identificatie": "045",
+            "bestaatuitbuurten_volgnummer": 2,
+            "bestaatuitbuurten_id": "045.2",
+        },
     ]
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -116,3 +116,28 @@ def test_dataset_schema_get_fields_with_surrogate_pk(
         "schema",
         "volgnummer",
     ]
+
+
+def test_dataset_with_loose_1n_relations_has_no_through_tables(meldingen_schema, gebieden_schema):
+    """Prove that a loose relation for a 1-N is not generating a though table.
+
+    The `meldingen_schema` has a 1-N relation to `buurt`, however,
+    that is a loose relation. Those relations should not get a through tables,
+    so, the only one table that should be generated is the main meldingen table.
+    """
+    tables_including_through = meldingen_schema.get_tables(include_through=True)
+    assert len(tables_including_through) == 1
+
+
+def test_dataset_with_loose_nm_relations_has_through_tables(
+    woningbouwplannen_schema, gebieden_schema
+):
+    """Prove that a loose relation for a NM relation is generating a though table.
+
+    The `woningbouwplannen_schema` has two NM relations to `buurt`, however,
+    those are loose relations. Those relations should get a through tables,
+    because NM relations always need a through table by nature.
+    So, in total, 3 tables should be created.
+    """
+    tables_including_through = woningbouwplannen_schema.get_tables(include_through=True)
+    assert len(tables_including_through) == 3


### PR DESCRIPTION
Through tables are created For 1-N temporal relations.
Usually, 1-N relations only need an FK in the source table.
However, for temporal relations, addional information about the
temporality needs to be stored in a through tables.

But, for a loose relation, this in not neccessary
and even unwanted. This commit checks for "looseness"
and acts accordingly by not generating through table definitions.

The check for "looseness" that was in the Django model factory
is now needed during schema generation, so it has been moved
to the `types` modules.