### PR TITLE
Make `reason` for pytest.mark.skipif a keyword argument

### DIFF
--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -17,7 +17,7 @@ from .conftest import DATABASE_URL
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(DATABASE_URL is None, "DATABASE_URL not set")
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL not set")
 def test_model_factory_fields(afval_dataset) -> None:
     """Prove that the fields from the schema will be generated"""
     table = afval_dataset.schema.tables[0]
@@ -58,7 +58,7 @@ def test_model_factory_fields(afval_dataset) -> None:
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(DATABASE_URL is None, "DATABASE_URL not set")
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL not set")
 def test_model_factory_table_name_no_versions(afval_dataset):
     """Prove that relations between models can be resolved"""
     models = {


### PR DESCRIPTION
If not, pytest considers it an error.