### PR TITLE
Cleanup and simplify model field factory logic

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1396,7 +1396,10 @@ class DatasetFieldSchema(DatasetType):
 
     @cached_property
     def is_object(self) -> bool:
-        """Tell whether the field references an object."""
+        """Tell whether the field references an object.
+        This might also be a relation, with a composite key.
+        In both cases, the object subfields could be inlined in the main SQL table.
+        """
         return self.get("type") == "object"
 
     @cached_property


### PR DESCRIPTION
This removes the complex `FieldMaker`/`RelationMaker` inheritance logic, and replaces them with plain Python functions.

This also accidentally fixes a bug with geometry fields. Because `JSON_TYPE_TO_DJANGO` has a a static kwargs argument for those, it would be directly altered by the `FieldMaker` - and therefore the next could field receive the `verbose_name` of the previous last geometry field that had one.