### PR TITLE
Have schema loaders returns dataset paths

### DIFF
--- a/src/schematools/ckan/_convert.py
+++ b/src/schematools/ckan/_convert.py
@@ -5,8 +5,11 @@ from typing import Any
 from ..types import DatasetSchema
 
 
-def from_dataset(ds: DatasetSchema) -> dict[str, Any]:
+def from_dataset(ds: DatasetSchema, path: str) -> dict[str, Any]:
     """Convert a dataset to the CKAN format variant used by data.overheid.nl.
+
+    path should be the dataset path as used in DSO-API, e.g., "beheerkaart/cbs_grid"
+    for the dataset with id "beheerkaartCbsGrid".
 
     The output, as JSON, can be used in a CKAN create_package request.
 
@@ -20,12 +23,7 @@ def from_dataset(ds: DatasetSchema) -> dict[str, Any]:
     # which we could use to represent the tables, but data.overheid.nl doesn't
     # seem to support that (or it's broken).
 
-    # The URL for the dataset also serves as the identifier.
-    #
-    # XXX The URL is not always correct, but the logic to construct paths lives in DSO-API.
-    # Only the Haal Centraal remotes have custom paths, though.
-    # Maybe get rid of the custom paths?
-    url = "https://api.data.amsterdam.nl/v1/" + ds.id
+    url = "https://api.data.amsterdam.nl/v1/" + path
 
     has_geo = any(table.has_geometry_fields for table in ds.tables)
     theme = THEME_RUIMTE if has_geo else THEME_BESTUUR
@@ -54,7 +52,7 @@ def from_dataset(ds: DatasetSchema) -> dict[str, Any]:
         "publisher": "http://standaarden.overheid.nl/owms/terms/Amsterdam",
         "theme": [theme],
         "title": title,
-        "url": "https://api.data.amsterdam.nl/v1/" + ds.id,
+        "url": url,
     }
 
     # XXX I can't find what the inverse is called, so we omit this field for

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -473,12 +473,12 @@ def to_ckan(schema_url: str, upload_url: str):
 
     status = 0
 
-    datasets = _get_all_dataset_schemas(schema_url).values()
+    datasets = _get_all_dataset_schemas(schema_url)
 
     data = []
-    for ds in datasets:
+    for path, ds in datasets.items():
         try:
-            data.append(ckan.from_dataset(ds))
+            data.append(ckan.from_dataset(ds, path))
         except Exception as e:
             logger.error("in dataset %s: %s", ds.identifier, str(e))
             status = 1

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -29,7 +29,10 @@ class SchemaLoader:
         raise NotImplementedError
 
     def get_all_datasets(self) -> dict[str, DatasetSchema]:
-        """Gets all datasets from the schema_url location."""
+        """Gets all datasets from the schema_url location.
+
+        The return value maps dataset paths (foo/bar) to schema's.
+        """
         raise NotImplementedError
 
 

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -61,14 +61,6 @@ def dataset_schema_from_url(
     )
 
 
-def profile_schemas_from_url(profiles_url: URL | str) -> dict[str, types.ProfileSchema]:
-    """Fetch all profile schemas from a remote file.
-
-    The URL could be ``https://schemas.data.amsterdam.nl/profiles/``
-    """
-    return schemas_from_url(base_url=profiles_url, data_type=types.ProfileSchema)
-
-
 def dataset_paths_from_url(base_url: URL | str) -> dict[str, str]:
     """Fetch all dataset paths from a remote location.
 

--- a/tests/test_ckan.py
+++ b/tests/test_ckan.py
@@ -28,7 +28,7 @@ def test_convert(here, name):
     with open(filename) as f:
         schema = DatasetSchema.from_dict(json_encoder.json.load(f))
 
-    data = ckan.from_dataset(schema)
+    data = ckan.from_dataset(schema, name)
 
     for key in ["identifier", "title"]:
         assert data.get(key) and re.match(r"^[a-z0-9_-]", data[key])


### PR DESCRIPTION
Fixes [AB#59480](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/59480): dataset schema loaders now return the paths as the keys in their dicts, instead of duplicating the id's (which are already present in the `DatasetSchema` objects). This allows us to easily produce the right paths in the CKAN exporter, it saves a round-trip to `schemas.data` in `dataset_paths_from_url` and I also need this for the DSO-API docs rewrite.

Still todo: update current DSO-API docs generation to the new semantics of `dataset_schema_from_(path|url)`.