### PR TITLE
Avoid dependency restrictions that break project upgrades

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 4.2.1
+version = 4.2.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,13 @@ package_dir =
 packages = find:
 python_requires = >= 3.9
 install_requires =
-    sqlalchemy ~= 1.3.23
+    sqlalchemy
     geoalchemy2
     psycopg2
     pg-grant
     click
     deepdiff
-    jsonschema[format] ~= 3.2.0
+    jsonschema[format] >= 3.2.0
     json-encoder
     ndjson>=0.3.0
     shapely
@@ -87,8 +87,8 @@ tests =
     requests-mock
 django =
     django >= 3.0
-    django-postgres-unlimited-varchar >= 1.1.0
-    django-gisserver >= 0.5
+    django-postgres-unlimited-varchar >= 1.1.1
+    django-gisserver >= 1.2.3
     django-environ
     django-db-comments
     factory_boy

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -14,7 +14,6 @@ from schematools.contrib.django import app_config, signals
 from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema
 from schematools.utils import get_rel_table_identifier, to_snake_case
 
-from .faker import get_field_factory
 from .mockers import DynamicModelMocker
 from .models import (
     FORMAT_MODELS_LOOKUP,
@@ -571,6 +570,10 @@ def model_mocker_factory(
     dataset: Dataset, table_schema: DatasetTableSchema, base_app_name: Optional[str] = None
 ) -> Type[DynamicModelMocker]:
     """Generate a Django model mocker class from a JSON Schema definition."""
+    # delayed import so Faker/shapely etc are not loaded for every application,
+    # but only when mocker functionality is used.
+    from .faker import get_field_factory
+
     dataset_schema = dataset.schema
     app_label = f"{dataset_schema.id}"
     base_app_name = base_app_name or "dso_api.dynamic_api"


### PR DESCRIPTION
That practice also hinders security patches in the future.