### PR TITLE
[FIX] camelCase in dataset id

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.3.5
+version = 3.3.6
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -76,7 +76,7 @@ def tables_factory(
         # leading to unwanted/unexepected results
         if (db_schema_name := (db_schema_names or {}).get(snaked_dataset_table_id)) is None:
             if is_versioned_dataset:
-                db_schema_name = dataset.id
+                db_schema_name = to_snake_case(dataset.id)
             else:
                 db_schema_name = DATABASE_SCHEMA_NAME_DEFAULT
         columns = []


### PR DESCRIPTION
The `dataset id` is used for defining the database schema where the tables of that dataset will reaside. In some cases the dataset id is camelCased. Leading to also the prefix of tables - that contain the name of its schema - to have camelCased prefixes. Which leads to wrong table names and issues for the datateams. To cope with this, the dataset id is snaked cased.