### PR TITLE
Revert "Intergrate django-db-comments into `create_tables` mgm. command"

### DIFF
--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -20,7 +20,7 @@ def test_model_factory_fields(afval_dataset) -> None:
     table = afval_dataset.schema.tables[0]
     model_cls = model_factory(afval_dataset, table, base_app_name="dso_api.dynamic_api")
     meta = model_cls._meta
-    assert meta.verbose_name == "Containers title | Containers description"
+    assert meta.verbose_name == "Containers title"
     assert {f.name for f in meta.get_fields()} == {
         "id",
         "cluster",
@@ -41,12 +41,7 @@ def test_model_factory_fields(afval_dataset) -> None:
     assert geo_field.db_index
     assert meta.app_label == afval_dataset.schema.id
 
-    # Title and description
     assert meta.get_field("eigenaar_naam").verbose_name == "Naam eigenaar"
-    assert meta.get_field("eigenaar_naam").help_text == "Naam van de eigenaar"
-    # Description only
-    assert meta.get_field("datum_creatie").verbose_name == ""
-    assert meta.get_field("datum_creatie").help_text == "Datum aangemaakt"
 
     table_with_id_as_string = afval_dataset.schema.tables[1]
     model_cls = model_factory(

--- a/tests/files/afval.json
+++ b/tests/files/afval.json
@@ -8,7 +8,6 @@
     {
       "id": "containers",
       "title": "Containers title",
-      "description": "Containers description",
       "type": "table",
       "version": "1.0.0",
       "schema": {
@@ -38,7 +37,7 @@
           "eigenaar naam": {
             "type": "string",
             "title": "Naam eigenaar",
-            "description": "Naam van de eigenaar"
+            "description": "Naam van eigenaar"
           },
           "datum creatie": {
             "type": "string",


### PR DESCRIPTION
This reverts commit b4dcf8983dc6bbf2c66ed8d76039847cbbebeda6 as a hotfix for [AB#44268](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/44268). import_schemas --create-tables fails on an id column that does not exist. I cannot reproduce this locally as I hit a different bug earlier in the process:

    django.core.exceptions.FieldError: Cannot resolve keyword 'sbiActiviteitNummer' into field...

Skipping this doesn't do much as many datasets have this issue. No idea what's going wrong here.