### PR TITLE
[AB#24838] Add get_field_by_id to DatasetFieldSchema

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1329,6 +1329,19 @@ class DatasetFieldSchema(DatasetType):
 
         return dataset_table.temporal.dimensions
 
+    @lru_cache()  # type: ignore[misc]
+    def get_field_by_id(self, field_id: str) -> DatasetFieldSchema:
+        """Finds and returns the subfield with the given id.
+
+        SchemaObjectNotFound is raised when the field does not exist.
+        """
+        for field_schema in self.subfields:
+            if field_schema.id == field_id:
+                return field_schema
+
+        name = self.table.id + "." + self.id
+        raise SchemaObjectNotFound(f"Subfield '{field_id}' does not exist below field '{name}'.")
+
     @cached_property
     def subfields(self) -> List[DatasetFieldSchema]:
         """Return the subfields for a nested structure.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from schematools.exceptions import SchemaObjectNotFound
 from schematools.types import (
     DatasetSchema,
     Json,
@@ -267,3 +268,15 @@ def test_from_dict(afval_schema_json: Json) -> None:
 
     # However that should not affect the dict that was originally passed in to `from_dict`
     assert all(map(is_tv, dataset["tables"]))
+
+
+def test_subfields(ggwgebieden_schema: DatasetSchema) -> None:
+    field = ggwgebieden_schema.get_table_by_id("buurten").get_field_by_id("ligtInWijk")
+    subfields = sorted(field.subfields, key=operator.attrgetter("id"))
+    assert subfields[0].id == "identificatie"
+    assert subfields[1].id == "volgnummer"
+
+    assert subfields[0] == field.get_field_by_id("identificatie")
+    assert subfields[1] == field.get_field_by_id("volgnummer")
+    with pytest.raises(SchemaObjectNotFound):
+        field.get_field_by_id("iDoNotExist")


### PR DESCRIPTION
The name of this method matches that of the one on DatasetTableSchema, rather than those of the other DatasetFieldSchema methods (`get_subfields` etc.). That's on purpose: the filter validation in DSO-API assumes it can use the same method on both types to walk a schema and resolve a compound field name.