### PR TITLE
AB#50108: Convert LooseRelationField into an actual relation

### DIFF
--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -59,6 +59,12 @@ class UserScopes:
         self._all_profiles = all_profiles
         self._scopes = set(request_scopes) | {PUBLIC_SCOPE}
 
+    def __repr__(self):
+        return f"<UserScopes: {self._scopes!r}>"
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._scopes)
+
     def add_query_params(self, params: list[str]):
         """Tell that the request has extra (implicit) parameters that are satisfied.
 
@@ -280,13 +286,6 @@ class UserScopes:
         return not mandatory_filtersets or any(
             _match_filter_rule(rule, self._query_param_names) for rule in mandatory_filtersets
         )
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._scopes)
-
-    def __str__(self) -> str:
-        scopes = ", ".join(repr(scope) for scope in self._scopes)
-        return f"UserScopes({scopes})"
 
 
 def _match_filter_rule(rule: Iterable[str], query_param_names: Iterable[str]) -> bool:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1241,13 +1241,22 @@ class DatasetFieldSchema(DatasetType):
         The returned list contains only the fields, e.g., ["id", "volgnummer"].
         These are fields on the table `self.related_table`.
 
+        For loose relations, it will only return
+        the first field of the related table.
+
         If self is not a relation field, the return value is None.
         """
         if not self.get("relation"):
             return None
         elif self.is_object:
             # Relation where the fields are defined as sub-fields
-            return list(self["properties"].keys())
+            return [
+                subfield_id
+                for subfield_id, subfield in self["properties"].items()
+                if not subfield.get("format") in ("date", "date-time")
+            ]
+        elif self.is_loose_relation:
+            return self.related_table.identifier[:1]
         else:
             # References the primary key of the related table.
             return self.related_table.identifier


### PR DESCRIPTION
This changes the LooseRelationField into an actual foreign key, so applications can perform joins on the relation. This change is backwards incompatible, and DSO-API will have an corresponding PR to be compatible with this change.

This only affects the fields that are *not* part of a composite foreign key. Those remain simple charfields.