### PR TITLE
Allow enable_db with an endpoint_url

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 4.1.3
+version = 4.2.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/management/commands/change_dataset.py
+++ b/src/schematools/contrib/django/management/commands/change_dataset.py
@@ -70,17 +70,9 @@ class Command(BaseCommand):  # noqa: D101
             available = ", ".join(sorted(Dataset.objects.values_list("name", flat=True)))
             raise CommandError(f"Dataset not found: {name}.\nAvailable are: {available}") from None
 
-        # Validate illogical combinations
-        endpoint_url = options.get("endpoint_url")
-        if endpoint_url is not None:
-            if options.get("enable_db"):
-                raise CommandError("Can't use --endpoint-url with --enable-db")
-
-            if dataset.enable_db:
-                options["enable_db"] = False
-
         # URL endpoints need to contain {table_id}, which DSO-API replaces
         # with the actual table name.
+        endpoint_url = options.get("endpoint_url")
         if endpoint_url is not None and "{table_id}" not in endpoint_url:
             raise CommandError("--endpoint-url argument must contain '{table_id}'")
 


### PR DESCRIPTION
The reason to allow this combination is to generate OpenAPI docs for the remotes. We generate those with drf_spectacular, which looks at the database. Generating OpenAPI docs from the schemas directly would be possible, but only by duplicating all of drf_spectacular's functionality.

For [AB#50780](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/50780).