### PR TITLE
Guido/fix from dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "3.1.1"
+current = "3.1.2"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pg-grant
     click
     deepdiff
-    jsonschema
+    jsonschema >= 4.2.1
     json-encoder
     ndjson>=0.3.0
     shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.1.1
+version = 3.1.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -10,6 +10,7 @@ import requests
 import sqlalchemy
 from deepdiff import DeepDiff
 from json_encoder import json
+from jsonschema import draft7_format_checker
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.schema import CreateTable
@@ -363,7 +364,9 @@ def validate(
     structural_errors = False
     try:
         click.echo("Structural validation: ", nl=False)
-        jsonschema.validate(instance=dataset.json_data(), schema=meta_schema)
+        jsonschema.validate(
+            instance=dataset.json_data(), schema=meta_schema, format_checker=draft7_format_checker
+        )
     except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
         structural_errors = True
         click.echo(f"\n{e!s}", err=True)
@@ -410,7 +413,11 @@ def batch_validate(meta_schema_url: str, schema_files: Tuple[str]) -> None:
             # No sense in continuing if we can't read the schema file.
             break
         try:
-            jsonschema.validate(instance=dataset.json_data(), schema=meta_schema)
+            jsonschema.validate(
+                instance=dataset.json_data(),
+                schema=meta_schema,
+                format_checker=draft7_format_checker,
+            )
         except (jsonschema.ValidationError, jsonschema.SchemaError) as struct_error:
             errors[schema].append(f"{struct_error.message}: ({', '.join(struct_error.path)})")
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -133,39 +133,30 @@ class SemVer(str):
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, SemVer):
             return NotImplemented
-        return self.major < other.major or self.minor < other.minor or self.patch < other.patch
+        return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
 
     def __le__(self, other: object) -> bool:
         if not isinstance(other, SemVer):
             return NotImplemented
 
-        return (
-            self.major < other.major or self.minor < other.minor or self.patch < other.patch
-        ) or (
-            self.major == other.major and self.minor == other.minor and self.patch == other.patch
-        )
+        return (self.major, self.minor, self.patch) <= (other.major, other.minor, other.patch)
 
     def __gt__(self, other: object) -> bool:
         if not isinstance(other, SemVer):
             return NotImplemented
-        return self.major > other.major or self.minor > other.minor or self.patch > other.patch
+        return (self.major, self.minor, self.patch) > (other.major, other.minor, other.patch)
 
     def __ge__(self, other: object) -> bool:
         if not isinstance(other, SemVer):
             return NotImplemented
 
-        return (
-            self.major > other.major or self.minor > other.minor or self.patch > other.patch
-        ) or (
-            self.major == other.major and self.minor == other.minor and self.patch == other.patch
-        )
+        return (self.major, self.minor, self.patch) >= (other.major, other.minor, other.patch)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SemVer):
             return False
-        return (
-            self.major == other.major and self.minor == other.minor and self.patch == other.patch
-        )
+
+        return (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch)
 
     def __ne__(self, other: object) -> bool:
         return not self == other

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1,6 +1,7 @@
 """Python types for the Amsterdam Schema JSON file contents."""
 from __future__ import annotations
 
+import copy
 import json
 import re
 import warnings
@@ -286,7 +287,7 @@ class SchemaType(UserDict):
 
     @classmethod
     def from_dict(cls: Type[ST], obj: Json) -> ST:
-        return cls(obj)
+        return cls(copy.deepcopy(obj))
 
 
 class DatasetType(UserDict):
@@ -344,7 +345,7 @@ class DatasetSchema(SchemaType):
         if obj.get("type") != "dataset" or not isinstance(obj.get("tables"), list):
             raise ValueError("Invalid Amsterdam Dataset schema file")
 
-        return cls(obj)
+        return cls(copy.deepcopy(obj))
 
     @property
     def title(self) -> Optional[str]:
@@ -1563,7 +1564,7 @@ class ProfileSchema(SchemaType):
     @classmethod
     def from_dict(cls, obj: Json) -> ProfileSchema:
         """Parses given dict and validates the given schema"""
-        return cls(obj)
+        return cls(copy.deepcopy(obj))
 
     @property
     def name(self) -> Optional[str]:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -32,6 +32,7 @@ from typing import (
 
 import jsonschema
 from deprecated import deprecated
+from jsonschema import draft7_format_checker
 from methodtools import lru_cache
 from more_itertools import first
 
@@ -900,7 +901,7 @@ class DatasetTableSchema(SchemaType):
 
     def validate(self, row: Json) -> None:
         """Validate a record against the schema."""
-        jsonschema.validate(row, self.data["schema"])
+        jsonschema.validate(row, self.data["schema"], format_checker=draft7_format_checker)
 
     def _resolve(self, ref: str) -> jsonschema.RefResolver:
         """Resolve the actual data type of a remote URI reference."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ HERE = Path(__file__).parent
 # https://github.com/toirl/pytest-sqlalchemy/blob/master/pytest_sqlalchemy.py
 
 
-@pytest.fixture()
+@pytest.fixture
 def here() -> Path:
     return HERE
 
@@ -63,7 +63,7 @@ def db_schema(engine, sqlalchemy_keep_db):
     sqlalchemy_utils.functions.drop_database(engine.url)
 
 
-@pytest.fixture()
+@pytest.fixture
 def schema_url():
     return URL(os.environ.get("SCHEMA_URL", "https://schemas.data.amsterdam.nl/datasets/"))
 
@@ -81,7 +81,7 @@ def dbsession(engine, dbsession, sqlalchemy_keep_db) -> Session:
         dbsession.close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def tconn(engine, local_metadata):
     """Will start a transaction on the connection. The connection will
     be rolled back after it leaves its scope.
@@ -178,7 +178,7 @@ class DummySessionMaker:
         return dummy_session()
 
 
-@pytest.fixture()
+@pytest.fixture
 def schemas_mock(schema_url: URL, monkeypatch: Any) -> DummySessionMaker:
     """Mock the requests to import schemas.
 
@@ -219,94 +219,100 @@ def schemas_mock(schema_url: URL, monkeypatch: Any) -> DummySessionMaker:
     yield dummy_session_maker
 
 
-@pytest.fixture()
+@pytest.fixture
+def afval_schema_json(here: Path) -> Json:
+    with open(here / "files/afval.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture
 def afval_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/afval.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def meetbouten_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/meetbouten.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def parkeervakken_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/parkeervakken.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def gebieden_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/gebieden.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def bouwblokken_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/bouwblokken.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def gebieden_schema_auth(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/gebieden_auth.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def gebieden_schema_auth_list(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/gebieden_auth_list.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def ggwgebieden_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/ggwgebieden.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def stadsdelen_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/stadsdelen.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def verblijfsobjecten_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/verblijfsobjecten.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def kadastraleobjecten_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/kadastraleobjecten.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def meldingen_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/meldingen.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def woonplaatsen_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/woonplaatsen.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def woningbouwplannen_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/woningbouwplannen.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def brp_r_profile_schema(here) -> ProfileSchema:
     """A downloaded profile schema definition"""
     return ProfileSchema.from_file(here / "files/profiles/BRP_R.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def profile_brk_encoded_schema(here) -> ProfileSchema:
     """A downloaded profile schema definition"""
     return ProfileSchema.from_file(here / "files/profiles/BRK_encoded.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def profile_brk_read_id_schema(here) -> ProfileSchema:
     return ProfileSchema.from_file(here / "files/profiles/BRK_RID.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def compound_key_schema(here) -> ProfileSchema:
     return DatasetSchema.from_file(here / "files/compound_key.json")
 
@@ -324,11 +330,11 @@ def profile_verkeer_medewerker_schema() -> ProfileSchema:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def brk_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/brk.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def hr_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/hr.json")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,18 @@
+import operator
+from functools import partial
 from pathlib import Path
 
 import pytest
 
-from schematools.types import DatasetSchema, Permission, PermissionLevel, ProfileSchema, SemVer
+from schematools.types import (
+    DatasetSchema,
+    Json,
+    Permission,
+    PermissionLevel,
+    ProfileSchema,
+    SemVer,
+    TableVersions,
+)
 from schematools.utils import dataset_schema_from_path
 
 
@@ -241,3 +251,19 @@ def test_dataset_with_camel_cased_id_generates_correct_through_relations(here):
     # The fields `hasrelations` and `hasNMRelation` are the FK's to source and target table.
     assert through_table.get_field_by_id("hasrelations").relation == "baseDataset:hasrelations"
     assert through_table.get_field_by_id("hasNMRelation").relation == "baseDataset:internalRelated"
+
+
+def test_from_dict(afval_schema_json: Json) -> None:
+    is_dict = lambda o: isinstance(o, dict)
+    is_tv = lambda o: isinstance(o, TableVersions)
+
+    assert all(map(is_dict, afval_schema_json["tables"]))
+
+    dataset = DatasetSchema.from_dict(afval_schema_json)
+
+    # Internally `DatasetSchema` uses `TableVersions` instances as the elements of the "tables"
+    # list.
+    assert all(map(is_dict, afval_schema_json["tables"]))
+
+    # However that should not affect the dict that was originally passed in to `from_dict`
+    assert all(map(is_tv, dataset["tables"]))


### PR DESCRIPTION
A deepcopy is required if we use a `dict` as the basis of our datastructures. Afterall we don't want our internal representation to be altered because the outside world still had a reference to the `dict` that was originally passed in to `from_dict`

Extracted `SemVer` into `more_ds`