### PR TITLE
Revert "Allow enable_db with an endpoint_url (#320)"

### DIFF
--- a/src/schematools/contrib/django/management/commands/change_dataset.py
+++ b/src/schematools/contrib/django/management/commands/change_dataset.py
@@ -70,9 +70,17 @@ class Command(BaseCommand):  # noqa: D101
             available = ", ".join(sorted(Dataset.objects.values_list("name", flat=True)))
             raise CommandError(f"Dataset not found: {name}.\nAvailable are: {available}") from None
 
+        # Validate illogical combinations
+        endpoint_url = options.get("endpoint_url")
+        if endpoint_url is not None:
+            if options.get("enable_db"):
+                raise CommandError("Can't use --endpoint-url with --enable-db")
+
+            if dataset.enable_db:
+                options["enable_db"] = False
+
         # URL endpoints need to contain {table_id}, which DSO-API replaces
         # with the actual table name.
-        endpoint_url = options.get("endpoint_url")
         if endpoint_url is not None and "{table_id}" not in endpoint_url:
             raise CommandError("--endpoint-url argument must contain '{table_id}'")
 


### PR DESCRIPTION
This reverts commit 2a9bbab25d2ed9004b046c7ff48d8a42acc9845a.

Reason: unforeseen side-effects of enable_db with some remotes.