### PR TITLE
Remove deprecated and unused code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 3.6.11
+version = 4.0.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Amsterdam Data en Informatie

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -40,7 +40,6 @@ from schematools.utils import (
     dataset_schema_from_path,
     dataset_schema_from_url,
     dataset_schemas_from_url,
-    schema_fetch_url_file,
 )
 
 # Configure a simple stdout logger for permissions output
@@ -274,7 +273,7 @@ def permissions_apply(
         ams_schema = dataset_schemas_from_url(schemas_url=schema_url)
 
     if profile_filename:
-        profile = schema_fetch_url_file(profile_filename)
+        profile = _schema_fetch_url_file(profile_filename)
         profiles = {profile["name"]: profile}
     else:
         # Profiles not live yet, temporarilly commented out
@@ -300,6 +299,22 @@ def permissions_apply(
         click.echo(
             "Choose --auto or specify both a --role and a --scope to be able to grant permissions"
         )
+
+
+def _schema_fetch_url_file(schema_url_file: URL | str) -> dict[str, Any]:
+    """Return schemadata from URL or File."""
+    # XXX Does not work with datasets that have their tables split
+    # out into separate files. Should use _get_dataset_schema instead.
+
+    if not schema_url_file.startswith("http"):
+        with open(schema_url_file) as f:
+            schema_data = json.load(f)
+    else:
+        response = requests.get(schema_url_file)
+        response.raise_for_status()
+        schema_data = response.json()
+
+    return cast(Dict[str, Any], schema_data)
 
 
 @schema.group()

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -620,13 +620,3 @@ class CompositeForeignKeySubField(models.ForeignKey):
 
 class LooseRelationManyToManyField(models.ManyToManyField):
     pass
-
-
-def get_field_schema(model_field: models.Field | models.ForeignObjectRel) -> DatasetFieldSchema:
-    # Backwards compatibility code.
-    warnings.warn(
-        "get_field_schema() is deprecated, use DynamicModel.get_field_schema() instead",
-        DeprecationWarning,
-    )
-
-    return DynamicModel.get_field_schema(model_field)

--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -686,10 +686,10 @@ def index_factory(
         """Creates an index on Foreign Keys."""
         indexes: dict[str, list[Index]] = {}
         indexes_to_create: list[Index] = []
-        if dataset_table.get_fk_fields():
+        if dataset_table._get_fk_fields():
 
-            for field in dataset_table.get_fk_fields():
-                field_name = f"{to_snake_case(field)}_id"
+            for field in dataset_table._get_fk_fields():
+                field_name = field.db_name()
                 index_name = f"{db_table_name}_{field_name}_idx"
                 if len(index_name) > MAX_TABLE_NAME_LENGTH:
                     index_name = make_hash_value(index_name)

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -174,17 +174,6 @@ def _schema_from_url_with_connection(
     return schema
 
 
-@deprecated(
-    version="2.3.1",
-    reason="""The `dataset_schema_from_file` is replaced by `dataset_schema_from_path`.""",
-)
-def dataset_schema_from_file(
-    file_path: Path | str, prefetch_related: bool = False
-) -> types.DatasetSchema:
-    """Gets a dataset scheme from a file path."""
-    return dataset_schema_from_path(file_path)
-
-
 def dataset_schema_from_path(
     dataset_path: Path | str,
 ) -> types.DatasetSchema:
@@ -277,25 +266,6 @@ def profile_schema_from_file(filename: Path | str) -> dict[str, types.ProfileSch
     with open(filename) as file_handler:
         schema_info = json.load(file_handler)
         return {schema_info["name"]: types.ProfileSchema.from_dict(schema_info)}
-
-
-@deprecated(
-    version="1.0.4",
-    reason="Does not work with datasets that have their tables split "
-    "out into separate files. Use something like "
-    "`schematools.cli._get_dataset_schema` instead.",
-)
-def schema_fetch_url_file(schema_url_file: URL | str) -> dict[str, Any]:
-    """Return schemadata from URL or File."""
-    if not schema_url_file.startswith("http"):
-        with open(schema_url_file) as f:
-            schema_data = json.load(f)
-    else:
-        response = requests.get(schema_url_file)
-        response.raise_for_status()
-        schema_data = response.json()
-
-    return cast(Dict[str, Any], schema_data)
 
 
 _CAMEL_CASE_REPLACE_PAT: Final[Pattern[str]] = re.compile(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,7 +323,7 @@ def profile_brk_read_id_schema(here) -> ProfileSchema:
 
 @pytest.fixture
 def composite_key_schema(here) -> ProfileSchema:
-    return DatasetSchema.from_file(here / "files/composite_key.json")
+    return dataset_schema_from_path(here / "files/composite_key.json")
 
 
 @pytest.fixture


### PR DESCRIPTION
None of this was used in DSO-API or dataservices-airflow. `get_fk_fields` was used internally, so it's now a private method. It also returns `[DatasetFieldSchema]` instead of `[str]` to be more generally useful and to allow reuse of the `db_name` method (-1 `to_snake_case`!). `schema_fetch_url_file` was moved to its only spot of use and made private, with the previous deprecation method as a comment.