### PR TITLE
Fix processing `id` field twice

### DIFF
--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -92,7 +92,7 @@ class TableFieldMapper:
         for field in self.dataset_table.get_fields(include_subfields=True):
             if field.id == "schema" and field.type.startswith("https://"):
                 continue
-            if field.id == "id" and self.dataset_table.has_composite_key:
+            if field.id == "id" and self.dataset_table.is_autoincrement and self.dataset_table.has_composite_key:
                 # The composite key is already inserted in main_row
                 # skip processing "id" field again
                 continue

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -92,6 +92,10 @@ class TableFieldMapper:
         for field in self.dataset_table.get_fields(include_subfields=True):
             if field.id == "schema" and field.type.startswith("https://"):
                 continue
+            if field.id == "id" and self.dataset_table.has_composite_key:
+                # The composite key is already inserted in main_row
+                # skip processing "id" field again
+                continue
 
             # Read the value from the record. As subfields are also part of the main loop,
             # extra care is needed to make sure the correct dictionary is checked for the value.

--- a/tests/files/data/kadastraleobjecten.ndjson
+++ b/tests/files/data/kadastraleobjecten.ndjson
@@ -1,2 +1,2 @@
-{"identificatie": "KAD.001", "volgnummer": 1, "isOntstaanUitKadastraalobject": [{"identificatie": "KAD.002", "volgnummer": 1}]}
-{"identificatie": "KAD.002", "volgnummer": 1, "isOntstaanUitKadastraalobject": []}
+{"id": "10", "identificatie": "KAD.001", "volgnummer": 1, "isOntstaanUitKadastraalobject": [{"identificatie": "KAD.002", "volgnummer": 1}]}
+{"id": "11", "identificatie": "KAD.002", "volgnummer": 1, "isOntstaanUitKadastraalobject": []}

--- a/tests/files/datasets/kadastraleobjecten.json
+++ b/tests/files/datasets/kadastraleobjecten.json
@@ -30,6 +30,11 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
+          "neuronId": {
+            "type": "string",
+            "description": "hoi",
+            "provenance": "id"
+          },
           "identificatie": {
             "type": "string",
             "description": "De unieke aanduiding van een Kadastraal object."

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -266,6 +266,7 @@ def test_ndjson_import_nm_composite_selfreferencing_keys(
             "begin_geldigheid": None,
             "eind_geldigheid": None,
             "koopsom": None,
+            "neuron_id": "10",
             "registratiedatum": None,
         },
         {
@@ -275,6 +276,7 @@ def test_ndjson_import_nm_composite_selfreferencing_keys(
             "begin_geldigheid": None,
             "eind_geldigheid": None,
             "koopsom": None,
+            "neuron_id": "11",
             "registratiedatum": None,
         },
     ]


### PR DESCRIPTION
When the data contains an `id` during import, its processed twice. Its safe to skip the second iteration.