### PR TITLE
Recognize the implicit scope "OPENBAAR"

### DIFF
--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable, List, Optional
 
 import methodtools
 
-from schematools.types import (
+from ..types import (
     DatasetFieldSchema,
     DatasetSchema,
     DatasetTableSchema,
@@ -19,6 +19,8 @@ from schematools.types import (
     ProfileSchema,
     ProfileTableSchema,
 )
+
+PUBLIC_SCOPE = "OPENBAAR"
 
 __all__ = ("UserScopes",)
 
@@ -48,13 +50,14 @@ class UserScopes:
         Args:
             query_params: The search query filter (e.g. request.GET).
             request_scopes: The scopes granted to a request.
+                Presence of the public scope "OPENBAAR" is implied.
             all_profiles: All profiles that need to be loaded.
                 If not None, this iterable is stored and converted to list
                 the first time it is needed.
         """
         self._query_param_names = [param for param, value in query_params.items() if value]
         self._all_profiles = all_profiles
-        self._scopes = frozenset(request_scopes)
+        self._scopes = set(request_scopes) | {PUBLIC_SCOPE}
 
     def add_query_params(self, params: List[str]):
         """Tell that the request has extra (implicit) parameters that are satisfied.
@@ -80,7 +83,7 @@ class UserScopes:
         This performs an OR check: having one of the scopes gives access.
         """
         needed_scopes = set(needed_scopes)
-        return not needed_scopes or any(scope in needed_scopes for scope in self._scopes)
+        return any(scope in needed_scopes for scope in self._scopes)
 
     def has_dataset_access(self, dataset: DatasetSchema) -> Permission:
         """Tell whether a dataset can be accessed."""

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -47,6 +47,8 @@ DTS = TypeVar("DTS", bound="DatasetTableSchema")
 Json = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 Ref = str
 
+_PUBLIC_SCOPE = "OPENBAAR"
+
 logger = logging.getLogger(__name__)
 
 
@@ -396,7 +398,7 @@ class DatasetSchema(SchemaType):
 
     @property
     def auth(self) -> FrozenSet[str]:
-        """Auth of the dataset (if set)"""
+        """Auth of the dataset, or OPENBAAR."""
         return _normalize_scopes(self.get("auth"))
 
     def get_dataset_schema(self, dataset_id: str) -> DatasetSchema:
@@ -990,7 +992,7 @@ class DatasetTableSchema(SchemaType):
 
     @property
     def auth(self) -> FrozenSet[str]:
-        """Auth of the table (if set)"""
+        """Auth of the table, or OPENBAAR."""
         return _normalize_scopes(self.get("auth"))
 
     @property
@@ -1465,7 +1467,7 @@ class DatasetFieldSchema(DatasetType):
 
     @property
     def auth(self) -> FrozenSet[str]:
-        """Auth of the field, or the empty set if auth is not set."""
+        """Auth of the field, or OPENBAAR."""
         return _normalize_scopes(self.get("auth"))
 
     @property
@@ -1883,8 +1885,8 @@ class Temporal:
 def _normalize_scopes(auth: Union[None, str, list, tuple]) -> FrozenSet[str]:
     """Make sure the auth field has a consistent type"""
     if not auth:
-        # Auth defined on schema
-        return frozenset()
+        # No auth implies OPENBAAR.
+        return frozenset({_PUBLIC_SCOPE})
     elif isinstance(auth, (list, tuple, set)):
         # Multiple scopes act choices (OR match).
         return frozenset(auth)


### PR DESCRIPTION
First step toward closed-by-default with explicit marking of public data sets, [AB#40314](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/40314).

This special scope is defined by the Amsterdam Schema spec, so it makes sense to handle it entirely in schema-tools rather than DSO-API.

The string constant is now repeated in several modules, because defining it centrally in permissions.auth causes a circular import (even when in a submodule permissions.auth._public). Leaving that problem for later, when we implement closed-by-default logic.

All DSO-API tests pass with this PR applied, except some index views that now display `["OPENBAAR"]` where they previously displayed `[]` or `None`. In the long run, that's what we want anyway, so I'll fix those tests instead of work around it in schema-tools.