### PR TITLE
CheckConstraint for non-composite string identifiers enforcing absence of slashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ FROM amsterdam/python:3.9-buster
 WORKDIR /app
 COPY . ./
 RUN pip install -e ".[django,tests]"
+# So we can use local schemas
+RUN pip install git+https://github.com/Amsterdam/amsterdam-schema.git
 
 USER datapunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 # Start runtime image,
-FROM amsterdam/python:3.9-buster
+FROM amsterdam/python:3.9-slim-buster
+
+RUN apt update
+RUN apt-get update \
+ && apt-get autoremove -y \
+ && apt-get install --no-install-recommends -y \
+        libpq-dev \
+        python-dev \
+        gcc \
+        git
 
 WORKDIR /app
 COPY . ./
 RUN pip install -e ".[django,tests]"
 # So we can use local schemas
-RUN pip install git+https://github.com/Amsterdam/amsterdam-schema.git
+RUN git clone https://github.com/Amsterdam/amsterdam-schema.git /tmp/ams-schema
 
 USER datapunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Start runtime image,
 FROM amsterdam/python:3.9-slim-buster
 
-RUN apt update
 RUN apt-get update \
  && apt-get autoremove -y \
  && apt-get install --no-install-recommends -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
-# Start runtime image,
-FROM amsterdam/python:3.9-slim-buster
-
-RUN apt-get update \
- && apt-get autoremove -y \
- && apt-get install --no-install-recommends -y \
-        libpq-dev \
-        python-dev \
-        gcc \
-        git
+FROM amsterdam/python:3.9-buster
 
 WORKDIR /app
 COPY . ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,12 @@ services:
       - database
     environment:
       SECRET_KEY: insecure
+      # In order to use local datasets, run
+      # SCHEMA_URL=$(python -c 'import site; print(f"{site.getsitepackages()[0]}/amsterdam_schema/datasets")')
       SCHEMA_URL: https://schemas.data.amsterdam.nl/datasets/
       DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
+    env_file: .env
     volumes:
       - ".:/app"
-      # Uncomment (and adjust the location of) this mount to experiment with
-      # edited datasets from your local amsterdam-schema clone
-      # - "../amsterdam-schema/datasets:/tmp/datasets"
     command: >
       bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - database
     environment:
       SECRET_KEY: insecure
-      # In order to use local datasets, run
+      # In order to use local datasets
       SCHEMA_URL: /tmp/ams-schema/datasets
       DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
     env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       SECRET_KEY: insecure
       # In order to use local datasets, run
-      SCHEMA_URL: /tmp/ams-schema/amsterdam-schema/datasets
+      SCHEMA_URL: /tmp/ams-schema/datasets
       DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
     env_file: .env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
     environment:
       SECRET_KEY: insecure
       # In order to use local datasets, run
-      # SCHEMA_URL=$(python -c 'import site; print(f"{site.getsitepackages()[0]}/amsterdam_schema/datasets")')
-      SCHEMA_URL: https://schemas.data.amsterdam.nl/datasets/
+      SCHEMA_URL: /tmp/ams-schema/amsterdam-schema/datasets
       DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
     env_file: .env
     volumes:


### PR DESCRIPTION
fixes [AB#38356](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/38356)

This will only work for newly imported tables. In order to apply this to existing datasets, they need to be dropped and re-imported.