### PR TITLE
non Amsterdam schema field for ingestion guidance

### DIFF
--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -300,19 +300,15 @@ class BaseImporter:
         }
 
         last_record: dict | None = None
-
         for records in chunked(data_generator, size=batch_size):
             # every record is keyed on tablename + inside there is a list
             for db_table_name, table_records in self._group_records(records).items():
-                print("db_table_name ==", db_table_name)
-
                 table_records = list(self.deduplicate(db_table_name, table_records))
                 # exclude the non target fields for ingestion into database table
                 # since they are not part of the Amsterdam
                 table_records_to_insert = [
                     item for item in table_records if item not in non_target_fields
                 ]
-
                 if table_records_to_insert:
                     self.engine.execute(
                         insert_statements[db_table_name],


### PR DESCRIPTION
The GOB data processing in Airflow utilizes the NDJSONImporter class to ingest .ndjson files. The processing logic relies on a non Amsterdam schema defined field called: "cursor". However, during the read of the .ndjson file, only schema defined fields are currently taken into account. Leading to an error when the processing logic wants to retrieve the value of "cursor".

Context:
The source field "cursor" is used to track the position of the next data row for the next batch. This "cursor" field is merely used as a guidance during ingestion and therefore does not to be present in the target table.

Changes:
- Class method `parse_records` provides an optional argument for extra fields that could be needed during ingestion (but not to be present in the target table).
- Class method `load_file` provides an optional argument for extra fields that could be needed during ingestion (but not to be present in the target table).