### PR TITLE
Add bandit security linter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
       - id: black
         additional_dependencies:
           - click==8.0.2  # Pin click, latest version is missing `_unicodefun` needed by black
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        args: [--quiet, --exclude, tests]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -157,7 +157,11 @@ def views_factory(dataset: DatasetSchema, tables: Dict[str, Table]) -> Dict[str,
         to_snake_case(dst.name): dst
         for dst in dataset.get_tables(include_nested=True, include_through=True)
     }
-    assert set(dataset_tables) == set(tables)  # noqa: S101
+    if set(dataset_tables) != set(tables):
+        raise ValueError(
+            f"mismatch: dataset_tables has {set(dataset_tables)}, tables has {set(tables)}"
+        )
+
     CREATE_VIEW = sql.SQL(
         """
         CREATE OR REPLACE VIEW "public".{view_name} AS

--- a/src/schematools/maps/interfaces/mapfile/serializers.py
+++ b/src/schematools/maps/interfaces/mapfile/serializers.py
@@ -34,7 +34,7 @@ class JinjaSerializer:
 
     @property
     def env(self) -> Environment:
-        env = Environment(loader=FileSystemLoader(self.template_dir))
+        env = Environment(loader=FileSystemLoader(self.template_dir))  # nosec
         env.trim_blocks = True
         env.lstrip_blocks = True
         return env

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1086,8 +1086,8 @@ class DatasetTableSchema(SchemaType):
             len(db_table_name),
             MAX_TABLE_NAME_LENGTH,
         )
-        if check_assert:
-            assert len(db_table_name) <= MAX_TABLE_NAME_LENGTH, (
+        if check_assert and len(db_table_name) > MAX_TABLE_NAME_LENGTH:
+            raise ValueError(
                 f"table name {db_table_name!r} is too long, having {len(db_table_name)} chars. "
                 f"Max allowed length is {MAX_TABLE_NAME_LENGTH} chars."
             )

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -221,11 +221,13 @@ def _active_versions(dataset: DatasetSchema) -> Iterator[str]:
     # etc) more definitely. And as a result can rely on those abstractions for our
     # validation instead of some internal representation.
     for tv in dataset["tables"]:
-        assert isinstance(  # noqa: S101
-            tv, TableVersions
-        ), 'Someone messed with the internal representation of DatasetSchema["tables"].'
+        if not isinstance(tv, TableVersions):
+            raise TypeError(
+                'Someone messed with the internal representation of DatasetSchema["tables"].'
+            )
         for version, table in tv.active.items():
-            assert isinstance(table, dict)  # noqa: S101
+            if not isinstance(table, dict):
+                raise TypeError(f"table is a {type(table).__name__} instead of a dict")
             if tv.id != table["id"]:
                 yield (
                     f"Table {tv.id!r} with version number '{version}' does not match with "


### PR DESCRIPTION
For [AB#46681](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/46681). Also fixed some errors that it found and added a "nosec" annotation to the final one: a jinja2.Environment was created with HTML/XML autoescaping off. We're not generating XML here, though.