### PR TITLE
Bump to 3.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.3.7
+version = 3.4.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie


### PR DESCRIPTION
We need a release in order to use the new validations from amsterdam-schema's pre-commit hook.