### PR TITLE
AB#28435 Fix shortnamed identifiers for ndjson import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     rev: 21.11b1
     hooks:
       - id: black
+        additional_dependencies:
+          - click==8.0.2  # Pin click, latest version is missing `_unicodefun` needed by black
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -102,6 +102,7 @@ class NDJSONImporter(BaseImporter):
         relation_field_info = []
         nm_relation_field_info = []
         nested_field_info = []
+        shortname_fields = []
         inactive_relation_info = []
         jsonpath_provenance_info = []
         geo_fields = []
@@ -124,12 +125,18 @@ class NDJSONImporter(BaseImporter):
                 nm_relation_field_info.append(field)
             if field.is_nested_table:
                 nested_field_info.append(field)
+            if field.has_shortname:
+                shortname_fields.append(field)
 
         with open(file_name) as fh:
             for _row in ndjson.reader(fh):
                 if through_fields_mapper is not None:
                     _row = through_fields_mapper(_row)
                 row = Row(_row, fields_provenances=fields_provenances)
+
+                for field in shortname_fields:
+                    row[field.name] = row[field.id]
+
                 for ir_field in inactive_relation_info:
                     row[ir_field.name] = json.dumps(row[ir_field.id])
                 for field_name in jsonpath_provenance_info:

--- a/tests/files/data/hr_auth.ndjson
+++ b/tests/files/data/hr_auth.ndjson
@@ -1,1 +1,1 @@
-{"sbi_ac_name": "harry", "sbi_ac_no": "1234", "schema": "test", "identifier": "123"}
+{"sbiActiviteitNaam": "harry", "sbiActiviteitNummer": "1234", "schema": "test", "identifier": "123"}

--- a/tests/files/data/hr_sbi_act_nr.ndjson
+++ b/tests/files/data/hr_sbi_act_nr.ndjson
@@ -1,0 +1,2 @@
+{"sbiActiviteitNummer": 12}
+{"sbiActiviteitNummer": 16}

--- a/tests/files/hr.json
+++ b/tests/files/hr.json
@@ -122,6 +122,7 @@
           },
           "sbiActiviteitNummer": {
             "type": "string",
+            "shortname": "sbiActNr",
             "description": "Samenstelling van KvK-nummer en/of Vestigingsnummer of {BSN- of RSIN-nummer}"
           }
         }

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -329,6 +329,19 @@ def test_ndjson_import_with_shortnames_in_schema(
     }
 
 
+def test_ndjson_import_with_shortnames_in_identifier(here, engine, hr_schema, dbsession):
+    """Prove that data for schemas with shortnames in an identifier is imported correctly."""
+    ndjson_path = here / "files" / "data" / "hr_sbi_act_nr.ndjson"
+    importer = NDJSONImporter(hr_schema, engine)
+    importer.generate_db_objects("sbiactiviteiten", truncate=True, ind_extra_index=False)
+    importer.load_file(ndjson_path)
+
+    records = [
+        dict(r) for r in engine.execute("SELECT * from hr_sbiactiviteiten ORDER BY sbi_act_nr")
+    ]
+    assert records == [{"sbi_act_nr": "12"}, {"sbi_act_nr": "16"}]
+
+
 def test_provenance_for_schema_field_ids_equal_to_ndjson_keys(
     here, engine, woonplaatsen_schema, dbsession
 ):


### PR DESCRIPTION
When a table identifier in an amsterdam schema definition
does have a shortname, the ndjson import is failing.

This commit fixes this behaviour by modifying incoming
records for those shortnamed identifiers.

The idea is that in the incoming ndjson the identifiers
that are used are always according to the amsterdam schema.
The shortname is a implementation detail, that should only
be used at the moment that records are prepared for
insertion into the sql database.