### PR TITLE
Fix circular import

### DIFF
--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -13,10 +13,10 @@ from cachetools.func import ttl_cache
 from more_ds.network.url import URL
 from string_utils import slugify
 
-from schematools import MAX_TABLE_NAME_LENGTH, RELATION_INDICATOR, TMP_TABLE_POSTFIX, types
+from schematools import MAX_TABLE_NAME_LENGTH, RELATION_INDICATOR, TMP_TABLE_POSTFIX
 
 if TYPE_CHECKING:
-    from schematools.loaders import SchemaLoader  # noqa: F401
+    from schematools import types
 
 RE_CAMEL_CASE: Final[Pattern[str]] = re.compile(
     r"(((?<=[^A-Z])[A-Z])|([A-Z](?![A-Z]))|((?<=[a-z])[0-9])|(?<=[0-9])[a-z])"


### PR DESCRIPTION
Importing types first and utils second works, but the other way around gave an exception. That's gone now.

TODO: refactor further by splitting utils into a loading module and a naming (snakes/camels) module.

Removed an import of loaders in utils that didn't seem to do anything.