### PR TITLE
Yrob/get all dataset scopes function

### DIFF
--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -152,7 +152,7 @@ def set_dataset_write_permissions(
         table_name = table.db_name()
         if is_remote(table_name):
             continue
-        table_privileges = ["INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES"]
+        table_privileges = ["SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES"]
         _execute_grant(
             session,
             grant(


### PR DESCRIPTION
* TA refactor that some logic from set_dataset_permissions() into a
separate function get_all_dataset_scopes(). This logic determines all
database scopes that should be applied to the tables of a dataset
from its schema.

* Dataset write scopes get SELECT on the tables they can write to