### PR TITLE
AB#52532 Add validator to check hostname in `$ref`

### DIFF
--- a/tests/files/schema_ref_validation.json
+++ b/tests/files/schema_ref_validation.json
@@ -1,0 +1,62 @@
+{
+  "type": "dataset",
+  "id": "schemrefvalidation",
+  "title": "Schema $ref hostname Validation Test",
+  "status": "beschikbaar",
+  "description": "Schema for unit testing schema $ref validator",
+  "version": "0.0.1",
+  "tables": [
+    {
+      "id": "incorrect",
+      "title": "Some title",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/tests/invalid.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "foo",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "foo",
+          "schema"
+        ],
+        "display": "foo",
+        "properties": {
+          "schema": {
+            "$ref": "https://invalid.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "foo": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "correct",
+      "title": "Some other title",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/tests/valid.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "bar",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "bar",
+          "schema"
+        ],
+        "display": "bar",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "bar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -276,3 +276,16 @@ def test_reasons_non_public_value(here: Path) -> None:
     dataset["reasonsNonPublic"] = ["5.1 1c: Bevat persoonsgegevens"]
     errors = list(validation.run(dataset))
     assert len(errors) == 0
+
+
+def test_schema_ref(here: Path) -> None:
+    dataset = dataset_schema_from_path(here / "files" / "schema_ref_validation.json")
+
+    errors = validation.run(dataset)
+
+    error = next(errors)
+    assert error
+    assert error.validator_name == "schema ref"
+    assert """Incorrect `$ref` for""" in error.message
+
+    assert list(errors) == []


### PR DESCRIPTION
Hostname in `properties/schema` should always be:
`schemas.data.amsterdam.nl`. The path part of the `$ref`
is already being checked in the structural validation.