### PR TITLE
AB#28930 add titles for table and fields to the database as extra comments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ django =
     django-postgres-unlimited-varchar >= 1.1.0
     django-gisserver >= 0.5
     django-environ
+    django-db-comments
 dev =
     build  # PEP5127 package builder (recommended by PYPA)
     twine  # Submmitting package to PYPI

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.4.1
+version = 3.4.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type, Union
 from urllib.parse import urlparse
 
 from django.apps import apps
@@ -399,6 +399,22 @@ def schema_models_factory(
     ]
 
 
+def _fetch_verbose_name(
+    obj: Union[DatasetTableSchema, DatasetTableSchema], with_description: bool = False
+) -> str:
+    """Generate a verbose_name for a table or field.
+
+    For fields, the description goes into `help_text`, so the flag `with_description`
+    can be used to leave it out of the `verbose_name`.
+    """
+    verbose_name_parts = []
+    if title := obj.title:
+        verbose_name_parts.append(title)
+    if with_description and (description := obj.description):
+        verbose_name_parts.append(description)
+    return " | ".join(verbose_name_parts)
+
+
 def model_factory(
     dataset: Dataset, table_schema: DatasetTableSchema, base_app_name: Optional[str] = None
 ) -> Type[DynamicModel]:
@@ -438,8 +454,7 @@ def model_factory(
         if init_kwargs is None:
             init_kwargs = {}
 
-        if field.title:
-            init_kwargs["verbose_name"] = field.title
+        init_kwargs["verbose_name"] = _fetch_verbose_name(field)
 
         # Generate field object
         kls, args, kwargs = FieldMaker(base_class, table_schema, **init_kwargs)(
@@ -465,7 +480,7 @@ def model_factory(
             "managed": False,
             "db_table": table_schema.db_name(),
             "app_label": app_label,
-            "verbose_name": (table_schema.title or table_schema.id).capitalize(),
+            "verbose_name": _fetch_verbose_name(table_schema, with_description=True),
             "ordering": [to_snake_case(fn) for fn in table_schema.identifier],
         },
     )

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -438,6 +438,9 @@ def model_factory(
         if init_kwargs is None:
             init_kwargs = {}
 
+        if field.title:
+            init_kwargs["verbose_name"] = field.title
+
         # Generate field object
         kls, args, kwargs = FieldMaker(base_class, table_schema, **init_kwargs)(
             field, dataset_schema
@@ -462,7 +465,7 @@ def model_factory(
             "managed": False,
             "db_table": table_schema.db_name(),
             "app_label": app_label,
-            "verbose_name": table_schema.id.title(),
+            "verbose_name": (table_schema.title or table_schema.id).capitalize(),
             "ordering": [to_snake_case(fn) for fn in table_schema.identifier],
         },
     )

--- a/src/schematools/contrib/django/management/commands/create_tables.py
+++ b/src/schematools/contrib/django/management/commands/create_tables.py
@@ -1,12 +1,17 @@
 import re
 from collections import defaultdict
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Type
 
 from django.core.management import BaseCommand, CommandError
-from django.db import DatabaseError, connection, router, transaction
+from django.db import DEFAULT_DB_ALIAS, DatabaseError, connection, router, transaction
+from django_db_comments.db_comments import (
+    add_column_comments_to_database,
+    add_table_comments_to_database,
+    get_comments_for_model,
+)
 
 from schematools.contrib.django.factories import schema_models_factory
-from schematools.contrib.django.models import Dataset
+from schematools.contrib.django.models import Dataset, DynamicModel
 
 
 class Command(BaseCommand):
@@ -26,13 +31,34 @@ class Command(BaseCommand):
         create_tables(self, Dataset.objects.db_enabled(), allow_unmanaged=True, skip=skip)
 
 
+def _add_comments_to_database(used_models: List[DynamicModel]) -> None:
+    """Add comments for tables and fields to the database.
+
+    The code below is coming from the `django_db_comments` package.
+    https://pypi.org/project/django-db-comments/
+
+    Because we are creating models dynamically, the standard approach that is
+    used (a `post_migrate` signal) in this package, does not apply in our case.
+    So, we re-use the packages' code as much as possible in our own approach.
+    """
+    columns_comments = {m._meta.db_table: get_comments_for_model(m) for m in used_models}
+    if columns_comments:
+        add_column_comments_to_database(columns_comments, DEFAULT_DB_ALIAS)
+    table_comments = {
+        m._meta.db_table: m._meta.verbose_name.title() for m in used_models if m._meta.verbose_name
+    }
+
+    if table_comments:
+        add_table_comments_to_database(table_comments, DEFAULT_DB_ALIAS)
+
+
 def create_tables(
     command: BaseCommand,
     datasets: Iterable[Dataset],
     allow_unmanaged: bool = False,
     base_app_name: Optional[str] = None,
     skip: Optional[List[str]] = None,
-) -> None:  # noqa:C901
+) -> None:  # noqa: C901
     """Create tables for all updated datasets.
     This is a separate function to allow easy reuse.
     """
@@ -55,6 +81,8 @@ def create_tables(
 
         models.extend(schema_models_factory(dataset, base_app_name=base_app_name))
 
+    # We need to collect the models for later re-use in adding comments to db.
+    used_models = []
     # Grouping multiple versions of same model by table name
     models_by_table = defaultdict(list)
     for model in models:
@@ -82,11 +110,15 @@ def create_tables(
             try:
                 command.stdout.write(f"* Creating table {model._meta.db_table}")
                 with transaction.atomic():
+                    used_models.append(model)
                     schema_editor.create_model(model)
             except (DatabaseError, ValueError) as e:
                 command.stderr.write(f"  Tables not created: {e}")
                 if not re.search(r'relation "[^"]+" already exists', str(e)):
                     errors += 1
+
+    # Add the comments for tables/fields for the models that have been created.
+    _add_comments_to_database(used_models)
 
     if errors:
         raise CommandError("Not all tables could be created")

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -744,6 +744,11 @@ class DatasetTableSchema(SchemaType):
         return self.get("shortname", self.id)
 
     @property
+    def title(self) -> Optional[str]:
+        """Title of the table."""
+        return self.get("title")
+
+    @property
     def has_shortname(self) -> bool:
         return self.get("shortname") is not None
 
@@ -1162,6 +1167,11 @@ class DatasetFieldSchema(DatasetType):
         The actual column name in SQL is the snake-casing of the name.
         """
         return cast(str, self.get("shortname", self._id))
+
+    @property
+    def title(self) -> Optional[str]:
+        """Title of the field."""
+        return self.get("title")
 
     @property
     def has_shortname(self) -> bool:

--- a/tests/django/conftest.py
+++ b/tests/django/conftest.py
@@ -23,6 +23,7 @@ def pytest_configure(config):
             "django.contrib.staticfiles",
             "django.contrib.gis",
             "django.contrib.postgres",
+            "django_db_comments",
             "schematools.contrib.django",
         ],
         DATABASES=databases,

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -18,7 +18,7 @@ def test_model_factory_fields(afval_dataset) -> None:
     table = afval_dataset.schema.tables[0]
     model_cls = model_factory(afval_dataset, table, base_app_name="dso_api.dynamic_api")
     meta = model_cls._meta
-    assert meta.verbose_name == "Containers title"
+    assert meta.verbose_name == "Containers title | Containers description"
     assert {f.name for f in meta.get_fields()} == {
         "id",
         "cluster",
@@ -39,7 +39,12 @@ def test_model_factory_fields(afval_dataset) -> None:
     assert geo_field.db_index
     assert meta.app_label == afval_dataset.schema.id
 
+    # Title and description
     assert meta.get_field("eigenaar_naam").verbose_name == "Naam eigenaar"
+    assert meta.get_field("eigenaar_naam").help_text == "Naam van de eigenaar"
+    # Description only
+    assert meta.get_field("datum_creatie").verbose_name == ""
+    assert meta.get_field("datum_creatie").help_text == "Datum aangemaakt"
 
     table_with_id_as_string = afval_dataset.schema.tables[1]
     model_cls = model_factory(

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -18,6 +18,7 @@ def test_model_factory_fields(afval_dataset) -> None:
     table = afval_dataset.schema.tables[0]
     model_cls = model_factory(afval_dataset, table, base_app_name="dso_api.dynamic_api")
     meta = model_cls._meta
+    assert meta.verbose_name == "Containers title"
     assert {f.name for f in meta.get_fields()} == {
         "id",
         "cluster",
@@ -37,6 +38,8 @@ def test_model_factory_fields(afval_dataset) -> None:
     assert geo_field.srid == 28992
     assert geo_field.db_index
     assert meta.app_label == afval_dataset.schema.id
+
+    assert meta.get_field("eigenaar_naam").verbose_name == "Naam eigenaar"
 
     table_with_id_as_string = afval_dataset.schema.tables[1]
     model_cls = model_factory(

--- a/tests/files/afval.json
+++ b/tests/files/afval.json
@@ -8,6 +8,7 @@
     {
       "id": "containers",
       "title": "Containers title",
+      "description": "Containers description",
       "type": "table",
       "version": "1.0.0",
       "schema": {
@@ -37,7 +38,7 @@
           "eigenaar naam": {
             "type": "string",
             "title": "Naam eigenaar",
-            "description": "Naam van eigenaar"
+            "description": "Naam van de eigenaar"
           },
           "datum creatie": {
             "type": "string",

--- a/tests/files/afval.json
+++ b/tests/files/afval.json
@@ -7,6 +7,7 @@
   "tables": [
     {
       "id": "containers",
+      "title": "Containers title",
       "type": "table",
       "version": "1.0.0",
       "schema": {
@@ -35,6 +36,7 @@
           },
           "eigenaar naam": {
             "type": "string",
+            "title": "Naam eigenaar",
             "description": "Naam van eigenaar"
           },
           "datum creatie": {


### PR DESCRIPTION
This is already being done for the SQLAlchemy based commands.

This functionality to add comments to the database is missing from the Django ORM. This is a long-standing feature request. However, there is an Django plugin `django-db-comments` that adds this functionality.
Unfortunately, this does not work out-of-the-box for our situation, where Django models are generated on-the-fly.

In this PR the plugin is used as far a possible.