### PR TITLE
Avoid adding compound keys to through table when relation is loose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start runtime image,
-FROM amsterdam/python:3.8-buster
+FROM amsterdam/python:3.9-buster
 
 WORKDIR /app
 COPY . ./

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -510,7 +510,7 @@ class DatasetSchema(SchemaType):
         The through tables are not defined separately in a schema.
         The fact that a M2M relation needs an extra table is an implementation aspect.
         However, the through (aka. junction) table schema is needed for the
-        dyanamic model generation and for data-importing.
+        dynamic model generation and for data-importing.
 
         FK relations also have an additional through table, because the temporal information
         of the relation needs to be stored somewhere.
@@ -651,7 +651,11 @@ class DatasetSchema(SchemaType):
                 (table, left_table_id),
                 (_get_fk_target_table(right_dataset_id, right_table_id), target_field_id),
             ):
-                if fk_target_table and fk_target_table.has_compound_key:
+                if (
+                    fk_target_table
+                    and fk_target_table.has_compound_key
+                    and not field.is_loose_relation
+                ):
                     _expand_relation_spec(fk_target_table, sub_table_schema, relation_field_id)
 
             sub_table_schema["schema"]["properties"].update(dim_fields)

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -240,6 +240,11 @@ def test_model_factory_loose_relations(meldingen_dataset, gebieden_dataset):
 def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_dataset, gebieden_dataset):
     """Prove that a loose relation is created when column
     is part of relation definition (<dataset>:<table>:column)
+    and that the intermediate model contains the correct references to both
+    associated tables.
+
+    Loose m2m relations defined with an array of scalars or an array of
+    single-property-objects generate the same output.
     """
     model_dict = {
         cls._meta.model_name: cls
@@ -250,11 +255,26 @@ def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_dataset, 
     model_cls = model_dict["woningbouwplan"]
     meta = model_cls._meta
     buurten_field = meta.get_field("buurten")
+    intermediate_table = buurten_field.remote_field.through
     assert isinstance(buurten_field, LooseRelationManyToManyField)
-    assert isinstance(buurten_field.remote_field.through, ModelBase)
+    assert isinstance(intermediate_table, ModelBase)
+
+    assert {x.name for x in intermediate_table._meta.get_fields()} == {
+        "buurten",
+        "id",
+        "woningbouwplan",
+    }
+
     buurten_as_scalar_field = meta.get_field("buurten_as_scalar")
+    intermediate_table = buurten_as_scalar_field.remote_field.through
     assert isinstance(buurten_as_scalar_field, LooseRelationManyToManyField)
     assert isinstance(buurten_as_scalar_field.remote_field.through, ModelBase)
+
+    assert {x.name for x in intermediate_table._meta.get_fields()} == {
+        "buurten_as_scalar",
+        "id",
+        "woningbouwplan",
+    }
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Since we are only pointing to the primary identifier of the target relation, we only need that FK in the through table.