### PR TITLE
Add validator for 'id' field with composite key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   * There is no need for `except (DatasetNotFound, SchemaObjectNotFound)` code, it can all be `except SchemaObjectNotFound:`.
 * Cleanup Django model field creation logic.
 * Cleanup SQLAlchemy column creation logic.
+* The schema validator now rejects tables with both an 'id' field and a composite primary key.
 
 
 # 2022-12-01 (5.1.3)

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -31,7 +31,7 @@ from urllib.parse import urlparse
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools.exceptions import SchemaObjectNotFound
 from schematools.naming import to_snake_case, toCamelCase
-from schematools.types import DatasetSchema, SemVer, TableVersions
+from schematools.types import DatasetSchema, TableVersions
 
 
 @dataclass(frozen=True)
@@ -43,21 +43,6 @@ class ValidationError:
 
     def __str__(self) -> str:
         return f"[{self.validator_name}] {self.message}"
-
-
-class ValidationException(Exception):
-    """Raised when validation fails to execute.
-
-    .. note::
-
-       This is not for validation errors. See :class:`ValidationError` instead.
-    """
-
-    message: str
-
-    def __init__(self, message: str) -> None:  # noqa: D107
-        super().__init__(message)
-        self.message = message
 
 
 _all: list[tuple[str, Callable[[DatasetSchema, str | None], Iterator[str]]]] = []

--- a/tests/files/datasets/idcomposite.json
+++ b/tests/files/datasets/idcomposite.json
@@ -1,0 +1,52 @@
+{
+  "id": "idcomposite",
+  "type": "dataset",
+  "description": "Dataset with an 'id' field an a composite pk",
+  "license": "public",
+  "status": "niet_beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+          "uniqid",
+          "sequenceNumber"
+        ],
+        "required": [
+          "schema",
+          "uniqid",
+          "sequenceNumber"
+        ],
+        "display": "uniqid",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "uniqid": {
+            "type": "integer",
+            "description": "Unique identifier"
+          },
+          "sequenceNumber": {
+            "type": "integer",
+            "description": "Sequence number"
+          },
+          "id": {
+              "type": "integer",
+              "description": "Some external identifier"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -59,6 +59,19 @@ def test_id_type(schema_loader) -> None:
     assert list(errors) == []
 
 
+def test_id_composite(schema_loader) -> None:
+    dataset = schema_loader.get_dataset_from_file("idcomposite.json")
+
+    errors = validation.run(dataset)
+
+    error = next(errors)
+    assert error
+    assert error.validator_name == "'id' field in the presence of composite primary key"
+    assert error.message == "table 'idcomposite.base' has a field called 'id'"
+
+    assert list(errors) == []
+
+
 def test_id_matches_path(here: Path, schema_loader) -> None:
     dataset = schema_loader.get_dataset_from_file("stadsdelen.json")
 


### PR DESCRIPTION
Checks for the issue that 'brk' previously had, where the identifier got overwritten inside the NDJSON importer.

Also removed unused bits from validation.py.