### PR TITLE
Normalize schematools exceptions for DatasetNotFound/SchemaObjectNotFound

### DIFF
--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -22,7 +22,7 @@ from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from schematools.exceptions import SchemaObjectNotFound
+from schematools.exceptions import DatasetFieldNotFound
 from schematools.loaders import CachedSchemaLoader
 from schematools.naming import to_snake_case
 from schematools.types import (
@@ -366,7 +366,7 @@ class DatasetTable(models.Model):
     def _get_geometry_field(cls, table_schema):
         try:
             field = table_schema.main_geometry_field
-        except SchemaObjectNotFound:
+        except DatasetFieldNotFound:
             # fallback to first GeoJSON field as geometry field.
             field = next((f for f in table_schema.fields if f.is_geo), None)
             if field is None:

--- a/src/schematools/exceptions.py
+++ b/src/schematools/exceptions.py
@@ -6,5 +6,13 @@ class SchemaObjectNotFound(ValueError):
     """Field does not exist."""
 
 
-class DatasetNotFound(ValueError):
+class DatasetNotFound(SchemaObjectNotFound):
     """The dataset could not be found."""
+
+
+class DatasetTableNotFound(SchemaObjectNotFound):
+    """The table could not be found."""
+
+
+class DatasetFieldNotFound(SchemaObjectNotFound):
+    """The field could not be found."""


### PR DESCRIPTION
All derive from `SchemaObjectNotFound` now, removing the need to catch multiple exception types. There are also distinct exception types when a dataset/table/field is not found - in case the caller needs that.