### PR TITLE
Upgrade type annotations to modern Python format

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -1,9 +1,10 @@
 """Cli tools."""
+from __future__ import annotations
 
 import logging
 import sys
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Tuple
+from typing import Any, DefaultDict, Iterable
 
 import click
 import jsonschema
@@ -92,7 +93,7 @@ argument_role = click.argument(
 )
 
 
-def _get_engine(db_url: str, pg_schemas: Optional[List[str]] = None) -> sqlalchemy.engine.Engine:
+def _get_engine(db_url: str, pg_schemas: list[str] | None = None) -> sqlalchemy.engine.Engine:
     """Initialize the SQLAlchemy engine, and report click errors."""
     kwargs = {}
     if pg_schemas is not None:
@@ -112,7 +113,7 @@ def main() -> None:
     """
     try:
         schema()
-    except (EnvironmentError, SQLAlchemyError, ParserError) as e:
+    except (OSError, SQLAlchemyError, ParserError) as e:
         click.echo(f"{e.__class__.__name__}: {e}", err=True)
         exit(1)
 
@@ -319,7 +320,7 @@ def diff() -> None:
     pass
 
 
-def _fetch_json(location: str) -> Dict[str, Any]:
+def _fetch_json(location: str) -> dict[str, Any]:
     """Fetch JSON from file or URL.
 
     Args:
@@ -350,7 +351,7 @@ def _fetch_json(location: str) -> Dict[str, Any]:
 )
 @click.argument("meta_schema_url")
 def validate(
-    schema_url: str, dataset_id: str, additional_schemas: List[str], meta_schema_url: str
+    schema_url: str, dataset_id: str, additional_schemas: list[str], meta_schema_url: str
 ) -> None:
     """Validate a schema against the Amsterdam Schema meta schema.
 
@@ -393,7 +394,7 @@ def validate(
 @schema.command()
 @click.argument("meta_schema_url")
 @click.argument("schema_files", nargs=-1)
-def batch_validate(meta_schema_url: str, schema_files: Tuple[str]) -> None:
+def batch_validate(meta_schema_url: str, schema_files: tuple[str]) -> None:
     """Batch validate schema's.
 
     This command was tailored so that it could be run from a pre-commit hook. As a result,
@@ -408,7 +409,7 @@ def batch_validate(meta_schema_url: str, schema_files: Tuple[str]) -> None:
         SCHEMA_FILES: one or more schema files to be validated
     """  # noqa: D301,D412,D417
     meta_schema = _fetch_json(meta_schema_url)
-    errors: DefaultDict[str, List[str]] = defaultdict(list)
+    errors: DefaultDict[str, list[str]] = defaultdict(list)
     for schema in schema_files:
         try:
             dataset = dataset_schema_from_path(schema)
@@ -594,7 +595,7 @@ def _get_dataset_schema(
         raise click.ClickException(e)
 
 
-def _get_all_dataset_schemas(schema_url: str) -> Dict[str, DatasetSchema]:
+def _get_all_dataset_schemas(schema_url: str) -> dict[str, DatasetSchema]:
     """Find all the dataset schemas for the given schema_url.
 
     Args:
@@ -670,7 +671,7 @@ def create_sql(versioned: bool, db_url: str, schema_path: str) -> None:
 )
 @click.argument("dataset_id", required=False)
 def create_all_objects(
-    db_url: str, schema_url: str, exclude: List[str], dataset_id: Optional[str]
+    db_url: str, schema_url: str, exclude: list[str], dataset_id: str | None
 ) -> None:
     """Execute SQLalchemy Index (Identifier fields) and Table objects.
 

--- a/src/schematools/contrib/django/app_config.py
+++ b/src/schematools/contrib/django/app_config.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from types import ModuleType
-from typing import Dict, Optional, Type
 
 from django.apps import apps
 from django.apps import config as apps_config
@@ -20,7 +21,7 @@ class VirtualAppConfig(apps_config.AppConfig):
         """Patch this object for virtual apps."""
         super().__init__(app_name, app_module)
         # Make django think that App is initiated already.
-        self.models: Dict[str, Type[models.Model]] = {}
+        self.models: dict[str, type[models.Model]] = {}
         # Path is required for Django to think this APP is real.
         self.path = os.path.dirname(__file__)
         self.apps = apps
@@ -39,17 +40,17 @@ class VirtualAppConfig(apps_config.AppConfig):
 
         self.ready()
 
-    def _path_from_module(self, module: ModuleType) -> Optional[str]:
+    def _path_from_module(self, module: ModuleType) -> str | None:
         """Disable OS loading for this App Config."""
         return None
 
-    def register_model(self, model: Type[models.Model]) -> None:
+    def register_model(self, model: type[models.Model]) -> None:
         """Register model in django registry and update models."""
         self.apps.register_model(self.label, model)
         self.models = self.apps.all_models[self.label]
 
 
-def register_model(dataset_id: str, model: Type[models.Model]) -> None:
+def register_model(dataset_id: str, model: type[models.Model]) -> None:
     """Register the model in django.apps."""
     try:
         app_config = apps.app_configs[dataset_id]

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Collection, Dict, Tuple, Type, TypeVar
 from urllib.parse import urlparse
 
 from django.apps import apps
@@ -172,7 +172,7 @@ class FKRelationMaker(RelationMaker):
             # as Django still uses the backwards relation internally.
             return "+"
 
-    def _get_to_field_name(self) -> Optional[str]:
+    def _get_to_field_name(self) -> str | None:
         """Determine the "to_field" for the foreign key.
 
         This returns a value when the relation doesn't point to the targets's primary key,
@@ -258,9 +258,9 @@ class FieldMaker:
 
     def __init__(
         self,
-        field_cls: Type[models.Field],
+        field_cls: type[models.Field],
         table_schema: DatasetTableSchema,
-        value_getter: Callable[[DatasetSchema], Dict[str, Any]] = None,
+        value_getter: Callable[[DatasetSchema], dict[str, Any]] = None,
         **kwargs,
     ):
         self.field_cls = field_cls
@@ -383,17 +383,17 @@ def remove_dynamic_models() -> None:
     MODEL_CREATION_COUNTER += 1
 
 
-def is_dangling_model(model: Type[DynamicModel]) -> bool:
+def is_dangling_model(model: type[DynamicModel]) -> bool:
     """Tell whether the model should have been removed, as everything reloaded."""
     return model.CREATION_COUNTER < MODEL_CREATION_COUNTER
 
 
 def schema_models_factory(
     dataset: Dataset,
-    tables: Optional[Collection[str]] = None,
-    base_app_name: Optional[str] = None,
-    base_model: Type[M] = DynamicModel,
-) -> List[Type[M]]:
+    tables: Collection[str] | None = None,
+    base_app_name: str | None = None,
+    base_model: type[M] = DynamicModel,
+) -> list[type[M]]:
     """Generate Django models from the data of the schema."""
     return [
         model_factory(
@@ -410,9 +410,9 @@ def schema_models_factory(
 def model_factory(
     dataset: Dataset,
     table_schema: DatasetTableSchema,
-    base_app_name: Optional[str] = None,
-    base_model: Type[M] = DynamicModel,
-) -> Type[M]:
+    base_app_name: str | None = None,
+    base_model: type[M] = DynamicModel,
+) -> type[M]:
     """Generate a Django model class from a JSON Schema definition."""
     dataset_schema = dataset.schema
     app_label = dataset_schema.id

--- a/src/schematools/contrib/django/management/commands/dump_models.py
+++ b/src/schematools/contrib/django/management/commands/dump_models.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import inspect
 import textwrap
 from argparse import ArgumentParser
 from datetime import date, datetime
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from django.apps import AppConfig, apps
 from django.core.management import BaseCommand
@@ -18,7 +20,7 @@ class Command(BaseCommand):
 
     help = "Dump the (dynamic) model definitions that Django holds in-memory."  # noqa: A003
 
-    model_meta_args: List[Tuple[str, Any]] = [
+    model_meta_args: list[tuple[str, Any]] = [
         # All possible options in Meta, with their defaults.
         # https://docs.djangoproject.com/en/3.2/ref/models/options/
         # The original model.Meta or Options.meta is not available after construction,
@@ -43,7 +45,7 @@ class Command(BaseCommand):
         ("verbose_name_plural", ""),  # is {modelname}s by default
     ]
 
-    path_aliases: List[Tuple[str, str]] = [
+    path_aliases: list[tuple[str, str]] = [
         ("django.db.models.", "models."),
         ("django.contrib.gis.db.models.fields.", ""),
         ("django_postgres_unlimited_varchar.", ""),
@@ -70,7 +72,7 @@ class Command(BaseCommand):
         """Write app start header."""
         self.stdout.write(f"# ---- App: {app.verbose_name or app.label}\n\n\n")
 
-    def write_model(self, model: Type[models.Model]) -> None:
+    def write_model(self, model: type[models.Model]) -> None:
         """Write the representation of a complete Django model to the output."""
         bases = ", ".join(base_class.__name__ for base_class in model.__bases__)
         self.stdout.write(f"class {model.__name__}({bases}):\n")
@@ -113,7 +115,7 @@ class Command(BaseCommand):
                 doc += "\n"
         self.stdout.write(f'    """{doc}"""\n\n')
 
-    def write_dynamic_model_attrs(self, model: Type[DynamicModel]) -> None:
+    def write_dynamic_model_attrs(self, model: type[DynamicModel]) -> None:
         """Write the attributes defined by model_factory() for completeness."""
         self.stdout.write("    # Set by model_factory()\n")
         self.stdout.write(f"    # _dataset = {model._dataset!r}\n")
@@ -123,7 +125,7 @@ class Command(BaseCommand):
             self.stdout.write("    _is_temporal = True\n")
         self.stdout.write("\n")
 
-    def write_model_meta(self, model: Type[models.Model]) -> None:
+    def write_model_meta(self, model: type[models.Model]) -> None:
         """Write the 'class Meta' section."""
         self.stdout.write("    class Meta:\n")
         for meta_arg, default in self.model_meta_args:
@@ -131,7 +133,7 @@ class Command(BaseCommand):
             if value != default:
                 self.stdout.write(f"        {meta_arg} = {value!r}\n")
 
-    def write_model_str(self, model: Type[DynamicModel]) -> None:
+    def write_model_str(self, model: type[DynamicModel]) -> None:
         """For dynamic model, we know how __str__() looks like."""
         self.stdout.write("\n")
         self.stdout.write("    def __str__(self):\n")
@@ -148,7 +150,7 @@ class Command(BaseCommand):
         name, path, args, kwargs = field.deconstruct()
         return self._get_deconstructable_repr(path, args, kwargs)
 
-    def _get_deconstructable_repr(self, path: str, args: List[Any], kwargs: Dict[str, Any]) -> str:
+    def _get_deconstructable_repr(self, path: str, args: list[Any], kwargs: dict[str, Any]) -> str:
         for prefix, alias in self.path_aliases:
             if path.startswith(prefix):
                 path = alias + path[len(prefix) :]
@@ -182,7 +184,7 @@ class Command(BaseCommand):
             return self._get_deconstructable_repr(*value.deconstruct())
         elif isinstance(value, list):
             # for validators=[...]
-            return "[{0}]".format(",".join(self._format_value(v) for v in value))
+            return "[{}]".format(",".join(self._format_value(v) for v in value))
         elif callable(value):
             if value is datetime.now:
                 return "datetime.now"
@@ -207,5 +209,5 @@ class Command(BaseCommand):
         return repr(value)
 
 
-def _format_model_name(model: Type[models.Model]) -> str:
+def _format_model_name(model: type[models.Model]) -> str:
     return f"{model._meta.app_label}.{model._meta.model_name}"

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -16,7 +16,7 @@ import json
 import logging
 import re
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Tuple, Type, TypeVar
 
 from django.apps import apps
 from django.conf import settings
@@ -69,7 +69,7 @@ class ObjectMarker:
     pass
 
 
-def _fetch_srid(dataset: DatasetSchema, field: DatasetFieldSchema) -> Dict[str, Any]:
+def _fetch_srid(dataset: DatasetSchema, field: DatasetFieldSchema) -> dict[str, Any]:
     return {"srid": CRS.from_string(dataset.data["crs"]).srid}
 
 
@@ -171,7 +171,7 @@ class DynamicModel(models.Model):
 
     @classmethod
     def get_field_schema(
-        cls, model_field: Union[models.Field, models.ForeignObjectRel]
+        cls, model_field: models.Field | models.ForeignObjectRel
     ) -> DatasetFieldSchema:
         """Provide access to the underlying amsterdam schema field that created the model field."""
         if isinstance(model_field, models.ForeignObjectRel):
@@ -213,7 +213,7 @@ class DynamicModel(models.Model):
         return cls._display_field is not None
 
     @classmethod
-    def get_display_field(cls) -> Optional[str]:
+    def get_display_field(cls) -> str | None:
         """Return the name of the display field, for usage by Django models."""
         return cls._display_field
 
@@ -274,7 +274,7 @@ class Dataset(models.Model):
         return name
 
     @classmethod
-    def create_for_schema(cls, schema: DatasetSchema, path: Optional[str] = None) -> Dataset:
+    def create_for_schema(cls, schema: DatasetSchema, path: str | None = None) -> Dataset:
         """Create the schema based on the Amsterdam Schema JSON input"""
         name = cls.name_from_schema(schema)
         if path is None:
@@ -373,8 +373,8 @@ class Dataset(models.Model):
         )
 
     def create_models(
-        self, base_app_name: Optional[str] = None, base_model: Type[M] = DynamicModel
-    ) -> List[Type[M]]:
+        self, base_app_name: str | None = None, base_model: type[M] = DynamicModel
+    ) -> list[type[M]]:
         """Extract the models found in the schema"""
         from schematools.contrib.django.factories import schema_models_factory
 
@@ -567,7 +567,7 @@ class LooseRelationField(models.CharField):
     @property
     def related_model(self):
         """Add ``related_model`` like all other Django relational fields do."""
-        dataset_name, table_name, *_ = [to_snake_case(part) for part in self.relation.split(":")]
+        dataset_name, table_name, *_ = (to_snake_case(part) for part in self.relation.split(":"))
         return apps.all_models[dataset_name][table_name]
 
 
@@ -622,9 +622,7 @@ class LooseRelationManyToManyField(models.ManyToManyField):
     pass
 
 
-def get_field_schema(
-    model_field: Union[models.Field, models.ForeignObjectRel]
-) -> DatasetFieldSchema:
+def get_field_schema(model_field: models.Field | models.ForeignObjectRel) -> DatasetFieldSchema:
     # Backwards compatibility code.
     warnings.warn(
         "get_field_schema() is deprecated, use DynamicModel.get_field_schema() instead",

--- a/src/schematools/datasetcollection.py
+++ b/src/schematools/datasetcollection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from more_ds.network.url import URL
@@ -24,8 +24,8 @@ class DatasetCollection(metaclass=Singleton):
     """
 
     def __init__(self) -> None:  # noqa: D107
-        self.datasets_cache: Dict[str, DatasetSchema] = {}
-        self._schema_loader: Optional[loaders.SchemaLoader] = None
+        self.datasets_cache: dict[str, DatasetSchema] = {}
+        self._schema_loader: loaders.SchemaLoader | None = None
 
     @property
     def schema_loader(self) -> loaders.SchemaLoader:
@@ -62,12 +62,12 @@ class DatasetCollection(metaclass=Singleton):
             self.add_dataset(dataset)
             return dataset
 
-    def get_all_datasets(self) -> Dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
         """Gets all the datasets using the configured schema loader."""
         return self.schema_loader.get_all_datasets()
 
 
-def set_schema_loader(schema_url: Union[URL, str]) -> None:
+def set_schema_loader(schema_url: URL | str) -> None:
     """Initialize the schema loader at module load time.
 
     schema_url:
@@ -75,7 +75,7 @@ def set_schema_loader(schema_url: Union[URL, str]) -> None:
         can be a web url, or a filesystem path.
     """
     dataset_collection = DatasetCollection()
-    loader: Optional[loaders.SchemaLoader] = None  # pleasing mypy
+    loader: loaders.SchemaLoader | None = None  # pleasing mypy
     if urlparse(schema_url).scheme in ("http", "https"):
         loader = loaders.URLSchemaLoader(schema_url)
     else:

--- a/src/schematools/events/consumer.py
+++ b/src/schematools/events/consumer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import List
 
 from confluent_kafka import Consumer, Message
 from sqlalchemy.engine import Connection
@@ -43,7 +42,7 @@ def _fetch_consumer_params() -> dict:
 
 
 def consume_events(
-    dataset_schemas: List[DatasetSchema],
+    dataset_schemas: list[DatasetSchema],
     srid: str,
     connection: Connection,
     topics: tuple(str),
@@ -85,7 +84,7 @@ def consume_events(
                 logger.debug("Waiting for message or event/error in poll()")
                 continue
             elif msg.error():
-                logger.error("error: {}".format(msg.error()))
+                logger.error(f"error: {msg.error()}")
             else:
                 process_message(importer, msg)
     except KeyboardInterrupt:

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, List
 
 from sqlalchemy.engine import Connection
 
@@ -61,7 +60,7 @@ class DataSplitter:
         relational_data, self.row_data = self._split_data(event_data)
         self.process_relational_data(relational_data)
 
-    def _split_data(self, event_data: dict) -> List[dict]:
+    def _split_data(self, event_data: dict) -> list[dict]:
         """Split the event_data in 2 parts, one with scalars, the other with relations."""
         data_bags = [{}, {}]
         for field in self.dataset_table.fields:
@@ -101,7 +100,7 @@ class DataSplitter:
 
         # id for target side of relation
         if field_data:
-            id_value = ".".join((str(field_data[fn]) for fn in target_identifier_fields))
+            id_value = ".".join(str(field_data[fn]) for fn in target_identifier_fields)
         else:
             id_value = None
 
@@ -111,7 +110,7 @@ class DataSplitter:
 
         self.row_data.update(fk_row_data)
 
-    def _fetch_target_identifier_fields(self, relation: str) -> List[str]:
+    def _fetch_target_identifier_fields(self, relation: str) -> list[str]:
         """Fetch the identifier fields for the target side of a relation.
 
         These fields will be ordered with the main identifier first, and
@@ -163,7 +162,7 @@ class DataSplitter:
             nm_row_data[snaked_source_table_id] = id_value
 
             # id for target side of relation
-            target_id_value = ".".join((str(row_data[fn]) for fn in target_identifier_fields))
+            target_id_value = ".".join(str(row_data[fn]) for fn in target_identifier_fields)
             nm_row_data[f"{snaked_field_id}_id"] = target_id_value
 
             # PK field, needed by Django
@@ -212,7 +211,7 @@ class EventsProcessor:
 
     def __init__(
         self,
-        datasets: List[DatasetSchema],
+        datasets: list[DatasetSchema],
         srid: str,
         connection: Connection,
         local_metadata=None,
@@ -230,7 +229,7 @@ class EventsProcessor:
                 in unit tests.
             truncate: indicates if the relational tables need to be truncated
         """
-        self.datasets: Dict[str, DatasetSchema] = {ds.id: ds for ds in datasets}
+        self.datasets: dict[str, DatasetSchema] = {ds.id: ds for ds in datasets}
         self.srid = srid
         self.conn = connection
         _metadata = local_metadata or metadata  # mainly for testing

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -1,6 +1,7 @@
 """Module to hold factories."""
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Dict, Optional, Set
 
 from psycopg2 import sql
 from sqlalchemy import Column, MetaData, Table
@@ -13,12 +14,12 @@ from schematools.utils import to_snake_case
 
 def tables_factory(
     dataset: DatasetSchema,
-    metadata: Optional[MetaData] = None,
-    db_table_names: Optional[Dict[str, Optional[str]]] = None,
-    db_schema_names: Optional[Dict[str, Optional[str]]] = None,
-    limit_tables_to: Optional[Set] = None,
+    metadata: MetaData | None = None,
+    db_table_names: dict[str, str | None] | None = None,
+    db_schema_names: dict[str, str | None] | None = None,
+    limit_tables_to: set | None = None,
     is_versioned_dataset: bool = False,
-) -> Dict[str, Table]:
+) -> dict[str, Table]:
     """Generate the SQLAlchemy Table objects base on a `DatasetSchema` definition.
 
     Args:
@@ -136,7 +137,7 @@ def tables_factory(
     return tables
 
 
-def views_factory(dataset: DatasetSchema, tables: Dict[str, Table]) -> Dict[str, sql.SQL]:
+def views_factory(dataset: DatasetSchema, tables: dict[str, Table]) -> dict[str, sql.SQL]:
     """Create VIEW statements.
 
     The views these statements define are there to provide the illusion that the tables they
@@ -153,7 +154,7 @@ def views_factory(dataset: DatasetSchema, tables: Dict[str, Table]) -> Dict[str,
 
     Returns: A dict mapping table names to VIEW statements.
     """
-    dataset_tables: Dict[str, DatasetTableSchema] = {
+    dataset_tables: dict[str, DatasetTableSchema] = {
         to_snake_case(dst.name): dst
         for dst in dataset.get_tables(include_nested=True, include_through=True)
     }
@@ -169,7 +170,7 @@ def views_factory(dataset: DatasetSchema, tables: Dict[str, Table]) -> Dict[str,
           FROM {src_schema}.{src_table};
         """
     )
-    views: Dict[str, sql.SQL] = {
+    views: dict[str, sql.SQL] = {
         tn: CREATE_VIEW.format(
             view_name=sql.Identifier(dataset_tables[tn].db_name()),
             src_schema=sql.Identifier(tables[tn].schema),

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 from pathlib import PosixPath
-from typing import Any, Callable, Dict, Iterator, List, Optional, cast
+from typing import Any, Callable, Iterator, List, cast
 
 import ndjson
 from shapely.geometry import shape
@@ -18,7 +20,7 @@ class NDJSONImporter(BaseImporter):
 
     def _get_through_fields_mapper(
         self, dataset_table: DatasetTableSchema
-    ) -> Optional[Callable[[Row], Row]]:
+    ) -> Callable[[Row], Row] | None:
         """Maps fields in ndjson to proper fieldnames and structure.
 
         When through tables (1-N and NM relations) are imported directly
@@ -81,10 +83,10 @@ class NDJSONImporter(BaseImporter):
         self,
         file_name: PosixPath,
         dataset_table: DatasetTableSchema,
-        db_table_name: Optional[str] = None,
+        db_table_name: str | None = None,
         is_through_table: bool = False,
         **kwargs: Any,
-    ) -> Iterator[Dict[str, List[Row]]]:
+    ) -> Iterator[dict[str, list[Row]]]:
         """Provide an iterator the reads the NDJSON records."""
         fields_provenances = kwargs.pop("fields_provenances", {})
         identifier = dataset_table.identifier

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING
 
 from more_ds.network.url import URL
 
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 class SchemaLoader:
     """Base class for schema loaders."""
 
-    def __init__(self, schema_url: Union[Path, URL, str]):
+    def __init__(self, schema_url: Path | URL | str):
         """Initialize the schema loader.
 
         schema_url:
             Either a web url to the dataset schemas, or a path on the local filesystem.
         """
-        self.schema_url: Union[Path, URL] = (
+        self.schema_url: Path | URL = (
             schema_url if isinstance(schema_url, Path) else URL(schema_url)
         )
 
@@ -28,7 +28,7 @@ class SchemaLoader:
         """Gets a dataset for dataset_id."""
         raise NotImplementedError
 
-    def get_all_datasets(self) -> Dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
         """Gets all datasets from the schema_url location."""
         raise NotImplementedError
 
@@ -49,7 +49,7 @@ class FileSystemSchemaLoader(SchemaLoader):
         except FileNotFoundError as e:
             raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from e
 
-    def get_all_datasets(self) -> Dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
         """Gets all datasets from the filesystem based on the `self.schema_url` path."""
         from schematools.utils import dataset_schemas_from_schemas_path
 
@@ -70,7 +70,7 @@ class URLSchemaLoader(SchemaLoader):
         except KeyError:
             raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from None
 
-    def get_all_datasets(self) -> Dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> dict[str, DatasetSchema]:
         """Gets all datasets from a web url based on the `self.schema_url` path."""
         from schematools.utils import dataset_schemas_from_url
 

--- a/src/schematools/maps/interfaces/json_.py
+++ b/src/schematools/maps/interfaces/json_.py
@@ -29,7 +29,7 @@ class JsonStrategicLoader(jsonref.JsonLoader):
 
 def local_strategy(uri: str) -> str:
     if uri.startswith("./"):
-        return open(uri, "r").read()
+        return open(uri).read()
     raise ValueError
 
 
@@ -42,6 +42,6 @@ def load(document_file: typing.IO[str], base_uri: str = "", loader=None, backend
 @click.argument("document_path", type=click.types.Path(), required=True)
 def main(document_path):
     base_uri = f"file://{os.path.dirname(os.path.realpath(document_path))}/"
-    with open(document_path, "r") as document:
+    with open(document_path) as document:
         result = load(document, base_uri)
         pprint.pprint(result)

--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -5,11 +5,11 @@ The other classes in this module ease to retrieval of permission objects.
 """
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional
+from typing import Iterable
 
 import methodtools
 
-from ..types import (
+from schematools.types import (
     DatasetFieldSchema,
     DatasetSchema,
     DatasetTableSchema,
@@ -41,9 +41,9 @@ class UserScopes:
 
     def __init__(
         self,
-        query_params: Dict[str, object],
+        query_params: dict[str, object],
         request_scopes: Iterable[str],
-        all_profiles: Optional[Iterable[ProfileSchema]] = None,
+        all_profiles: Iterable[ProfileSchema] | None = None,
     ):
         """Initialize the user scopes object.
 
@@ -59,7 +59,7 @@ class UserScopes:
         self._all_profiles = all_profiles
         self._scopes = set(request_scopes) | {PUBLIC_SCOPE}
 
-    def add_query_params(self, params: List[str]):
+    def add_query_params(self, params: list[str]):
         """Tell that the request has extra (implicit) parameters that are satisfied.
 
         For example, the detail URL of a resource already implicitly passes the
@@ -227,7 +227,7 @@ class UserScopes:
         return max_permission
 
     @methodtools.lru_cache()
-    def get_active_profile_datasets(self, dataset_id: str) -> List[ProfileDatasetSchema]:
+    def get_active_profile_datasets(self, dataset_id: str) -> list[ProfileDatasetSchema]:
         """Find all profiles that mention a dataset and match the scopes.
 
         This already checks whether the mandatory user scopes are set.
@@ -250,7 +250,7 @@ class UserScopes:
     @methodtools.lru_cache()
     def get_active_profile_tables(
         self, dataset_id: str, table_id: str
-    ) -> List[ProfileTableSchema]:
+    ) -> list[ProfileTableSchema]:
         """Find all profiles that mention a particular table and give access.
 
         This already checks whether the table passes the `mandatoryFilterSets` check,

--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -1,7 +1,9 @@
 """Create GRANT statements to give roles very specific access to the database."""
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union, cast, DefaultDict
+from typing import Any, DefaultDict, Dict, List, cast
 
 from pg_grant import PgObjectType, parse_acl_item, query
 from pg_grant.sql import grant, revoke
@@ -74,8 +76,8 @@ def revoke_permissions(engine: Engine, role: str, verbose: int = 0) -> None:
 def apply_schema_and_profile_permissions(
     engine: Engine,
     pg_schema: str,
-    ams_schema: Union[DatasetSchema, Dict[str, DatasetSchema]],
-    profiles: Dict[str, Any],
+    ams_schema: DatasetSchema | dict[str, DatasetSchema],
+    profiles: dict[str, Any],
     role: str,
     scope: str,
     set_read_permissions: bool = True,
@@ -126,7 +128,7 @@ def apply_schema_and_profile_permissions(
 def create_acl_from_profiles(
     engine: Engine,
     pg_schema: str,
-    profile_list: List[Dict[str, Any]],
+    profile_list: list[dict[str, Any]],
     role: str,
     scope: str,
     verbose: int = 0,
@@ -242,7 +244,7 @@ def get_all_dataset_scopes(
                     '
     """
 
-    def _fetch_grantees(scopes: frozenset[str]) -> List[str]:
+    def _fetch_grantees(scopes: frozenset[str]) -> list[str]:
         if role == "AUTO":
             grantees = [scope_to_role(scope) for scope in scopes]
         elif scope in scopes:
@@ -352,7 +354,7 @@ def set_dataset_read_permissions(
         If NM and nested relation fields (type `array` in the schema) have a scope `bar`
         the associated sub-table gets the grant `scope_bar`.
     """
-    grantee: Optional[str] = f"write_{to_snake_case(ams_schema.id)}"
+    grantee: str | None = f"write_{to_snake_case(ams_schema.id)}"
 
     grantee = None if role == "AUTO" else role
     if create_roles and grantee:
@@ -384,7 +386,7 @@ def set_dataset_read_permissions(
 def create_acl_from_schemas(
     session: Session,
     pg_schema: str,
-    schemas: Union[DatasetSchema, Dict[str, DatasetSchema]],
+    schemas: DatasetSchema | dict[str, DatasetSchema],
     role: str,
     scope: str,
     set_read_permissions: bool,
@@ -459,7 +461,7 @@ def _revoke_all_privileges_from_role(
     session: Session,
     pg_schema: str,
     role: str,
-    dataset: Optional[DatasetSchema] = None,
+    dataset: DatasetSchema | None = None,
     echo: bool = True,
     dry_run: bool = False,
 ) -> None:
@@ -493,7 +495,7 @@ def _revoke_all_privileges_from_role(
 def _revoke_all_privileges_from_read_and_write_roles(
     session: Session,
     pg_schema: str,
-    dataset: Optional[DatasetSchema] = None,
+    dataset: DatasetSchema | None = None,
     echo: bool = True,
     dry_run: bool = False,
 ) -> None:

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -6,7 +6,7 @@ import os
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Final, Match, Optional, Pattern, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Final, Match, Pattern, cast
 
 import requests
 from cachetools.func import ttl_cache
@@ -29,10 +29,10 @@ logger = logging.getLogger(__name__)
 
 @ttl_cache(ttl=16)  # type: ignore[misc]
 def dataset_schemas_from_url(
-    schemas_url: Union[URL, str],
-    dataset_name: Optional[str] = None,
+    schemas_url: URL | str,
+    dataset_name: str | None = None,
     prefetch_related: bool = False,
-) -> Dict[str, types.DatasetSchema]:
+) -> dict[str, types.DatasetSchema]:
     """Fetch all dataset schemas from a remote file (or single dataset if specified).
 
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
@@ -50,7 +50,7 @@ def dataset_schemas_from_url(
 
 
 def dataset_schema_from_url(
-    schemas_url: Union[URL, str],
+    schemas_url: URL | str,
     dataset_name: str,
     prefetch_related: bool = False,
 ) -> types.DatasetSchema:
@@ -63,7 +63,7 @@ def dataset_schema_from_url(
     )
 
 
-def profile_schemas_from_url(profiles_url: Union[URL, str]) -> Dict[str, types.ProfileSchema]:
+def profile_schemas_from_url(profiles_url: URL | str) -> dict[str, types.ProfileSchema]:
     """Fetch all profile schemas from a remote file.
 
     The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
@@ -71,7 +71,7 @@ def profile_schemas_from_url(profiles_url: Union[URL, str]) -> Dict[str, types.P
     return schemas_from_url(base_url=profiles_url, data_type=types.ProfileSchema)
 
 
-def dataset_paths_from_url(base_url: Union[URL, str]) -> Dict[str, str]:
+def dataset_paths_from_url(base_url: URL | str) -> dict[str, str]:
     """Fetch all dataset paths from a remote location.
 
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
@@ -84,12 +84,12 @@ def dataset_paths_from_url(base_url: Union[URL, str]) -> Dict[str, str]:
         return cast(Dict[str, str], response.json())
 
 
-def schemas_from_url(base_url: Union[URL, str], data_type: Type[types.ST]) -> Dict[str, types.ST]:
+def schemas_from_url(base_url: URL | str, data_type: type[types.ST]) -> dict[str, types.ST]:
     """Fetch all schema definitions from a remote file.
 
     The URL could be ``https://schemas.data.amsterdam.nl/datasets/``
     """
-    schema_lookup: Dict[str, types.ST] = {}
+    schema_lookup: dict[str, types.ST] = {}
     base_url = URL(base_url)
 
     with requests.Session() as connection:
@@ -107,8 +107,8 @@ def schemas_from_url(base_url: Union[URL, str], data_type: Type[types.ST]) -> Di
 
 
 def schema_from_url(
-    base_url: Union[URL, str],
-    data_type: Type[types.ST],
+    base_url: URL | str,
+    data_type: type[types.ST],
     dataset_id: str,
     prefetch_related: bool = False,
 ) -> types.ST:
@@ -141,7 +141,7 @@ def _schema_from_url_with_connection(
     connection: requests.Session,
     base_url: URL,
     dataset_path: str,
-    data_type: Type[types.ST],
+    data_type: type[types.ST],
 ) -> types.ST:
     """Fetch single schema from url with connection."""
     response = connection.get(base_url / dataset_path / "dataset")
@@ -179,14 +179,14 @@ def _schema_from_url_with_connection(
     reason="""The `dataset_schema_from_file` is replaced by `dataset_schema_from_path`.""",
 )
 def dataset_schema_from_file(
-    file_path: Union[Path, str], prefetch_related: bool = False
+    file_path: Path | str, prefetch_related: bool = False
 ) -> types.DatasetSchema:
     """Gets a dataset scheme from a file path."""
     return dataset_schema_from_path(file_path)
 
 
 def dataset_schema_from_path(
-    dataset_path: Union[Path, str],
+    dataset_path: Path | str,
 ) -> types.DatasetSchema:
     """Read a dataset schema from the filesystem.
 
@@ -225,7 +225,7 @@ def dataset_schema_from_path(
 
 def dataset_schema_from_id_and_schemas_path(
     dataset_id: str,
-    schemas_path: Union[Path, str],
+    schemas_path: Path | str,
     prefetch_related: bool = False,
 ) -> types.DatasetSchema:
     """Read a dataset schema from a file on local drive.
@@ -238,7 +238,7 @@ def dataset_schema_from_id_and_schemas_path(
     dataset_path = Path(schemas_path) / dataset_id / "dataset.json"
     dataset_schema: types.DatasetSchema = dataset_schema_from_path(dataset_path)
 
-    index: Dict[str, Path] = {}
+    index: dict[str, Path] = {}
 
     # Build the mapping from dataset -> path with jsonschema file
     if prefetch_related:
@@ -255,15 +255,13 @@ def dataset_schema_from_id_and_schemas_path(
     return dataset_schema
 
 
-def dataset_schemas_from_schemas_path(
-    schemas_path: Union[Path, str]
-) -> Dict[str, types.DatasetSchema]:
+def dataset_schemas_from_schemas_path(schemas_path: Path | str) -> dict[str, types.DatasetSchema]:
     """Read all datasets from the schemas_path.
 
     Args:
         schemas_path: Path to the filesystem location with the dataset schemas.
     """
-    schema_lookup: Dict[str, types.DatasetSchema] = {}
+    schema_lookup: dict[str, types.DatasetSchema] = {}
     for root, _, files in os.walk(schemas_path):
         if "dataset.json" in files:
             root_path = Path(root)
@@ -274,9 +272,9 @@ def dataset_schemas_from_schemas_path(
     return schema_lookup
 
 
-def profile_schema_from_file(filename: Union[Path, str]) -> Dict[str, types.ProfileSchema]:
+def profile_schema_from_file(filename: Path | str) -> dict[str, types.ProfileSchema]:
     """Read a profile schema from a file on local drive."""
-    with open(filename, "r") as file_handler:
+    with open(filename) as file_handler:
         schema_info = json.load(file_handler)
         return {schema_info["name"]: types.ProfileSchema.from_dict(schema_info)}
 
@@ -287,7 +285,7 @@ def profile_schema_from_file(filename: Union[Path, str]) -> Dict[str, types.Prof
     "out into separate files. Use something like "
     "`schematools.cli._get_dataset_schema` instead.",
 )
-def schema_fetch_url_file(schema_url_file: Union[URL, str]) -> Dict[str, Any]:
+def schema_fetch_url_file(schema_url_file: URL | str) -> dict[str, Any]:
     """Return schemadata from URL or File."""
     if not schema_url_file.startswith("http"):
         with open(schema_url_file) as f:

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -24,7 +24,7 @@ import operator
 import re
 from dataclasses import dataclass
 from functools import partial, wraps
-from typing import Callable, Iterator, List, Optional, Set, cast
+from typing import Callable, Iterator, Set, cast
 
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools.exceptions import SchemaObjectNotFound
@@ -58,7 +58,7 @@ class ValidationException(Exception):
         self.message = message
 
 
-_all: List[tuple[str, Callable[[DatasetSchema], Iterator[str]]]] = []
+_all: list[tuple[str, Callable[[DatasetSchema], Iterator[str]]]] = []
 
 
 def run(dataset: DatasetSchema) -> Iterator[ValidationError]:
@@ -103,7 +103,7 @@ def _camelcase(dataset: DatasetSchema) -> Iterator[str]:
                 yield error
 
 
-def _camelcase_ident(ident: str) -> Optional[str]:
+def _camelcase_ident(ident: str) -> str | None:
     if ident == "":
         return "empty identifier not allowed"
     camel = toCamelCase(to_snake_case(ident))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import json
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, ContextManager, Dict
+from typing import Any, ContextManager
 from urllib.parse import ParseResult, urlparse
 
 import pytest
@@ -171,7 +171,7 @@ class DummySessionMaker:
     """
 
     def __init__(self):
-        self.routes: Dict[URL, Json] = {}
+        self.routes: dict[URL, Json] = {}
 
     def add_route(self, path: URL, content: Json) -> None:
         self.routes[path] = content

--- a/tests/django/fixtures.py
+++ b/tests/django/fixtures.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from django.test import RequestFactory
 
 from schematools.contrib.django.factories import remove_dynamic_models
 from schematools.contrib.django.models import Dataset, Profile

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -277,7 +277,7 @@ def test_table_shortname(verblijfsobjecten_dataset, hr_dataset):
         "hr_activiteiten_wordt_uitgeoefend_in_commerciele_vestiging",
     }
 
-    assert db_table_names == set(m._meta.db_table for m in model_dict.values())
+    assert db_table_names == {m._meta.db_table for m in model_dict.values()}
 
 
 @pytest.mark.django_db
@@ -294,13 +294,13 @@ def test_column_shortnames_in_nm_throughtables(verblijfsobjecten_dataset, hr_dat
     }
 
     db_colnames = {"activiteiten_id", "sbi_voor_activiteit_id"}
-    assert db_colnames == set(
+    assert db_colnames == {
         f.db_column
         for f in model_dict[
             "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming"
         ]._meta.fields
         if f.db_column is not None
-    )
+    }
 
 
 @pytest.mark.django_db

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -590,7 +590,7 @@ def _create_role(engine, role):
     This may happen if a previous pytest did not terminate correctly.
     """
     try:
-        engine.execute('CREATE ROLE "{}"'.format(role))
+        engine.execute(f'CREATE ROLE "{role}"')
     except ProgrammingError as e:
         if not isinstance(e.orig, DuplicateObject):
             raise
@@ -610,10 +610,10 @@ def _check_select_permission_denied(engine, role, table, column="*"):
     """
     with pytest.raises(Exception) as e_info:
         with engine.begin() as connection:
-            connection.execute("SET ROLE {}".format(role))
-            connection.execute("SELECT {} FROM {}".format(column, table))
+            connection.execute(f"SET ROLE {role}")
+            connection.execute(f"SELECT {column} FROM {table}")
             connection.execute("RESET ROLE")
-    assert "permission denied for table {}".format(table) in str(e_info)
+    assert f"permission denied for table {table}" in str(e_info)
 
 
 def _check_select_permission_granted(engine, role, table, column="*"):
@@ -621,8 +621,8 @@ def _check_select_permission_granted(engine, role, table, column="*"):
     Fail if role, table or column does not exist.
     """
     with engine.begin() as connection:
-        connection.execute("SET ROLE {}".format(role))
-        result = connection.execute("SELECT {} FROM {}".format(column, table))
+        connection.execute(f"SET ROLE {role}")
+        result = connection.execute(f"SELECT {column} FROM {table}")
         connection.execute("RESET ROLE")
     assert result
 
@@ -632,8 +632,8 @@ def _check_insert_permission_granted(engine, role, table, column, value):
     Fail if role, table or column does not exist, or value mismatches in datatype.
     """
     with engine.begin() as connection:
-        connection.execute("SET ROLE {}".format(role))
-        result = connection.execute("INSERT INTO {} ({}) VALUES ({})".format(table, column, value))
+        connection.execute(f"SET ROLE {role}")
+        result = connection.execute(f"INSERT INTO {table} ({column}) VALUES ({value})")
         connection.execute("RESET ROLE")
     assert result
 
@@ -644,10 +644,10 @@ def _check_insert_permission_denied(engine, role, table, column, value):
     """
     with pytest.raises(Exception) as e_info:
         with engine.begin() as connection:
-            connection.execute("SET ROLE {}".format(role))
-            connection.execute("INSERT INTO {} ({}) VALUES ({})".format(table, column, value))
+            connection.execute(f"SET ROLE {role}")
+            connection.execute(f"INSERT INTO {table} ({column}) VALUES ({value})")
             connection.execute("RESET ROLE")
-    assert "permission denied for table {}".format(table) in str(e_info)
+    assert f"permission denied for table {table}" in str(e_info)
 
 
 def _check_update_permission_granted(engine, role, table, column, value, condition):
@@ -655,10 +655,8 @@ def _check_update_permission_granted(engine, role, table, column, value, conditi
     Fail if role, table or column does not exist, or value mismatches in datatype.
     """
     with engine.begin() as connection:
-        connection.execute("SET ROLE {}".format(role))
-        result = connection.execute(
-            "UPDATE {} SET {} =  {} WHERE {}".format(table, column, value, condition)
-        )
+        connection.execute(f"SET ROLE {role}")
+        result = connection.execute(f"UPDATE {table} SET {column} =  {value} WHERE {condition}")
         connection.execute("RESET ROLE")
     assert result
 
@@ -669,20 +667,18 @@ def _check_update_permission_denied(engine, role, table, column, value, conditio
     """
     with pytest.raises(Exception) as e_info:
         with engine.begin() as connection:
-            connection.execute("SET ROLE {}".format(role))
-            connection.execute(
-                "UPDATE {} SET {} =  {} WHERE {}".format(table, column, value, condition)
-            )
+            connection.execute(f"SET ROLE {role}")
+            connection.execute(f"UPDATE {table} SET {column} =  {value} WHERE {condition}")
             connection.execute("RESET ROLE")
-    assert "permission denied for table {}".format(table) in str(e_info)
+    assert f"permission denied for table {table}" in str(e_info)
 
 
 def _check_delete_permission_granted(engine, role, table, condition):
     """Check if role has DELETE permission on table.
     Fail if role, table or column does not exist, or value mismatches in datatype."""
     with engine.begin() as connection:
-        connection.execute("SET ROLE {}".format(role))
-        result = connection.execute("DELETE FROM {} WHERE {}".format(table, condition))
+        connection.execute(f"SET ROLE {role}")
+        result = connection.execute(f"DELETE FROM {table} WHERE {condition}")
         connection.execute("RESET ROLE")
     assert result
 
@@ -692,10 +688,10 @@ def _check_delete_permission_denied(engine, role, table, condition):
     Fail if role, table or column does not exist, or value mismatches in datatype."""
     with pytest.raises(Exception) as e_info:
         with engine.begin() as connection:
-            connection.execute("SET ROLE {}".format(role))
-            connection.execute("DELETE FROM {} WHERE {}".format(table, condition))
+            connection.execute(f"SET ROLE {role}")
+            connection.execute(f"DELETE FROM {table} WHERE {condition}")
             connection.execute("RESET ROLE")
-    assert "permission denied for table {}".format(table) in str(e_info)
+    assert f"permission denied for table {table}" in str(e_info)
 
 
 def _check_truncate_permission_granted(engine, role, table):

--- a/tests/test_permissions_auth.py
+++ b/tests/test_permissions_auth.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from schematools.permissions import Permission, UserScopes
 from schematools.types import PermissionLevel
 
 
 def _active_profiles(
-    user_scopes: UserScopes, dataset_id: str, table_id: Optional[str] = None
+    user_scopes: UserScopes, dataset_id: str, table_id: str | None = None
 ) -> set[str]:
     """Shorthand to get active profile names"""
     if table_id is not None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,4 @@
 import operator
-from functools import partial
 from pathlib import Path
 
 import pytest
@@ -191,7 +190,7 @@ def test_dataset_schema_get_fields_with_surrogate_pk(
     composite_key_schema = composite_key_schema.tables[0]
 
     # this schema gets a generated 'id'
-    assert sorted([x.id for x in verblijfsobjecten.get_fields(include_subfields=False)]) == [
+    assert sorted(x.id for x in verblijfsobjecten.get_fields(include_subfields=False)) == [
         "beginGeldigheid",
         "eindGeldigheid",
         "gebruiksdoel",
@@ -203,7 +202,7 @@ def test_dataset_schema_get_fields_with_surrogate_pk(
     ]
 
     # this schema defines an 'id'
-    assert sorted([x.name for x in composite_key_schema.get_fields(include_subfields=False)]) == [
+    assert sorted(x.name for x in composite_key_schema.get_fields(include_subfields=False)) == [
         "beginGeldigheid",
         "eindGeldigheid",
         "id",


### PR DESCRIPTION
pyupgrade --py38-plus already suggests to use the Python 3.9 format if the type annotations use a 'from __future__' construct that avoids actual code execution.