### PR TITLE
CKAN: Skip datasets that are "niet_beschikbaar"

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -479,6 +479,8 @@ def to_ckan(schema_url: str, upload_url: str):
 
     data = []
     for path, ds in datasets.items():
+        if ds.status != DatasetSchema.Status.beschikbaar:
+            continue
         try:
             data.append(ckan.from_dataset(ds, path))
         except Exception as e:


### PR DESCRIPTION
I still haven't found what "not available" is called on data.overheid.nl, or if there even is a status value that expresses it. Looks like omitting the availability field is interpreted as available, so just don't upload datasets marked "not available".