### PR TITLE
AB#24662 Generate correct tablename in grants

### DIFF
--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -116,7 +116,7 @@ def set_dataset_write_permissions(session, pg_schema, ams_schema, dry_run, creat
         _create_role_if_not_exists(session, grantee, dry_run=dry_run)
     for table in ams_schema.get_tables(include_nested=True, include_through=True):
         table_name = "{}_{}".format(
-            table.dataset.id, to_snake_case(table.id)
+            to_snake_case(table.dataset.id), to_snake_case(table.id)
         )  # een aantal table.id's zijn camelcase
         table_privileges = ["INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES"]
         _execute_grant(
@@ -156,7 +156,7 @@ def set_dataset_read_permissions(
 
     for table in ams_schema.get_tables(include_nested=True, include_through=True):
         table_name = "{}_{}".format(
-            table.dataset.id, to_snake_case(table.id)
+            to_snake_case(table.dataset.id), to_snake_case(table.id)
         )  # een aantal table.id's zijn camelcase
         table_scope = table.auth if table.auth else dataset_scope
         table_scope_set = {table_scope} if isinstance(table_scope, str) else set(table_scope)


### PR DESCRIPTION
When a `dataset.id` has capital letters (camelcase)
the GRANT statement has a wrong tablename.

This commit fixed that by applying a `to_snake_case`
on the `dataset.id` so that GRANTS can be applied correctly.