### PR TITLE
Use list instead of dict for dataset collections

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from collections import defaultdict
 from pathlib import PosixPath
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Tuple
+from typing import Any, DefaultDict, Dict, Iterable, List
 
 import click
 import jsonschema
@@ -611,7 +611,7 @@ def _get_dataset_schema(
         raise click.ClickException(str(e))
 
 
-def _get_all_dataset_schemas(schema_url: str) -> dict[str, DatasetSchema]:
+def _get_all_dataset_schemas(schema_url: str) -> list[DatasetSchema]:
     """Find all the dataset schemas for the given schema_url.
 
     Args:
@@ -697,13 +697,11 @@ def create_all_objects(
         click.echo("No 'dataset_id' provided. Processing all datasets!")
         dataset_schemas = _get_all_dataset_schemas(schema_url)
     else:
-        dataset_schemas = {
-            dataset_id: _get_dataset_schema(dataset_id, schema_url, prefetch_related=True)
-        }
+        dataset_schemas = [_get_dataset_schema(dataset_id, schema_url, prefetch_related=True)]
 
     engine = _get_engine(db_url)
-    for dataset_id, dataset_schema in dataset_schemas.items():
-        if dataset_id in exclude:
+    for dataset_schema in dataset_schemas:
+        if dataset_schema.id in exclude:
             msg = f"Skipping dataset {dataset_id!r}"
             click.echo(msg)
             click.echo("=" * len(msg))

--- a/src/schematools/datasetcollection.py
+++ b/src/schematools/datasetcollection.py
@@ -62,7 +62,7 @@ class DatasetCollection(metaclass=Singleton):
             self.add_dataset(dataset)
             return dataset
 
-    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> list[DatasetSchema]:
         """Gets all the datasets using the configured schema loader."""
         return self.schema_loader.get_all_datasets()
 
@@ -75,7 +75,6 @@ def set_schema_loader(schema_url: URL | str) -> None:
         can be a web url, or a filesystem path.
     """
     dataset_collection = DatasetCollection()
-    loader: loaders.SchemaLoader | None = None  # pleasing mypy
     if urlparse(schema_url).scheme in ("http", "https"):
         loader = loaders.URLSchemaLoader(schema_url)
     else:

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -28,7 +28,7 @@ class SchemaLoader:
         """Gets a dataset for dataset_id."""
         raise NotImplementedError
 
-    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> list[DatasetSchema]:
         """Gets all datasets from the schema_url location."""
         raise NotImplementedError
 
@@ -49,11 +49,11 @@ class FileSystemSchemaLoader(SchemaLoader):
         except FileNotFoundError as e:
             raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from e
 
-    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> list[DatasetSchema]:
         """Gets all datasets from the filesystem based on the `self.schema_url` path."""
         from schematools.utils import dataset_schemas_from_schemas_path
 
-        return dataset_schemas_from_schemas_path(self.schema_url)
+        return list(dataset_schemas_from_schemas_path(self.schema_url))
 
 
 class URLSchemaLoader(SchemaLoader):
@@ -70,8 +70,8 @@ class URLSchemaLoader(SchemaLoader):
         except KeyError:
             raise DatasetNotFound(f"Dataset `{dataset_id}` not found.") from None
 
-    def get_all_datasets(self) -> dict[str, DatasetSchema]:
+    def get_all_datasets(self) -> list[DatasetSchema]:
         """Gets all datasets from a web url based on the `self.schema_url` path."""
         from schematools.utils import dataset_schemas_from_url
 
-        return dataset_schemas_from_url(self.schema_url)  # type: ignore[no-any-return]
+        return dataset_schemas_from_url(self.schema_url)


### PR DESCRIPTION
We were passing around dicts keyed on the dataset id. But the dataset id is contained in a DatasetSchema, so we can just use lists instead.

Also, check for inconsistencies in index.json in _schemas_from_url.