### PR TITLE
AB#39233 permissions revoke error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.6.5
+version = 3.6.6
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -165,10 +165,11 @@ def permissions_introspect(db_url: str, role: str) -> None:
 @permissions.command("revoke")
 @option_db_url
 @argument_role
-def permissions_revoke(db_url: str, role: str) -> None:
+@click.option("-v", "--verbose", count=True)
+def permissions_revoke(db_url: str, role: str, verbose: int) -> None:
     """Revoke all table select priviliges for role."""
     engine = _get_engine(db_url)
-    revoke_permissions(engine, role)
+    revoke_permissions(engine, role, verbose=verbose)
 
 
 @permissions.command("apply")
@@ -235,6 +236,7 @@ def permissions_revoke(db_url: str, role: str) -> None:
     default=False,
     help="Before granting new permissions, revoke first all previous table and column permissions",
 )
+@click.option("-v", "--verbose", count=True)
 def permissions_apply(
     db_url: str,
     schema_url: str,
@@ -247,9 +249,10 @@ def permissions_apply(
     scope: str,
     execute: bool,
     create_roles: bool,
-    revoke: bool,
     set_read_permissions: bool,
     set_write_permissions: bool,
+    revoke: bool,
+    verbose: int,
 ) -> None:
     """Set permissions for a postgres role.
 
@@ -290,6 +293,7 @@ def permissions_apply(
             dry_run,
             create_roles,
             revoke,
+            verbose=verbose,
         )
     else:
         click.echo(

--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from pg_grant import PgObjectType, parse_acl_item, query
 from pg_grant.sql import grant, revoke
-from psycopg2.errors import UndefinedTable
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -472,21 +472,18 @@ class TestWritePermissions:
         #  It is now possible to INSERT data into the dataset tables
         _check_insert_permission_granted(engine, "testuser", "gebieden_bouwblokken", "id", "'abc'")
 
-        #  The write_ roles do not have SELECT permissions, therefore testuser should not have it
-        _check_select_permission_denied(engine, "testuser", "gebieden_bouwblokken")
+        #  The write_ roles do have SELECT permissions, therefore testuser should not have it
+        _check_select_permission_granted(engine, "testuser", "gebieden_bouwblokken")
 
-        #  Without SELECT it is not possible to UPDATE or DELETE on given condition
-        _check_update_permission_denied(
+        #  With SELECT it is possible to UPDATE or DELETE on given condition
+        _check_update_permission_granted(
             engine, "testuser", "gebieden_bouwblokken", "id", "'def'", "id = 'abc'"
         )
-        _check_delete_permission_denied(engine, "testuser", "gebieden_bouwblokken", "id = 'abc'")
+        _check_delete_permission_granted(engine, "testuser", "gebieden_bouwblokken", "id = 'abc'")
 
         # Add SELECT permissions by granting the appropriate scope to the user
         with engine.begin() as connection:
             connection.execute("GRANT scope_level_b TO testuser")
-
-        # Still not possible to SELECT * because not all columns are within scope
-        _check_select_permission_denied(engine, "testuser", "gebieden_bouwblokken", "*")
 
         # But now it's possible to SELECT the columns within scope level_b
         _check_select_permission_granted(


### PR DESCRIPTION
On Azure, not every schema has an associated PostgreSQL table. The `schema permissions apply` was crashing on this.
Now, the code is catching these exceptions and only issues a warning (a Notice from PostgreSQL).

Furthermore, the cli command is now less chatty by default.
