### PR TITLE
Drop tbump

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,20 @@ However not all `json` files are Amsterdam schema files.
 To exclude files or directories use `exclude` with pattern.
 
 `pre-commit` depends on properly tagged revisions of its hooks.
-Hence we should take care to, not only bump version numbers
-on updates to this package,
-but also commit a tag with the version number.
-This is automated by means of the `tbump` tool.
-Bumping a version from 0.18.1 to 0.18.2
-and generating the appropriate git commits/tags
-is as easy as running:
+Hence, we should not only bump version numbers on updates to this package,
+but also commit a tag with the version number; see below.
 
-```console
-$ tbump 0.18.2
-```
+## Doing a release
+
+(This is for schema-tools developers.)
+
+We use GitHub pull requests. If your PR should produce a new release of
+schema-tools, make sure one of the commit increments the version number in
+``setup.cfg`` appropriately. Then,
+
+* merge the commit in GitHub, after review;
+* pull the code from GitHub and merge it into the master branch,
+  ``git checkout master && git fetch origin && git merge --ff-only origin/master``;
+* tag the release X.Y.Z with ``git tag -a vX.Y.Z -m "Bump to vX.Y.Z"``;
+* push the tag to GitHub with ``git push origin --tags``;
+* release to PyPI: ``make upload`` (requires the PyPI secret).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,37 +27,3 @@ exclude = '''
 '''
 
 github_url = "https://github.com/Amsterdam/schema-tools"
-
-[tool.tbump.version]
-current = "3.3.5"
-regex = '''
-  (?P<major>\d+)
-  \.
-  (?P<minor>\d+)
-  \.
-  (?P<patch>\d+)
-  '''
-
-[tool.tbump.git]
-message_template = "Bump to {new_version}"
-tag_template = "v{new_version}"
-
-# For each file to patch, add a [[tool.tbump.file]] config
-# section containing the path of the file, relative to the
-# tbump.toml location.
-[[tool.tbump.file]]
-src = "setup.cfg"
-
-# You can specify a list of commands to
-# run after the files have been patched
-# and before the git commit is made
-
-#  [[tool.tbump.before_commit]]
-#  name = "check changelog"
-#  cmd = "grep -q {new_version} Changelog.rst"
-
-# Or run some commands after the git tag and the branch
-# have been pushed:
-#  [[tool.tbump.after_push]]
-#  name = "publish"
-#  cmd = "./publish.sh"

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,6 @@ django =
     django-gisserver >= 0.5
     django-environ
 dev =
-    tbump == 6.3.1  # Bumping version number and Git tagging
     build  # PEP5127 package builder (recommended by PYPA)
     twine  # Submmitting package to PYPI
 kafka =


### PR DESCRIPTION
tbump wants to push to master on GH, which we don't allow anymore.
Replace it by instructions for doing a release.