### PR TITLE
AB#27817 Consider shortnames when applying table perms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# This compose file is supplied for local dev
+# Since there is no running process, it just starts a bash
+# session in order to run tests etc.
+version: "3.0"
+services:
+  database:
+    image: amsterdam/postgres11
+    environment:
+      POSTGRES_DB: dataservices
+      POSTGRES_USER: dataservices
+      POSTGRES_PASSWORD: insecure
+
+  app:
+    build: .
+    links:
+      - database
+    environment:
+      SECRET_KEY: insecure
+      SCHEMA_URL: https://schemas.data.amsterdam.nl/datasets/
+      DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
+    volumes:
+      - ".:/app"
+      # Uncomment (and adjust the location of) this mount to experiment with
+      # edited datasets from your local amsterdam-schema clone
+      # - "../amsterdam-schema/datasets:/tmp/datasets"
+    command: >
+      bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,3 +347,8 @@ def brk_schema(here) -> DatasetSchema:
 @pytest.fixture
 def hr_schema(here) -> DatasetSchema:
     return dataset_schema_from_path(here / "files/hr.json")
+
+
+@pytest.fixture
+def hr_schema_auth(here) -> DatasetSchema:
+    return dataset_schema_from_path(here / "files/hr_auth.json")

--- a/tests/files/data/hr_auth.ndjson
+++ b/tests/files/data/hr_auth.ndjson
@@ -1,0 +1,1 @@
+{"sbi_ac_name": "harry", "sbi_ac_no": "1234", "schema": "test", "identifier": "123"}

--- a/tests/files/hr_auth.json
+++ b/tests/files/hr_auth.json
@@ -1,0 +1,46 @@
+{
+  "type": "dataset",
+  "id": "hr",
+  "title": "hr",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "auth": "HR/R",
+  "tables": [
+    {
+      "id": "sbiactiviteiten",
+      "type": "table",
+      "version": "1.0.0",
+      "shortname": "sbiAc",
+      "auth": "LEVEL/B",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/hr/sbiactiviteiten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "identifier",
+        "required": ["schema", "sbiActiviteitNummer"],
+        "display": "sbiActiviteitNummer",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "sbiActiviteitNummer": {
+            "type": "string",
+            "description": "Samenstelling van KvK-nummer en/of Vestigingsnummer of {BSN- of RSIN-nummer}",
+            "shortname": "sbiAcNo",
+            "auth": "LEVEL/C"
+          },
+          "sbiActiviteitNaam": {
+            "type": "string",
+            "description": "name",
+            "shortname": "sbiAcNaam"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
While implementing this, I noticed that the exception handler inside the SQL statement was silently swallowing errors whenever we try to run a GRANT on a non-existing field or table. Removing this revealed two other bugs:

1) applying permissions to FK fields doesnt work because the name used to apply the perm does not include the `_id` suffix
2) snakecasing dataset ids breaks the command because dataset ids are imported with their raw id (i.e. unsnakecased)

The first problem is now explicitly omitted with a FIXME and ive added a [ticket](https://dev.azure.com/CloudCompetenceCenter/Data%20Diensten/_backlogs/backlog/Data%20Diensten%20Team/Stories/?workitem=28436)
The second problem has been solved by #249 
