### PR TITLE
Skip tests that require the database if not configured

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ from schematools.utils import dataset_schema_from_path
 HERE = Path(__file__).parent
 
 
+try:
+    # Will raise ImproperlyConfigured if env. vars not set.
+    import django  # noqa: F401
+except Exception:
+    collect_ignore_glob = ["django"]
+
+
 # fixtures engine and dbengine provided by pytest-sqlalchemy,
 # automatically discovered by pytest via setuptools entry-points.
 # https://github.com/toirl/pytest-sqlalchemy/blob/master/pytest_sqlalchemy.py
@@ -42,7 +49,9 @@ def here() -> Path:
 @pytest.fixture(scope="session")
 def db_url():
     """Get the DATABASE_URL, prepend test_ to it."""
-    url = os.environ.get("DATABASE_URL", "postgresql://localhost/schematools")
+    url = os.environ.get("DATABASE_URL")
+    if url is None:
+        pytest.skip("DATABASE_URL not set")
 
     parts = urlparse(url)
     dbname = parts.path[1:]

--- a/tests/django/conftest.py
+++ b/tests/django/conftest.py
@@ -1,6 +1,12 @@
 """Extra fixtures for ``schematools.contrib.django``"""
+import os
+
 from django.conf import settings
 from pytest_django.plugin import _setup_django
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if DATABASE_URL is None:
+    collect_ignore_glob = "*"
 
 
 def pytest_configure(config):
@@ -15,7 +21,7 @@ def pytest_configure(config):
         ),
     }
     databases["default"]["NAME"] += "_django"  # avoid duplication with sqlalchemy tests
-    settings.configure(
+    settings.configure(  # noqa: S106
         DEBUG=True,
         INSTALLED_APPS=[
             "django.contrib.auth",

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -13,8 +13,11 @@ from schematools.contrib.django.models import (
     LooseRelationManyToManyField,
 )
 
+from .conftest import DATABASE_URL
+
 
 @pytest.mark.django_db
+@pytest.mark.skipif(DATABASE_URL is None, "DATABASE_URL not set")
 def test_model_factory_fields(afval_dataset) -> None:
     """Prove that the fields from the schema will be generated"""
     table = afval_dataset.schema.tables[0]
@@ -55,6 +58,7 @@ def test_model_factory_fields(afval_dataset) -> None:
 
 
 @pytest.mark.django_db
+@pytest.mark.skipif(DATABASE_URL is None, "DATABASE_URL not set")
 def test_model_factory_table_name_no_versions(afval_dataset):
     """Prove that relations between models can be resolved"""
     models = {


### PR DESCRIPTION
This way, pytest will run the tests that it can without a database, so we can set up continuous testing (#331).

The implementation is very ugly, but I couldn't boil it down further. The pytest-django plugin doesn't have good support for skipping, so we need to stop collecting the tests instead of skipping them. This gives misleading output, in the sense that the skipped tests aren't even reported as such.