### PR TITLE
Revert changes to fix broken _parent_schema field.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 github_url = "https://github.com/Amsterdam/schema-tools"
 
 [tool.tbump.version]
-current = "3.3.0"
+current = "3.3.1"
 regex = '''
   (?P<major>\d+)
   \.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.3.0
+version = 3.3.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -209,7 +209,7 @@ class M2MRelationMaker(RelationMaker):
     @property
     def field_kwargs(self):
         snakecased_fieldname = to_snake_case(self.field.name)
-        parent_table = to_snake_case(self.field._parent_table.name)
+        parent_table = to_snake_case(self.field.table.name)
 
         if (additional_relation := self.field.reverse_relation) is not None:
             # The relation is described by the other table, return it

--- a/src/schematools/importer/__init__.py
+++ b/src/schematools/importer/__init__.py
@@ -77,5 +77,5 @@ def fetch_col_type(field):
 
 def get_table_name(dataset_table: DatasetTableSchema) -> str:
     """Generate the database identifier for the table."""
-    schema = dataset_table.parent_schema
+    schema = dataset_table.dataset
     return f"{schema.id}_{dataset_table.id}".replace("-", "_")

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -517,7 +517,7 @@ class DatasetSchema(SchemaType):
                 table.name, snakecased_fieldname
             )
         return DatasetTableSchema(
-            sub_table_schema, parent_schema=self, parent_table=table, nested_table=True
+            sub_table_schema, parent_schema=self, _parent_table=table, nested_table=True
         )
 
     def build_through_table(
@@ -666,7 +666,7 @@ class DatasetSchema(SchemaType):
             sub_table_schema["schema"]["properties"].update(dim_fields)
 
         return DatasetTableSchema(
-            sub_table_schema, parent_schema=self, parent_table=table, through_table=True
+            sub_table_schema, parent_schema=self, _parent_table=table, through_table=True
         )
 
     @property
@@ -715,14 +715,14 @@ class DatasetTableSchema(SchemaType):
         self,
         *args: Any,
         parent_schema: DatasetSchema,
-        parent_table: Optional[DatasetTableSchema] = None,
+        _parent_table: Optional[DatasetTableSchema] = None,
         nested_table: bool = False,
         through_table: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.parent_schema = parent_schema
-        self.parent_table = parent_table
+        self._parent_schema = parent_schema
+        self._parent_table = _parent_table
         self.nested_table = nested_table
         self.through_table = through_table
 
@@ -751,7 +751,15 @@ class DatasetTableSchema(SchemaType):
     @property
     def dataset(self) -> DatasetSchema:
         """The dataset that this table is part of."""
-        return self.parent_schema
+        return self._parent_schema
+
+    @property
+    def parent_table(self) -> Optional[DatasetTableSchema]:
+        """The parent table of this table.
+
+        For nested and through tables, the parent table is available.
+        """
+        return self._parent_table
 
     @property
     def parent_table_field(self) -> Optional[DatasetFieldSchema]:


### PR DESCRIPTION
Does what @gkoller intended, without breaking the other changes from #239. Can check later whether the attribute naming should be improved.