### PR TITLE
Rewrite schema validators as decorated functions

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.schema import CreateTable
 
-from schematools import DEFAULT_PROFILE_URL, DEFAULT_SCHEMA_URL
+from schematools import DEFAULT_PROFILE_URL, DEFAULT_SCHEMA_URL, validation
 from schematools.datasetcollection import DatasetCollection, set_schema_loader
 from schematools.events.export import export_events
 from schematools.events.full import EventsProcessor
@@ -42,7 +42,6 @@ from schematools.utils import (
     dataset_schemas_from_url,
     schema_fetch_url_file,
 )
-from schematools.validation import Validator
 
 option_db_url = click.option(
     "--db-url",
@@ -371,8 +370,7 @@ def validate(
 
     click.echo("Semantic validation: ", nl=False)
     semantic_errors = False
-    validator = Validator(dataset=dataset)
-    for error in validator.run_all():
+    for error in validation.run():
         semantic_errors = True
         click.echo(f"\n{error!s}", err=True)
     if not semantic_errors:
@@ -417,8 +415,7 @@ def batch_validate(meta_schema_url: str, schema_files: Tuple[str]) -> None:
         except (jsonschema.ValidationError, jsonschema.SchemaError) as struct_error:
             errors[schema].append(f"{struct_error.message}: ({', '.join(struct_error.path)})")
 
-        validator = Validator(dataset=dataset)
-        for sem_error in validator.run_all():
+        for sem_error in validation.run():
             errors[schema].append(str(sem_error))
     if errors:
         width = len(max(errors.keys()))

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -16,37 +16,15 @@ Structural validation cannot verify that the properties specified in that array
 actually do exist in the schema.
 Semantic validation can and should.
 
-Specific semantic validations are created by subclassing :class:`Validator`
-and overriding the :meth:`Validator.validate` method.
-Simply by means of subclassing,
-the new validator is automatically registered.
-Registered validator classes will all be run
-when :meth:`Validator.run_all()` is invoked.
-
-.. note::
-
-   For the registration to work
-   all :class:`Validator` subclasses need to be parsed by the Python interpreter.
-   This can be achieved by importing the module they reside in.
-
-Example:
-    The following will run all registered validators
-    on a dataset ``dataset``.
-    Any validation errors are printed to ``stdout``::
-
-        dataset = _get_dataset_schema(meta_schema_url, schema_location)
-        validator = Validator(dataset=dataset)
-        for error in validator.run_all():
-            print(error)
-
+Semantic validations are created decorating a function with `_validator`.
 """
 from __future__ import annotations
 
 import operator
 import re
 from dataclasses import dataclass
-from functools import partial
-from typing import Callable, ClassVar, Iterator, List, Optional, Set, Type, cast, final
+from functools import partial, wraps
+from typing import Callable, Iterator, List, Optional, Set, cast
 
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools.types import DatasetSchema, SemVer, TableVersions
@@ -79,77 +57,62 @@ class ValidationException(Exception):
         self.message = message
 
 
-class Validator:
-    """Base class for validators.
+_all: List[tuple[str, Callable[[DatasetSchema], Iterator[str]]]] = []
 
-    Not only is this a base class for validators,
-    it is also used for running all registered validators.
-    See Also: :meth:`run_all`
 
-    Registration is a side-effect of overriding this base class.
+def run(dataset: DatasetSchema) -> Iterator[ValidationError]:
+    r"""Run all registered validators.
 
+    Yields:
+        :class:`ValidationError`\s, if any.
+
+    """  # noqa: W605
+    for name, validator in _all:
+        for msg in validator(dataset):
+            yield ValidationError(validator_name=name, message=msg)
+
+
+def _register_validator(name: str) -> Callable:
+    """Marks a function as a validator and registers it with `run`.
+
+    The function should yield strings describing the problem.
+    `run` combines those strings with `name` into ValidationErrors.
     """
+    if not name:
+        raise ValueError("validator must have a name")
 
-    _registry: ClassVar[List[Type[Validator]]] = []
-    dataset: DatasetSchema
+    def decorator(func: Callable[[DatasetSchema], Iterator[str]]) -> Callable:
+        @wraps(func)
+        def decorated(dataset: DatasetSchema) -> Iterator[str]:
+            return func(dataset)
 
-    @classmethod
-    def __init_subclass__(cls: Type[Validator]) -> None:
-        """Register sub classes."""
-        super().__init_subclass__()
-        cls._registry.append(cls)
+        _all.append((name, decorated))
+        return decorated
 
-    def __init__(self, dataset: DatasetSchema) -> None:
-        """Initialize the validator with a dataset.
-
-        Args:
-            dataset: The dataset to run the validations on.
-        """
-        self.dataset = dataset
-
-    def validate(self) -> Iterator[ValidationError]:
-        """Run validation."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__}.{self.validate.__name__} should be overridden in "
-            f"subclasses and called from there."
-        )
-
-    @final
-    def run_all(self) -> Iterator[ValidationError]:
-        r"""Run all registered validators.
-
-        Yields:
-            :class:`ValidationError`\s if any.
-
-        """  # noqa: W605
-        for validator_cls in self._registry:
-            validator_inst = validator_cls(dataset=self.dataset)
-            yield from validator_inst.validate()
+    return decorator
 
 
-class CamelCaseValidator(Validator):
+@_register_validator("camel case")
+def _camelcase(dataset: DatasetSchema) -> Iterator[str]:
     """Checks that conversion to snake case and back leaves field identifiers unchanged."""
-
-    def validate(self) -> Iterator[ValidationError]:
-        """Run validation."""
-        for table in self.dataset.tables:
-            for field in table.fields:
-                error = _validate_camelcase(field.id)
-                if error is not None:
-                    yield error
+    for table in dataset.tables:
+        for field in table.fields:
+            error = _camelcase_ident(field.id)
+            if error is not None:
+                yield error
 
 
-def _validate_camelcase(ident: str) -> Optional[ValidationError]:
+def _camelcase_ident(ident: str) -> Optional[str]:
     if ident == "":
-        return ValidationError("CamelCaseValidator", "empty identifier not allowed")
+        return "empty identifier not allowed"
     camel = toCamelCase(to_snake_case(ident))
     if camel == ident:
         return None
-    msg = f"{ident} does not survive conversion to snake case and back; suggestion: {camel}"
-    return ValidationError("CamelCaseValidator", msg)
+    return f"{ident} does not survive conversion to snake case and back; suggestion: {camel}"
 
 
-class PsqlIdentifierLengthValidator(Validator):
+@_register_validator("PostgreSQL identifier length")
+def _postgres_identifier_length(dataset: DatasetSchema) -> Iterator[str]:
     """Validate inferred PostgreSQL table names for not exceeding max length.
 
     PostgreSQL has a maximum length for identifiers such as table names.
@@ -157,114 +120,103 @@ class PsqlIdentifierLengthValidator(Validator):
     Those inferred table names should not exceed the max identifier length
     supported by PostgreSQL.
     """
-
-    def validate(self) -> Iterator[ValidationError]:  # noqa: D102
-        for table in self.dataset.get_tables(include_nested=True, include_through=True):
-            db_name = table.db_name(
-                with_dataset_prefix=True, with_version=True, check_assert=False
+    for table in dataset.get_tables(include_nested=True, include_through=True):
+        db_name = table.db_name(with_dataset_prefix=True, with_version=True, check_assert=False)
+        # print(f"{db_name:>{MAX_TABLE_NAME_LENGTH}}")
+        if (length := len(db_name)) > MAX_TABLE_NAME_LENGTH:
+            excess = length - MAX_TABLE_NAME_LENGTH
+            yield (
+                f"Inferred PostgreSQL table name '{db_name}' is '{excess}' characters "
+                f"too long. Maximum table name length is '{MAX_TABLE_NAME_LENGTH}'. Define "
+                f"a `shortname`!"
             )
-            # print(f"{db_name:>{MAX_TABLE_NAME_LENGTH}}")
-            if (length := len(db_name)) > MAX_TABLE_NAME_LENGTH:
-                excess = length - MAX_TABLE_NAME_LENGTH
-                yield ValidationError(
-                    self.__class__.__name__,
-                    f"Inferred PostgreSQL table name '{db_name}' is '{excess}' characters "
-                    f"too long. Maximum table name length is '{MAX_TABLE_NAME_LENGTH}'. Define "
-                    f"a `shortname`!",
-                )
 
 
-class IdentPropRefsValidator(Validator):
+@_register_validator("identifier properties")
+def _identifier_properties(dataset: DatasetSchema) -> Iterator[str]:
     """Validate that the identifier property refers to actual fields on the table definitions."""
 
-    def validate(self) -> Iterator[ValidationError]:  # noqa: D102
-        @dataclass
-        class DerivedField:
-            original: str
-            derived: str
+    @dataclass
+    class DerivedField:
+        original: str
+        derived: str
 
-        for table in self.dataset.get_tables(include_nested=True):
-            identifiers = set(table.identifier)
-            table_fields = cast(Set[str], set(map(operator.attrgetter("id"), table.fields)))
-            if not identifiers.issubset(table_fields):
-                missing_fields = identifiers - table_fields
-                # The 'identifier' property is weird in that it is not exclusively defined in
-                # terms of literally defined fields on the table. For instance, given a relation:
-                #
-                #     "indicatorDefinitie": {
-                #       "type": "string",
-                #       "relation": "bbga:indicatorenDefinities",
-                #        "description": "De variabele in kwestie."
-                #     }
-                #
-                # 'identifier' can refer to this field as 'identifierDefinitionId' (mind the
-                # 'Id' postfix). Simply referring to this field (from 'identifier') as
-                # 'indicatorDefinitie', eg as:
-                #
-                #     "identifier": ["indicatorDefinitie", "jaar", "gebiedcode15"],
-                #
-                #  will NOT work. It has to be postfixed with 'Id', eg:
-                #
-                #     "identifier": ["indicatorDefinitieId", "jaar", "gebiedcode15"],
-                #
-                # I think this is a bug is schema-tools, but for now I'll cover this case
-                # explicitly.
-                remove_id_suffix = cast(Callable[[str], str], partial(re.sub, r"(.+)Id", r"\1"))
-                derived_fields = tuple(
-                    map(
-                        lambda f: DerivedField(original=remove_id_suffix(f), derived=f),
-                        missing_fields,
-                    )
+    for table in dataset.get_tables(include_nested=True):
+        identifiers = set(table.identifier)
+        table_fields = cast(Set[str], set(map(operator.attrgetter("id"), table.fields)))
+        if not identifiers.issubset(table_fields):
+            missing_fields = identifiers - table_fields
+            # The 'identifier' property is weird in that it is not exclusively defined in
+            # terms of literally defined fields on the table. For instance, given a relation:
+            #
+            #     "indicatorDefinitie": {
+            #       "type": "string",
+            #       "relation": "bbga:indicatorenDefinities",
+            #        "description": "De variabele in kwestie."
+            #     }
+            #
+            # 'identifier' can refer to this field as 'identifierDefinitionId' (mind the
+            # 'Id' postfix). Simply referring to this field (from 'identifier') as
+            # 'indicatorDefinitie', eg as:
+            #
+            #     "identifier": ["indicatorDefinitie", "jaar", "gebiedcode15"],
+            #
+            #  will NOT work. It has to be postfixed with 'Id', eg:
+            #
+            #     "identifier": ["indicatorDefinitieId", "jaar", "gebiedcode15"],
+            #
+            # I think this is a bug is schema-tools, but for now I'll cover this case
+            # explicitly.
+            remove_id_suffix = cast(Callable[[str], str], partial(re.sub, r"(.+)Id", r"\1"))
+            derived_fields = tuple(
+                map(
+                    lambda f: DerivedField(original=remove_id_suffix(f), derived=f),
+                    missing_fields,
                 )
-                for df in derived_fields:
-                    if df.original in table_fields:
-                        missing_fields.discard(df.derived)
-                if missing_fields:
-                    fields, have = (
-                        ("fields", "have") if len(missing_fields) > 1 else ("field", "has")
-                    )
-                    yield ValidationError(
-                        self.__class__.__name__,
-                        f"Property 'identifier' on table '{table.id}' refers to {fields} "
-                        f"'{', '.join(missing_fields)}' that {have} not been defined on the "
-                        "table.",
-                    )
+            )
+            for df in derived_fields:
+                if df.original in table_fields:
+                    missing_fields.discard(df.derived)
+            if missing_fields:
+                fields, have = ("fields", "have") if len(missing_fields) > 1 else ("field", "has")
+                yield (
+                    f"Property 'identifier' on table '{table.id}' refers to {fields} "
+                    f"'{', '.join(missing_fields)}' that {have} not been defined on the "
+                    "table."
+                )
 
 
-class ActiveVersionsValidator(Validator):
+@_register_validator("active versions")
+def _active_versions(dataset: DatasetSchema) -> Iterator[str]:
     """Validate activeVersions and table identifiers in referenced tables."""
-
-    def validate(self) -> Iterator[ValidationError]:  # noqa: D102
-        # The current Amsterdam Meta Schema does not allow for inline definitions of multiple
-        # active tables versions. In addition :class:`DatasetSchema`'s
-        # :property:`~DatasetSchema.tables` property and :meth:~DatasetSchema.get_tables` method
-        # still assume that there will always be one and only one version. The part of
-        # :class:`DatasetSchema` that has gained some knowledge of multiple active versions is
-        # its internal representation with the addition of the :class:`TableVersions` class.
-        # Hence it is the internal representation that we use for this validation.
-        #
-        # This obviously is a stop gap. Ideally we have a more, arguably, sensible definition of
-        # multiple active version in the Amsterdam Meta Schema (eg an inline definition). When
-        # we do, we are in a position to restructure our abstraction (eg :class:`DatasetSchema`,
-        # etc) more definitely. And as a result can rely on those abstractions for our
-        # validation instead of some internal representation.
-        for tv in self.dataset["tables"]:
-            assert isinstance(  # noqa: S101
-                tv, TableVersions
-            ), 'Someone messed with the internal representation of DatasetSchema["tables"].'
-            for version, table in tv.active.items():
-                assert isinstance(table, dict)  # noqa: S101
-                if tv.id != table["id"]:
-                    yield ValidationError(
-                        self.__class__.__name__,
-                        f"Table {tv.id!r} with version number '{version}' does not match with "
-                        f"id {table['id']!r} of the referenced table.",
-                    )
-                version_in_table = SemVer(table["version"])
-                if version != version_in_table:
-                    yield ValidationError(
-                        self.__class__.__name__,
-                        f"Version number '{version}' in activeVersions for table {table['id']!r} "
-                        f"does not match with version number '{version_in_table}' of the "
-                        "referenced table.",
-                    )
+    # The current Amsterdam Meta Schema does not allow for inline definitions of multiple
+    # active tables versions. In addition :class:`DatasetSchema`'s
+    # :property:`~DatasetSchema.tables` property and :meth:~DatasetSchema.get_tables` method
+    # still assume that there will always be one and only one version. The part of
+    # :class:`DatasetSchema` that has gained some knowledge of multiple active versions is
+    # its internal representation with the addition of the :class:`TableVersions` class.
+    # Hence it is the internal representation that we use for this validation.
+    #
+    # This obviously is a stop gap. Ideally we have a more, arguably, sensible definition of
+    # multiple active version in the Amsterdam Meta Schema (eg an inline definition). When
+    # we do, we are in a position to restructure our abstraction (eg :class:`DatasetSchema`,
+    # etc) more definitely. And as a result can rely on those abstractions for our
+    # validation instead of some internal representation.
+    for tv in dataset["tables"]:
+        assert isinstance(  # noqa: S101
+            tv, TableVersions
+        ), 'Someone messed with the internal representation of DatasetSchema["tables"].'
+        for version, table in tv.active.items():
+            assert isinstance(table, dict)  # noqa: S101
+            if tv.id != table["id"]:
+                yield (
+                    f"Table {tv.id!r} with version number '{version}' does not match with "
+                    f"id {table['id']!r} of the referenced table."
+                )
+            version_in_table = SemVer(table["version"])
+            if version != version_in_table:
+                yield (
+                    f"Version number '{version}' in activeVersions for table {table['id']!r} "
+                    f"does not match with version number '{version_in_table}' of the "
+                    "referenced table."
+                )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,66 +7,60 @@ from typing import cast
 import pytest
 from more_itertools import first
 
+from schematools import validation
 from schematools.types import Json, TableVersions
 from schematools.utils import dataset_schema_from_path
-from schematools.validation import (
-    ActiveVersionsValidator,
-    IdentPropRefsValidator,
-    PsqlIdentifierLengthValidator,
-    ValidationError,
-    _validate_camelcase,
-)
 
 
-def test_validate_camelcase():
+def test_camelcase() -> None:
     for ident in ("camelCase", "camelCase100"):
-        assert _validate_camelcase(ident) is None
+        assert validation._camelcase_ident(ident) is None
 
-    assert isinstance(_validate_camelcase(""), ValidationError)
+    error = validation._camelcase_ident("")
+    assert error is not None
+    assert "empty identifier" in error
 
     for ident, suggest in (
         ("snake_case", "snakeCase"),
         ("camelCase_snake", "camelCaseSnake"),
         ("camel100camel", "camel100Camel"),
     ):
-        error = _validate_camelcase(ident)
-        assert isinstance(error, ValidationError)
-        assert error.message.endswith(f"suggestion: {suggest}")
+        error = validation._camelcase_ident(ident)
+        assert error is not None
+        assert error.endswith(f"suggestion: {suggest}")
 
 
-def test_PsqlIdentifierLengthValidator(here: Path) -> None:
+def test_postgres_identifier_length(here: Path) -> None:
     dataset = dataset_schema_from_path(here / "files/long_ids.json")
-    validator = PsqlIdentifierLengthValidator(dataset=dataset)
-    error = next(validator.validate())
+
+    error = next(validation.run(dataset))
     assert error
+    assert error.validator_name == "PostgreSQL identifier length"
+    assert "absurdly_long" in error.message
 
     dataset = dataset_schema_from_path(here / "files/stadsdelen.json")
-    validator = PsqlIdentifierLengthValidator(dataset=dataset)
     with pytest.raises(StopIteration):
         # no validation error
-        next(validator.validate())
+        next(validation.run(dataset))
 
 
-def test_IdentPropRefsValidator(here: Path) -> None:
+def test_identifier_properties(here: Path) -> None:
     dataset = dataset_schema_from_path(here / "files/identifier_ref.json")
-    validator = IdentPropRefsValidator(dataset=dataset)
-    error = next(validator.validate())
+    error = next(validation.run(dataset))
     assert error
     assert "foobar" in error.message
 
     dataset = dataset_schema_from_path(here / "files/stadsdelen.json")
-    validator = IdentPropRefsValidator(dataset=dataset)
     with pytest.raises(StopIteration):
         # no validation error
-        next(validator.validate())
+        next(validation.run(dataset))
 
 
-def test_ActiveVersionsValidator(here: Path) -> None:
+def test_active_versions(here: Path) -> None:
     dataset = dataset_schema_from_path(here / "files/gebieden_sep_tables/dataset.json")
     table_version = cast(TableVersions, first(dataset["tables"]))
     table_version.id = table_version.id.capitalize()
-    validator = ActiveVersionsValidator(dataset=dataset)
-    error = next(validator.validate())
+    error = next(validation.run(dataset))
     assert error
     assert "does not match with id" in error.message
 
@@ -76,13 +70,11 @@ def test_ActiveVersionsValidator(here: Path) -> None:
         incorrect_version = copy.deepcopy(version)
         incorrect_version.major += 1
         cast(dict[str, Json], table_version.active[version])["version"] = str(incorrect_version)
-    validator = ActiveVersionsValidator(dataset=dataset)
-    error = next(validator.validate())
+    error = next(validation.run(dataset))
     assert error
     assert "does not match with version number" in error.message
 
     dataset = dataset_schema_from_path(here / "files/gebieden_sep_tables/dataset.json")
-    validator = ActiveVersionsValidator(dataset=dataset)
     with pytest.raises(StopIteration):
         # no validation error
-        next(validator.validate())
+        next(validation.run(dataset))


### PR DESCRIPTION
All decorators were stateless classes with a single validate method that
were attached to their base class. This made writing new validators a
pain because of all the boilerplate and the flake8 requirement of having
a docstring both on the class and on the validate method.

The new code uses ordinary standalone functions with a decorator to
register them as validators. They're now also all marked as private with
the familiar underscore, and they have a human-readable name that is
independent of their identifier.