### PR TITLE
Split naming module off of utils

### DIFF
--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -11,8 +11,8 @@ from django.db.models import CheckConstraint, Q
 from django.db.models.base import ModelBase
 
 from schematools.contrib.django import app_config, signals
+from schematools.naming import get_rel_table_identifier, to_snake_case
 from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema
-from schematools.utils import get_rel_table_identifier, to_snake_case
 
 from .mockers import DynamicModelMocker
 from .models import (

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -6,8 +6,9 @@ from django.db.models import Q
 
 from schematools.contrib.django.models import Dataset
 from schematools.datasetcollection import DatasetCollection, set_schema_loader
+from schematools.naming import to_snake_case
 from schematools.types import DatasetSchema
-from schematools.utils import dataset_schema_from_path, to_snake_case
+from schematools.utils import dataset_schema_from_path
 
 from .create_tables import create_tables
 

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -26,6 +26,7 @@ from django.utils.translation import gettext_lazy as _
 from django_postgres_unlimited_varchar import UnlimitedCharField
 from gisserver.types import CRS
 
+from schematools.naming import to_snake_case
 from schematools.types import (
     DatasetFieldSchema,
     DatasetSchema,
@@ -33,7 +34,6 @@ from schematools.types import (
     ProfileSchema,
     SemVer,
 )
-from schematools.utils import to_snake_case
 
 from . import managers
 from .validators import URLPathValidator, validate_json

--- a/src/schematools/events/export.py
+++ b/src/schematools/events/export.py
@@ -19,8 +19,8 @@ from sqlalchemy.engine import Connection
 
 from schematools.events import metadata
 from schematools.factories import tables_factory
+from schematools.naming import to_snake_case
 from schematools.types import DatasetSchema, DatasetTableSchema
-from schematools.utils import to_snake_case
 
 
 @dataclass

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -9,8 +9,8 @@ from sqlalchemy.engine import Connection
 
 from schematools.events import metadata
 from schematools.factories import tables_factory
+from schematools.naming import to_snake_case, toCamelCase
 from schematools.types import DatasetSchema
-from schematools.utils import to_snake_case, toCamelCase
 
 # Enable the sqlalchemy logger by uncommenting the following 2 lines to debug SQL related issues
 # logging.basicConfig()

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -15,8 +15,8 @@ from schematools import (
     TMP_TABLE_POSTFIX,
 )
 from schematools.importer import fetch_col_type
+from schematools.naming import to_snake_case
 from schematools.types import DatasetSchema, DatasetTableSchema
-from schematools.utils import to_snake_case
 
 
 def tables_factory(

--- a/src/schematools/introspect/db.py
+++ b/src/schematools/introspect/db.py
@@ -2,7 +2,7 @@ import copy
 
 from sqlalchemy import inspect
 
-from ..utils import toCamelCase
+from ..naming import toCamelCase
 from .utils import DATASET_TMPL, TABLE_TMPL
 
 # the Geometry field has a property geometry_type, could be mapped to more

--- a/src/schematools/naming.py
+++ b/src/schematools/naming.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from typing import Final, Match, Pattern
+
+from string_utils import slugify
+
+from schematools import MAX_TABLE_NAME_LENGTH, RELATION_INDICATOR, TMP_TABLE_POSTFIX
+
+_RE_CAMEL_CASE: Final[Pattern[str]] = re.compile(
+    r"(((?<=[^A-Z])[A-Z])|([A-Z](?![A-Z]))|((?<=[a-z])[0-9])|(?<=[0-9])[a-z])"
+)
+
+_CAMEL_CASE_REPLACE_PAT: Final[Pattern[str]] = re.compile(
+    r"""
+    (?:_|\s)+   # Find word boundaries by looking for underscore and whitespace characters, they
+                # will be discarded (not captured)
+    (.)         # Capture first letter of word on word boundary
+    |           # OR
+    (\d+)       # Capture a number
+    (?:_|\s)*   # Optionally followed by underscore and whitespace characters (to be discarded)
+    (.)         # Capture first letter of word on word boundary
+    """,
+    re.VERBOSE,
+)
+
+
+@lru_cache(maxsize=500)
+def toCamelCase(ident: str) -> str:
+    """Convert an identifier to camelCase format.
+
+    Word boundaries are determined by:
+    - numbers
+    - underscore characters
+    - whitespace characters (this violates the concept of identifiers,
+      but we handle it nevertheless)
+
+    A camelCased identifier, when it starts with a letter, it will start with a lower cased letter.
+
+    Empty strings are not allowed. They will raise an :exc:`ValueError` exception.
+
+    Examples::
+
+        >>> toCamelCase("dataset_table_schema")
+        'datasetTableSchema'
+        >>> toCamelCase("dataset table schema")
+        'datasetTableSchema'
+        >>> toCamelCase("fu_33_bar")
+        'fu33Bar'
+        >>> toCamelCase("fu_33bar")
+        'fu33Bar'
+        >>> toCamelCase("fu_33Bar")
+        'fu33Bar'
+        >>> toCamelCase("33_fu_bar")
+        '33FuBar'
+
+    Args:
+        ident: The identifier to be converted.
+
+    Returns:
+        The identifier in camelCase format.
+
+    Raises:
+        ValueError: If ``indent`` is an empty string.
+
+    """
+
+    def replacement(m: Match) -> str:
+        # As we use the OR operator in the regular expression with capture groups on both sides,
+        # we will always have at least one capture group that results in `None`. We filter those
+        # out in the generator expression. Even though a captured group sometimes represents a
+        # number (as a string), we still call `upper()` on it. That's faster than another
+        # explicit test.
+        return "".join(s.upper() for s in m.groups() if s)
+
+    if ident == "":
+        raise ValueError("Parameter `ident` cannot be an empty string.")
+    result = _CAMEL_CASE_REPLACE_PAT.sub(replacement, ident)
+    # The first letter of camelCase identifier is always lower case
+    return result[0].lower() + result[1:]
+
+
+@lru_cache(maxsize=500)
+def to_snake_case(ident: str) -> str:
+    """Convert an identifier to snake_case format.
+
+    Empty strings are not allowed. They will raise an :exc:`ValueError` exception.
+
+    Args:
+        ident: The identifier to be converted.
+
+    Returns:
+        The identifier in snake_case foramt.
+
+    Raises:
+        ValueError: If ``ident`` is an empty string.
+    """
+    if ident == "":
+        raise ValueError("Parameter `ident` cannot be an empty string.")
+    # Convert to field name, avoiding snake_case to snake_case issues.
+    # Also preserve RELATION_INDICATOR in names (RELATION_INDICATOR are used for object relations)
+    name_parts = [toCamelCase(part) for part in ident.split(RELATION_INDICATOR)]
+    return RELATION_INDICATOR.join(
+        slugify(_RE_CAMEL_CASE.sub(r" \1", part).strip(), separator="_") for part in name_parts
+    )
+
+
+def get_rel_table_identifier(table_identifier: str, through_identifier: str) -> str:
+    """Create identifier for related table (FK or M2M)."""
+    return f"{table_identifier}_{through_identifier}"
+
+
+def shorten_name(db_table_name: str, with_postfix: bool = False) -> str:
+    """Shorten names to safe length for postgresql."""
+    max_length = MAX_TABLE_NAME_LENGTH - int(with_postfix) * len(TMP_TABLE_POSTFIX)
+    return db_table_name[:max_length]

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -33,7 +33,7 @@ from methodtools import lru_cache
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools.datasetcollection import DatasetCollection
 from schematools.exceptions import ParserError, SchemaObjectNotFound
-from schematools.utils import get_rel_table_identifier, to_snake_case, toCamelCase
+from schematools.naming import get_rel_table_identifier, to_snake_case, toCamelCase
 
 ST = TypeVar("ST", bound="SchemaType")
 DTS = TypeVar("DTS", bound="DatasetTableSchema")
@@ -450,8 +450,6 @@ class DatasetSchema(SchemaType):
     def get_table_by_id(
         self, table_id: str, include_nested: bool = True, include_through: bool = True
     ) -> DatasetTableSchema:
-        from schematools.utils import to_snake_case
-
         snakecased_table_id = to_snake_case(table_id)
         for table in self.get_tables(
             include_nested=include_nested, include_through=include_through
@@ -564,8 +562,6 @@ class DatasetSchema(SchemaType):
             - bestaat_uit_buurten_identificatie
             - bestaat_uit_buurten_volgnummer
         """
-        from schematools.utils import get_rel_table_identifier, toCamelCase
-
         # Build the through_table for n-m relation
         # For relations, we have to use the real ids of the tables
         # and not the shortnames
@@ -1024,8 +1020,6 @@ class DatasetTableSchema(SchemaType):
     def model_name(self) -> str:
         """Returns model name for this table. Including version number, if needed."""
 
-        from schematools.utils import to_snake_case
-
         if self.dataset is None:
             raise ValueError(
                 "Cannot obtain a model_name from a DatasetTableSchema without a parent dataset."
@@ -1065,8 +1059,6 @@ class DatasetTableSchema(SchemaType):
             A derived table name suitable for DB usage.
 
         """
-        from schematools.utils import to_snake_case
-
         dataset_prefix = version_postfix = ""
         if with_version:
             version_postfix = self.version.signif

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -30,8 +30,8 @@ from urllib.parse import urlparse
 
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools.exceptions import SchemaObjectNotFound
+from schematools.naming import to_snake_case, toCamelCase
 from schematools.types import DatasetSchema, SemVer, TableVersions
-from schematools.utils import to_snake_case, toCamelCase
 
 
 @dataclass(frozen=True)

--- a/tests/django/test_mocking.py
+++ b/tests/django/test_mocking.py
@@ -9,7 +9,7 @@ from schematools.contrib.django.factories import (
 )
 from schematools.contrib.django.faker.create import create_data_for
 from schematools.contrib.django.faker.relate import relate_datasets
-from schematools.utils import to_snake_case
+from schematools.naming import to_snake_case
 
 from .conftest import DATABASE_URL
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from schematools.utils import to_snake_case, toCamelCase
+from schematools.naming import to_snake_case, toCamelCase
 
 
 def test_toCamelCase() -> None:


### PR DESCRIPTION
Triggered by circular import exceptions that occur when utils is imported before typing (but not the other way around). Having a utils module is a code smell anyway.

This replaces #341.