### PR TITLE
Remove unused property DatasetSchema.identifier

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -323,11 +323,6 @@ class DatasetSchema(SchemaType):
         return self.get("license")
 
     @property
-    def identifier(self) -> str:
-        """Which fields acts as identifier. (default is Django "pk" field)."""
-        return self.get("identifier", "pk")
-
-    @property
     def version(self) -> str:
         """Dataset Schema version."""
         return self.get("version", None)


### PR DESCRIPTION
This method gives access to the "identifier" property on datasets. While some datasets have that, it is not in line with the Schema spec and never used. When I replace the property definition by

    @property
    def identifier(self) -> str:
        raise ValueError("crash")

the tests for schema-tools and DSO-API all still run.