### PR TITLE
AB#26860 Use schemaloader for loading of all datasets

### DIFF
--- a/src/schematools/exceptions.py
+++ b/src/schematools/exceptions.py
@@ -4,3 +4,7 @@ class ParserError(ValueError):
 
 class SchemaObjectNotFound(ValueError):
     """Field does not exist."""
+
+
+class DatasetNotFound(ValueError):
+    """The dataset could not be found."""

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, Union
 
 from more_ds.network.url import URL
+
+from schematools.exceptions import DatasetNotFound
 
 if TYPE_CHECKING:
     from schematools.types import DatasetSchema
@@ -26,6 +28,10 @@ class SchemaLoader:
         """Gets a dataset for dataset_id."""
         raise NotImplementedError
 
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+        """Gets all datasets from the schema_url location."""
+        raise NotImplementedError
+
 
 class FileSystemSchemaLoader(SchemaLoader):
     """Loader that loads dataset schemas from the filesystem."""
@@ -34,11 +40,20 @@ class FileSystemSchemaLoader(SchemaLoader):
         """Gets a dataset from the filesystem for dataset_id."""
         from schematools.utils import dataset_schema_from_id_and_schemas_path
 
-        return dataset_schema_from_id_and_schemas_path(
-            dataset_id,
-            schemas_path=self.schema_url,
-            prefetch_related=prefetch_related,
-        )
+        try:
+            return dataset_schema_from_id_and_schemas_path(
+                dataset_id,
+                schemas_path=self.schema_url,
+                prefetch_related=prefetch_related,
+            )
+        except FileNotFoundError as e:
+            raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from e
+
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+        """Gets all datasets from the filesystem based on the `self.schema_url` path."""
+        from schematools.utils import dataset_schemas_from_schemas_path
+
+        return dataset_schemas_from_schemas_path(self.schema_url)
 
 
 class URLSchemaLoader(SchemaLoader):
@@ -48,6 +63,15 @@ class URLSchemaLoader(SchemaLoader):
         """Gets a dataset from a url for dataset_id."""
         from schematools.utils import dataset_schema_from_url
 
-        return dataset_schema_from_url(
-            self.schema_url, dataset_id, prefetch_related=prefetch_related
-        )
+        try:
+            return dataset_schema_from_url(
+                self.schema_url, dataset_id, prefetch_related=prefetch_related
+            )
+        except KeyError:
+            raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from None
+
+    def get_all_datasets(self) -> Dict[str, DatasetSchema]:
+        """Gets all datasets from a web url based on the `self.schema_url` path."""
+        from schematools.utils import dataset_schemas_from_url
+
+        return dataset_schemas_from_url(self.schema_url)  # type: ignore[no-any-return]


### PR DESCRIPTION
The configurable schemaloader could only be used for loading
individual datasets. It now has been expanded to also
support loading all datasets using the schemaloader.

So, it is now possible to load all dataset from the filesystem.

(Rant could be removed from the comments :-)