### PR TITLE
Make name of the check constraint more specific

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.6.4
+version = 3.6.5
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -465,8 +465,8 @@ def model_factory(
         if field.is_primary and field.type == "string":
             constraints.append(
                 CheckConstraint(
-                    check=~Q(**{f"{field_name}__contains": "/"}),
-                    name=f"{field.name}_not_contains_slash",
+                    check=~Q(**{f"{field.name}__contains": "/"}),
+                    name=f"{dataset.name}_{table_schema.name}_{field.name}_not_contains_slash",
                 )
             )
 

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -351,6 +351,6 @@ def test_non_composite_string_identifiers_use_slash_constraints(parkeervakken_da
 
     with pytest.raises(
         IntegrityError,
-        match=r'^new row for relation "parkeervakken_parkeervakken" violates check constraint "id_not_contains_slash".*',
+        match=r'^new row for relation "parkeervakken_parkeervakken" violates check constraint "parkeervakken_parkeervakken_id_not_contains_slash".*',
     ):
         model.objects.create(id="forbidden/slash")


### PR DESCRIPTION
The check constraint for slashes in ids is not unique
over the datasets. Django checks borks on this.
