### PR TITLE
Restore ability to use snake-cased table ID's in limit_tables_to.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# in git
+# 2022-11-22 (5.1.1)
 
 * Improve `limit_tables_to` to accept snake-cased table identifiers, which broke Airflow jobs.
   This addresses an inconsistency between parameters, where `BaseImporter.generate_db_objects()`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# in git
+
+* Improve `limit_tables_to` to accept snake-cased table identifiers, which broke Airflow jobs.
+  This addresses an inconsistency between parameters, where `BaseImporter.generate_db_objects()`
+  allowed snake-cased identifiers for `table_id`, but needed exact-cased values for `limit_tables_to`.
+
+
 # 2022-11-21 (5.1)
 
 A big change in schema loading.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.1
+version = 5.1.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -36,7 +36,15 @@ def test_ndjson_import_separate_relations_target_composite(
 ):
     ndjson_path = here / "files" / "data" / "meetbouten_ligt_in_buurt.ndjson"
     importer = NDJSONImporter(meetbouten_schema, engine)
-    importer.generate_db_objects("meetbouten_ligt_in_buurt", truncate=True, ind_extra_index=False)
+    # NOTE: the table ID is actually "meetbouten_ligtInBuurt".
+    # This also tests that both parameters still work with the old snake-cased identifiers,
+    # as get_table_by_id() still does.
+    importer.generate_db_objects(
+        table_id="meetbouten_ligt_in_buurt",
+        truncate=True,
+        ind_extra_index=False,
+        limit_tables_to={"meetbouten_ligt_in_buurt"},
+    )
 
     importer.load_file(ndjson_path, is_through_table=True)
     records = [


### PR DESCRIPTION
This is done for consistency as `get_table_by_id()` also accepts the old snake-cased identifiers.

Otherwise, the parameters of `BaseImporter.generate_db_objects()` allow snake-cased ID's for `table_id` but need the exact ID's for `limit_tables_to`.