### PR TITLE
Add validator for the types of identifier fields

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 4.2.0
+version = 4.2.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/tests/files/id_type.json
+++ b/tests/files/id_type.json
@@ -1,0 +1,42 @@
+{
+  "id": "idtype",
+  "type": "dataset",
+  "description": "Dataset with an identifier field that is not integer or string",
+  "license": "public",
+  "status": "niet_beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+          "uniqid"
+        ],
+        "required": [
+          "schema",
+          "uniqid"
+        ],
+        "display": "uniqid",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "uniqid": {
+            "type": "number",
+            "description": "A number can be a float"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -39,7 +39,7 @@ def test_camelcase() -> None:
 
 
 def test_id_auth(here: Path) -> None:
-    dataset = dataset_schema_from_path(here / "files/id_auth.json")
+    dataset = dataset_schema_from_path(here / "files" / "id_auth.json")
 
     errors = validation.run(dataset)
 
@@ -47,6 +47,20 @@ def test_id_auth(here: Path) -> None:
     assert error
     assert error.validator_name == "Auth on identifier field"
     assert """auth on field 'id'""" in error.message
+
+    assert list(errors) == []
+
+
+def test_id_type(here: Path) -> None:
+    dataset = dataset_schema_from_path(here / "files" / "id_type.json")
+
+    errors = validation.run(dataset)
+
+    error = next(errors)
+    assert error
+    assert error.validator_name == "Identifier field with the wrong type"
+    assert """field 'uniqid'""" in error.message
+    assert """'number'""" in error.message
 
     assert list(errors) == []
 


### PR DESCRIPTION
For [AB#53421](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/53421).

I had to change an unrelated map expression to a comprehension to make flake8 happy.