### PR TITLE
Support primary keys that also have a relation

### DIFF
--- a/src/schematools/contrib/django/apps.py
+++ b/src/schematools/contrib/django/apps.py
@@ -1,4 +1,9 @@
 from django.apps import AppConfig
+from django.db import models
+
+# Make sure OneToOneField also allows __contains= lookups (will only work for type=string).
+# This allows model_factory() to create the CheckConstraint check for a relational PK field.
+models.OneToOneField.register_lookup(models.lookups.Contains)
 
 
 class SchematoolsAppConfig(AppConfig):

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1275,10 +1275,12 @@ class DatasetFieldSchema(DatasetType):
         when the field is a relation, or has a short-name.
         """
         db_name = self.get("shortname", self._id)
-        if self.relation is not None:
+        if self.relation is not None and not self.is_primary:
             # In schema foreign keys should be specified without _id,
             # but the db_column should be with _id
             # Regular foreign keys have a _id field for the database, just like Django ORM does.
+            # ...but this is not done for primary keys that have a relationship constraint,
+            # as those should read the original db column directly as their value.
             db_name += "_id"
 
         if self._parent_field is not None and self._parent_field.is_object:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,11 @@ def schema_loader(here) -> FileSystemSchemaLoader:
 
 
 @pytest.fixture
+def aardgasverbruik_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("aardgasverbruik.json")
+
+
+@pytest.fixture
 def afval_schema(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("afval.json")
 

--- a/tests/django/fixtures.py
+++ b/tests/django/fixtures.py
@@ -64,6 +64,12 @@ def brp_dataset(brp_schema_json: dict) -> Dataset:
 
 
 @pytest.fixture
+def aardgasverbruik_dataset(aardgasverbruik_schema: DatasetSchema) -> Dataset:
+    """Create Aardgasverbruik dataset."""
+    return Dataset.create_for_schema(aardgasverbruik_schema)
+
+
+@pytest.fixture
 def afval_dataset(afval_schema: DatasetSchema) -> Dataset:
     """Create Afvalwegingen dataset."""
     return Dataset.create_for_schema(afval_schema)

--- a/tests/files/datasets/aardgasverbruik.json
+++ b/tests/files/datasets/aardgasverbruik.json
@@ -1,0 +1,90 @@
+{
+  "type": "dataset",
+  "id": "aardgasverbruik",
+  "title": "aardgasverbruik",
+  "status": "beschikbaar",
+  "version": "1.0.0",
+  "owner": "Liander / Gemeente Amsterdam",
+  "publisher": "Datateam Basisstatistiek",
+  "crs": "EPSG:28992",
+  "creator": "Onderzoek en Statistiek",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "basisstatistiek.os@amsterdam.nl",
+  "tables": [
+    {
+      "id": "mraLiander",
+      "title": "Data over Standaard Jaarverbruik (SJV) en aantal aansluitingen per postcode-range in de MRA",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "id",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "title": "id",
+            "type": "string",
+            "description": "Unieke identificatie"
+          },
+          "dataDate": {
+            "title": "dataDate",
+            "type": "string",
+            "format": "date",
+            "description": "Datum van de aangeleverde data"
+          },
+          "postcodeVanaf": {
+            "title": "postcodeVanaf",
+            "type": "string",
+            "description": "Postcode vanaf (eerste postcode in postcoderange)"
+          },
+          "postcodeTotEnMet": {
+            "title": "postcodeTotEnMet",
+            "type": "string",
+            "description": "Postcode t/m (laatste postcode in postcoderange)"
+          }
+        }
+      }
+    },
+    {
+      "id": "mraStatistiekenPcranges",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "id",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "title": "id",
+            "type": "string",
+            "description": "Unieke identificatie",
+            "relation": "aardgasverbruik:mraLiander"
+          },
+          "gemiddeldVerbruik": {
+            "title": "gemiddeldAardgasverbruikPerAansluiting",
+            "type": "number",
+            "description": "Gemiddeld standaard jaarverbruik per aansluiting"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This makes sure the field is 'tagged' as OneToOneField, and has all database features that come with that field class. The actual model lookup is purposefully disabled, so accessing the field will still return the raw db_column value. Otherwise, Django would query the related table to retrieve the value.