### PR TITLE
Loading and validating publishers under metaschema 1.3.0 and 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ ENV/
 /scratch
 
 monkeytype.sqlite3
+
+# Dataset indices used during development are ignored
+datasets/index.json

--- a/src/schematools/__init__.py
+++ b/src/schematools/__init__.py
@@ -12,6 +12,11 @@ DATABASE_SCHEMA_NAME_DEFAULT: Final[str] = "public"
 # Defaults
 DEFAULT_SCHEMA_URL: Final[str] = "https://schemas.data.amsterdam.nl/datasets/"
 DEFAULT_PROFILE_URL: Final[str] = "https://schemas.data.amsterdam.nl/profiles/"
+# The directory where all publisher objects are defined for amsterdam-schema
+PUBLISHER_DIR: Final[str] = "publishers"
+# Files that can exist in publishers directory but should be ignored by
+# the FileLoaders
+PUBLISHER_EXCLUDE_FILES: Final[str] = ["publishers.json", "index.json"]
 
 # Common coordinate reference systems
 CRS_WGS84: Final[str] = "EPSG:4326"  # World Geodetic System 1984, used in GPS

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -201,7 +201,7 @@ class Dataset(models.Model):
             path = name
         obj = cls(
             name=name,
-            schema_data=schema.json(inline_tables=True),
+            schema_data=schema.json(inline_tables=True, inline_publishers=True),
             auth=" ".join(schema.auth),
             path=path,
             version=schema.version,
@@ -222,7 +222,7 @@ class Dataset(models.Model):
 
     def save_for_schema(self, schema: DatasetSchema):
         """Update this model with schema data"""
-        self.schema_data = schema.json(inline_tables=True)
+        self.schema_data = schema.json(inline_tables=True, inline_publishers=True)
         self.auth = " ".join(schema.auth)
         self.enable_api = Dataset.has_api_enabled(schema)
         self._dataset_collection = schema.loader  # retain collection on saving

--- a/src/schematools/utils.py
+++ b/src/schematools/utils.py
@@ -134,3 +134,12 @@ def dataset_schemas_from_schemas_path(root: Path | str) -> dict[str, types.Datas
 
     loader = FileSystemSchemaLoader(root)
     return loader.get_all_datasets()
+
+
+def publishers_from_url(base_url: URL | str) -> dict[str, list[types.Publisher]]:
+    """
+    The URL could be ``https://schemas.data.amsterdam.nl/publishers/``
+    """
+
+    loader = URLSchemaLoader(base_url)
+    return loader.get_all_publishers()

--- a/tests/files/datasets/afval.json
+++ b/tests/files/datasets/afval.json
@@ -19,10 +19,7 @@
         "required": ["id", "schema"],
         "display": "id",
         "properties": {
-          "id": {
-            "type": "integer",
-            "description": "Container-ID"
-          },
+          "id": { "type": "integer", "description": "Container-ID" },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
           },
@@ -69,18 +66,14 @@
         "required": ["id", "schema"],
         "display": "id",
         "properties": {
-          "id": {
-            "type": "string"
-          },
+          "id": { "type": "string" },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
           },
-          "status": {
-            "type": "string",
-            "description": "Status"
-          }
+          "status": { "type": "string", "description": "Status" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/afvalwegingen_clusters/v1.0.0.json
+++ b/tests/files/datasets/afvalwegingen_clusters/v1.0.0.json
@@ -2,7 +2,7 @@
   "id": "clusters",
   "type": "table",
   "version": "1.0.0",
-      "schema": {
+  "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,

--- a/tests/files/datasets/afvalwegingen_sep_table.json
+++ b/tests/files/datasets/afvalwegingen_sep_table.json
@@ -1,229 +1,229 @@
 {
-    "id": "afvalwegingen_sep_table",
-    "type": "dataset",
-    "status": "beschikbaar",
-    "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
-    "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
-    "homepage": "https://data.amsterdam.nl",
-    "owner": "Gemeente Amsterdam, Stadswerken",
-    "dateModified": "2020-01-13",
-    "spatialDescription": "Gemeente Amsterdam",
-    "version": "2",
-    "title": "Onder- en bovengrondse Afvalcontainers en putten (2)",
-    "language": "Nederlands",
-    "dateCreated": "2020-01-13",
-    "license": "Creative Commons, Naamsvermelding",
-    "hasBeginning": "2016",
-    "accrualPeriodicity": "dagelijks",
-    "publisher": "OIS",
-    "description": "Alle locaties van de actieve onder- en bovengronds afvalcontainers en betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas, Textiel en Plastic. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
-    "crs": "EPSG:28992",
-    "tables": [
-      {
-        "id": "containers",
-        "type": "table",
-        "version": "1.0.0",
+  "id": "afvalwegingen_sep_table",
+  "type": "dataset",
+  "status": "beschikbaar",
+  "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
+  "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Gemeente Amsterdam, Stadswerken",
+  "dateModified": "2020-01-13",
+  "spatialDescription": "Gemeente Amsterdam",
+  "version": "2",
+  "title": "Onder- en bovengrondse Afvalcontainers en putten (2)",
+  "language": "Nederlands",
+  "dateCreated": "2020-01-13",
+  "license": "Creative Commons, Naamsvermelding",
+  "hasBeginning": "2016",
+  "accrualPeriodicity": "dagelijks",
+  "publisher": "OIS",
+  "description": "Alle locaties van de actieve onder- en bovengronds afvalcontainers en betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas, Textiel en Plastic. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "containers",
+      "type": "table",
+      "version": "1.0.0",
       "schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "additionalProperties": false,
-          "identifier": ["id"],
-          "required": ["id", "schema"],
-          "display": "id",
-          "properties": {
-            "id": {
-              "type": "integer",
-              "description": "Container-ID"
-            },
-            "schema": {
-              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-            },
-            "cluster": {
-              "type": "string",
-              "relation": "afvalwegingen_sep_table:clusters",
-              "description": "Cluster-ID"
-            },
-            "serienummer": {
-              "type": "string",
-              "description": "Serienummer van container"
-            },
-            "eigenaar id": {
-              "type": "string",
-              "description": "Eigenaar-ID"
-            },
-            "eigenaar naam": {
-              "type": "string",
-              "description": "Naam van eigenaar"
-            },
-            "status": {
-              "type": "string",
-              "description": "Status"
-            },
-            "afvalfractie": {
-              "type": "string",
-              "description": "Afvalfractie"
-            },
-            "datum creatie": {
-              "type": "string",
-              "format": "date",
-              "description": "Datum aangemaakt"
-            },
-            "datum plaatsing": {
-              "type": "string",
-              "format": "date",
-              "description": "Datum plaatsing"
-            },
-            "datum operationeel": {
-              "type": "string",
-              "format": "date",
-              "description": "Datum operationeel"
-            },
-            "datum aflopen garantie": {
-              "type": "string",
-              "format": "date",
-              "description": "Datum aflopen garantie"
-            },
-            "datum oplevering": {
-              "type": "string",
-              "format": "date",
-              "description": "Datum oplevering"
-            },
-            "containerlocatie id": {
-              "type": "string",
-              "description": "Locatie-ID van container"
-            },
-            "geometry": {
-              "$ref": "https://geojson.org/schema/Point.json",
-              "description": "Geometrie"
-            },
-            "containertype": {
-              "type": "string",
-              "relation": "afvalwegingen_sep_table:containertypes",
-              "description": "Containertype-ID"
-            }
-          }
-        }
-      },
-      {
-        "id": "clusters",
-        "$ref": "afvalwegingen_clusters/v1.0.0",
-        "activeVersions": {
-          "1.0.0": "afvalwegingen_clusters/v1.0.0"
-        }
-      },
-      {
-        "id": "wegingen",
-        "type": "table",
-        "version": "1.0.0",
-      "schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["id", "schema"],
-          "display": "id",
-          "properties": {
-            "id": {
-              "type": "string",
-              "description": "Weging-ID"
-            },
-            "schema": {
-              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-            },
-            "cluster": {
-              "type": "string",
-              "relation": "afvalwegingen_sep_table:clusters",
-              "description": "Cluster-ID"
-            },
-            "weegsysteem id": {
-              "type": "string",
-              "description": "Weegsysteem-ID"
-            },
-            "weegsysteem omschrijving": {
-              "type": "string",
-              "description": "Omschrijving van weegsysteem"
-            },
-            "volgnummer": {
-              "type": "string",
-              "description": "Volgnummer"
-            },
-            "tijdstip": {
-              "type": "string",
-              "format": "date-time",
-              "description": "Tijdstip"
-            },
-            "welvaartslocatienummer": {
-              "type": "string",
-              "description": "Welvaartslocatienummer"
-            },
-            "fractiecode": {
-              "type": "string",
-              "description": "Fractiecode"
-            },
-            "fractie omschrijving": {
-              "type": "string",
-              "description": "Omschrijving fractie"
-            },
-            "eerste weging": {
-              "type": "number",
-              "description": "Eerste weging"
-            },
-            "tweede weging": {
-              "type": "number",
-              "description": "Tweede weging"
-            },
-            "netto gewicht": {
-              "type": "number",
-              "unit": "kg",
-              "description": "Netto gewicht"
-            },
-            "geometry": {
-              "$ref": "https://geojson.org/schema/Point.json",
-              "description": "Geometrie"
-            },
-            "bediening code": {
-              "type": "string",
-              "description": "Code bediening"
-            },
-            "bediening omschrijving": {
-              "type": "string",
-              "description": "Omschrijving bediening"
-            }
-          }
-        }
-      },
-      {
-        "id": "containertypes",
-        "type": "table",
-        "version": "1.0.0",
-      "schema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["id", "schema"],
-          "display": "naam",
-          "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "schema": {
-              "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-            },
-            "naam": {
-              "type": "string",
-              "description": "Naam"
-            },
-            "volume": {
-              "type": "number",
-              "description": "Volume",
-              "unit": "m3"
-            },
-            "gewicht": {
-              "type": "string",
-              "description": "Gewicht",
-              "unit": "kg"
-            }
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["id"],
+        "required": ["id", "schema"],
+        "display": "id",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Container-ID"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "cluster": {
+            "type": "string",
+            "relation": "afvalwegingen_sep_table:clusters",
+            "description": "Cluster-ID"
+          },
+          "serienummer": {
+            "type": "string",
+            "description": "Serienummer van container"
+          },
+          "eigenaar id": {
+            "type": "string",
+            "description": "Eigenaar-ID"
+          },
+          "eigenaar naam": {
+            "type": "string",
+            "description": "Naam van eigenaar"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status"
+          },
+          "afvalfractie": {
+            "type": "string",
+            "description": "Afvalfractie"
+          },
+          "datum creatie": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum aangemaakt"
+          },
+          "datum plaatsing": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum plaatsing"
+          },
+          "datum operationeel": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum operationeel"
+          },
+          "datum aflopen garantie": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum aflopen garantie"
+          },
+          "datum oplevering": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum oplevering"
+          },
+          "containerlocatie id": {
+            "type": "string",
+            "description": "Locatie-ID van container"
+          },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Geometrie"
+          },
+          "containertype": {
+            "type": "string",
+            "relation": "afvalwegingen_sep_table:containertypes",
+            "description": "Containertype-ID"
           }
         }
       }
-    ]
-  }
+    },
+    {
+      "id": "clusters",
+      "$ref": "afvalwegingen_clusters/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "afvalwegingen_clusters/v1.0.0"
+      }
+    },
+    {
+      "id": "wegingen",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "schema"],
+        "display": "id",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Weging-ID"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "cluster": {
+            "type": "string",
+            "relation": "afvalwegingen_sep_table:clusters",
+            "description": "Cluster-ID"
+          },
+          "weegsysteem id": {
+            "type": "string",
+            "description": "Weegsysteem-ID"
+          },
+          "weegsysteem omschrijving": {
+            "type": "string",
+            "description": "Omschrijving van weegsysteem"
+          },
+          "volgnummer": {
+            "type": "string",
+            "description": "Volgnummer"
+          },
+          "tijdstip": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Tijdstip"
+          },
+          "welvaartslocatienummer": {
+            "type": "string",
+            "description": "Welvaartslocatienummer"
+          },
+          "fractiecode": {
+            "type": "string",
+            "description": "Fractiecode"
+          },
+          "fractie omschrijving": {
+            "type": "string",
+            "description": "Omschrijving fractie"
+          },
+          "eerste weging": {
+            "type": "number",
+            "description": "Eerste weging"
+          },
+          "tweede weging": {
+            "type": "number",
+            "description": "Tweede weging"
+          },
+          "netto gewicht": {
+            "type": "number",
+            "unit": "kg",
+            "description": "Netto gewicht"
+          },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Geometrie"
+          },
+          "bediening code": {
+            "type": "string",
+            "description": "Code bediening"
+          },
+          "bediening omschrijving": {
+            "type": "string",
+            "description": "Omschrijving bediening"
+          }
+        }
+      }
+    },
+    {
+      "id": "containertypes",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "schema"],
+        "display": "naam",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "naam": {
+            "type": "string",
+            "description": "Naam"
+          },
+          "volume": {
+            "type": "number",
+            "description": "Volume",
+            "unit": "m3"
+          },
+          "gewicht": {
+            "type": "string",
+            "description": "Gewicht",
+            "unit": "kg"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/files/datasets/bouwblokken.json
+++ b/tests/files/datasets/bouwblokken.json
@@ -14,9 +14,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
@@ -37,7 +35,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -95,5 +93,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/bouwblokken.json
+++ b/tests/files/datasets/bouwblokken.json
@@ -35,7 +35,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",

--- a/tests/files/datasets/brk.json
+++ b/tests/files/datasets/brk.json
@@ -14,9 +14,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
@@ -30,10 +28,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string",
-            "description": "Neuron ID"
-          },
+          "id": { "type": "string", "description": "Neuron ID" },
           "volgnummer": {
             "type": "integer",
             "description": "Uniek volgnummer van de toestand van het object."
@@ -63,10 +58,7 @@
             "type": "integer",
             "description": "Volgnummer van het Appartementsrecht"
           },
-          "gemeente": {
-            "type": "string",
-            "description": ""
-          },
+          "gemeente": { "type": "string", "description": "" },
           "soortGrootteCode": {
             "type": "string",
             "provenance": "$.soortGrootte.code",
@@ -84,24 +76,20 @@
           "soortCultuurOnbebouwdCode": {
             "type": "string",
             "provenance": "$.soortCultuurOnbebouwd.code",
-            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als ‘omschrijving kadastraal object’ in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
+            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
           },
           "soortCultuurOnbebouwdOmschrijving": {
             "type": "string",
             "provenance": "$.soortCultuurOnbebouwd.omschrijving",
-            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als ‘omschrijving kadastraal object’ in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
+            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
           },
           "soortCultuurBebouwd": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "code": {
-                  "type": "string"
-                },
-                "omschrijving": {
-                  "type": "string"
-                }
+                "code": { "type": "string" },
+                "omschrijving": { "type": "string" }
               }
             }
           },
@@ -115,7 +103,7 @@
           },
           "plaatscoordinaten": {
             "$ref": "https://geojson.org/schema/Geometry.json",
-            "description": "De aanduiding van een kaartpunt voor de weergave van de identificatie van een perceel (centroïde)"
+            "description": "De aanduiding van een kaartpunt voor de weergave van de identificatie van een perceel (centro\u00efde)"
           },
           "perceelnummerRotatie": {
             "type": "number",
@@ -123,11 +111,11 @@
           },
           "perceelnummerVerschuivingX": {
             "type": "string",
-            "description": "Coördinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden x"
+            "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden x"
           },
           "perceelnummerVerschuivingY": {
             "type": "string",
-            "description": "Coördinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden y"
+            "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden y"
           },
           "bijpijlingGeometrie": {
             "$ref": "https://geojson.org/schema/Geometry.json",
@@ -177,12 +165,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "string"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "string" }
               }
             },
             "relation": "verblijfsobjecten:verblijfsobjecten",
@@ -198,9 +182,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/zakelijkerechten.json",
@@ -244,12 +226,8 @@
           "rustOpKadastraalobject": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "string"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "string" }
             },
             "relation": "brk:kadastraleobjecten",
             "description": "Het kadastraal object en volgnummer waarop het zakelijk recht rust"
@@ -600,9 +578,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
@@ -620,17 +596,10 @@
             "type": "string",
             "description": "De identificatie is een uniek nummer aan deze tenaamstelling binnen de kadastrale registratie."
           },
-          "volgnummer": {
-            "type": "integer",
-            "description": ""
-          },
+          "volgnummer": { "type": "integer", "description": "" },
           "vanKadastraalsubject": {
             "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "properties": { "identificatie": { "type": "string" } },
             "relation": "brk:kadastralesubjecten",
             "description": "Het Subject waarvoor deze tenaamstelling geldt."
           },
@@ -684,19 +653,12 @@
             "provenance": "$.verkregenNamensSamenwerkingsverband.omschrijving",
             "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. omschrijving"
           },
-          "inOnderzoek": {
-            "type": "string",
-            "description": ""
-          },
+          "inOnderzoek": { "type": "string", "description": "" },
           "vanZakelijkrecht": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "string"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "string" }
             },
             "relation": "brk:zakelijkerechten",
             "description": "Het Zakelijk recht waarover deze tenaamstelling gaat."
@@ -725,10 +687,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string",
-            "description": "Neuron ID"
-          },
+          "id": { "type": "string", "description": "Neuron ID" },
           "identificatie": {
             "type": "string",
             "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
@@ -756,11 +715,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "identificatie": {
-                  "type": "string"
-                }
-              }
+              "properties": { "identificatie": { "type": "string" } }
             },
             "relation": "brk:kadastralesubjecten",
             "description": "Identificatie van het betrokken subject"
@@ -789,9 +744,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenkadastraleobjecten.json",
@@ -846,11 +799,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "identificatie": {
-                  "type": "string"
-                }
-              }
+              "properties": { "identificatie": { "type": "string" } }
             },
             "relation": "brk:kadastralesubjecten",
             "description": "Identificatie van het betrokken subject"
@@ -858,12 +807,8 @@
           "heeftBetrekkingOpKadastraalObject": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "string"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "string" }
             },
             "relation": "brk:kadastraleobjecten",
             "description": "Identificatie van het kadastrale object (onroerende zaak)"
@@ -929,12 +874,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "string"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "string" }
               }
             },
             "relation": "brk:aantekeningenkadastraleobjecten",
@@ -944,11 +885,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "identificatie": {
-                  "type": "string"
-                }
-              }
+              "properties": { "identificatie": { "type": "string" } }
             },
             "relation": "brk:aantekeningenrechten",
             "description": "Geeft weer welke aantekening recht is ontstaan op basis van dit stukdeel"
@@ -958,12 +895,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "string"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "string" }
               }
             },
             "relation": "brk:zakelijkerechten",
@@ -1088,7 +1021,7 @@
           },
           "naam": {
             "type": "string",
-            "description": "De officiële vastgestelde gemeentenaam."
+            "description": "De offici\u00eble vastgestelde gemeentenaam."
           },
           "beginGeldigheid": {
             "type": "string",
@@ -1124,10 +1057,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "integer",
-            "description": ""
-          },
+          "id": { "type": "integer", "description": "" },
           "kennisgevingsdatum": {
             "type": "string",
             "format": "date-time",
@@ -1162,11 +1092,7 @@
           },
           "isOnderdeelVanKadastralegemeentecode": {
             "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "properties": { "identificatie": { "type": "string" } },
             "relation": "brk:kadastralegemeentecodes",
             "description": "Een alfanumerieke aanduiding van de kadastrale gemeentecode, deel van de kadastrale aanduiding van de onroerende zaak. (bv. ASD02)."
           },
@@ -1200,11 +1126,7 @@
           },
           "isOnderdeelVanKadastralegemeente": {
             "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "properties": { "identificatie": { "type": "string" } },
             "relation": "brk:kadastralegemeentes",
             "description": "De kadastrale gemeente waar de kadastrale gemeentecode onderdeel van is (bv. Sloten)."
           },
@@ -1238,11 +1160,7 @@
           },
           "ligtInGemeente": {
             "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "properties": { "identificatie": { "type": "string" } },
             "relation": "brk:gemeentes",
             "description": "De burgelijke gemeente waarin de kadastrale gemeente ligt."
           },
@@ -1254,5 +1172,6 @@
         "mainGeometry": "geometrie"
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/brk.json
+++ b/tests/files/datasets/brk.json
@@ -76,12 +76,12 @@
           "soortCultuurOnbebouwdCode": {
             "type": "string",
             "provenance": "$.soortCultuurOnbebouwd.code",
-            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
+            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
           },
           "soortCultuurOnbebouwdOmschrijving": {
             "type": "string",
             "provenance": "$.soortCultuurOnbebouwd.omschrijving",
-            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
+            "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notariële akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
           },
           "soortCultuurBebouwd": {
             "type": "array",
@@ -1021,7 +1021,7 @@
           },
           "naam": {
             "type": "string",
-            "description": "De offici\u00eble vastgestelde gemeentenaam."
+            "description": "De officiële vastgestelde gemeentenaam."
           },
           "beginGeldigheid": {
             "type": "string",

--- a/tests/files/datasets/brp.json
+++ b/tests/files/datasets/brp.json
@@ -17,55 +17,30 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "geslachtsaanduiding": {
-            "type": "string"
-          },
+          "geslachtsaanduiding": { "type": "string" },
           "naam": {
             "type": "object",
             "properties": {
-              "aanduidingNaamgebruik": {
-                "type": "string"
-              },
-              "voornamen": {
-                "type": "string"
-              },
-              "voorletters": {
-                "type": "string"
-              },
-              "geslachtsnaam": {
-                "type": "string"
-              },
-              "voorvoegsel": {
-                "type": "string"
-              }
+              "aanduidingNaamgebruik": { "type": "string" },
+              "voornamen": { "type": "string" },
+              "voorletters": { "type": "string" },
+              "geslachtsnaam": { "type": "string" },
+              "voorvoegsel": { "type": "string" }
             },
             "required": []
           },
-          "leeftijd": {
-            "type": "integer"
-          },
-          "burgerservicenummer": {
-            "type": "string"
-          },
+          "leeftijd": { "type": "integer" },
+          "burgerservicenummer": { "type": "string" },
           "geboorte": {
             "type": "object",
             "properties": {
               "datum": {
                 "type": "object",
                 "properties": {
-                  "datum": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "jaar": {
-                    "type": "integer"
-                  },
-                  "maand": {
-                    "type": "integer"
-                  },
-                  "dag": {
-                    "type": "integer"
-                  }
+                  "datum": { "type": "string", "format": "date" },
+                  "jaar": { "type": "integer" },
+                  "maand": { "type": "integer" },
+                  "dag": { "type": "integer" }
                 },
                 "required": []
               }
@@ -75,65 +50,35 @@
           "verblijfplaats": {
             "type": "object",
             "properties": {
-              "functieAdres": {
-                "type": "string"
-              },
-              "huisnummer": {
-                "type": "string"
-              },
-              "postcode": {
-                "type": "string"
-              },
-              "straatnaam": {
-                "type": "string"
-              },
+              "functieAdres": { "type": "string" },
+              "huisnummer": { "type": "string" },
+              "postcode": { "type": "string" },
+              "straatnaam": { "type": "string" },
               "datumAanvangAdreshouding": {
                 "type": "object",
                 "properties": {
-                  "datum": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "jaar": {
-                    "type": "integer"
-                  },
-                  "maand": {
-                    "type": "integer"
-                  },
-                  "dag": {
-                    "type": "integer"
-                  }
+                  "datum": { "type": "string", "format": "date" },
+                  "jaar": { "type": "integer" },
+                  "maand": { "type": "integer" },
+                  "dag": { "type": "integer" }
                 },
                 "required": []
               },
               "datumInschrijvingInGemeente": {
                 "type": "object",
                 "properties": {
-                  "datum": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "jaar": {
-                    "type": "integer"
-                  },
-                  "maand": {
-                    "type": "integer"
-                  },
-                  "dag": {
-                    "type": "integer"
-                  }
+                  "datum": { "type": "string", "format": "date" },
+                  "jaar": { "type": "integer" },
+                  "maand": { "type": "integer" },
+                  "dag": { "type": "integer" }
                 },
                 "required": []
               },
               "gemeenteVanInschrijving": {
                 "type": "object",
                 "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "omschrijving": {
-                    "type": "string"
-                  }
+                  "code": { "type": "string" },
+                  "omschrijving": { "type": "string" }
                 },
                 "required": []
               }
@@ -141,10 +86,9 @@
             "required": []
           }
         },
-        "required": [
-          "burgerservicenummer"
-        ]
+        "required": ["burgerservicenummer"]
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/composite_key.json
+++ b/tests/files/datasets/composite_key.json
@@ -12,9 +12,7 @@
       "version": "0.0.1",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/africanswallows",
@@ -28,10 +26,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string",
-            "description": "id"
-          },
+          "id": { "type": "string", "description": "id" },
           "identificatie": {
             "type": "string",
             "description": "Landelijke identificerende sleutel."
@@ -40,16 +35,11 @@
             "type": "integer",
             "description": "Uniek volgnummer van de toestand van het object."
           },
-          "beginGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "eindGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          }
+          "beginGeldigheid": { "type": "string", "format": "date-time" },
+          "eindGeldigheid": { "type": "string", "format": "date-time" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/crs_validation.json
+++ b/tests/files/datasets/crs_validation.json
@@ -16,20 +16,15 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "identifier": "fubar",
         "type": "object",
-        "mainGeometry":"geometrie",
+        "mainGeometry": "geometrie",
         "additionalProperties": false,
-        "required": [
-          "fubar",
-          "schema"
-        ],
+        "required": ["fubar", "schema"],
         "display": "fubar",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "fubar": {
-            "type": "string"
-          },
+          "fubar": { "type": "string" },
           "geometrie": {
             "$ref": "https://geojson.org/schema/Geometry.json",
             "description": "Geometrische beschrijving van een object."
@@ -37,5 +32,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/gebieden.json
+++ b/tests/files/datasets/gebieden.json
@@ -43,12 +43,12 @@
           },
           "code": {
             "type": "string",
-            "description": "Offici\u00eble code van het object."
+            "description": "Officiële code van het object."
           },
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -128,7 +128,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -209,7 +209,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -290,7 +290,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -363,7 +363,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",

--- a/tests/files/datasets/gebieden.json
+++ b/tests/files/datasets/gebieden.json
@@ -13,9 +13,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
@@ -45,12 +43,12 @@
           },
           "code": {
             "type": "string",
-            "description": "Officiële code van het object."
+            "description": "Offici\u00eble code van het object."
           },
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -60,20 +58,10 @@
           "ligtInBuurt": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              },
-              "beginGeldigheid": {
-                "type": "string",
-                "format": "date"
-              },
-              "eindGeldigheid": {
-                "type": "string",
-                "format": "date"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date" },
+              "eindGeldigheid": { "type": "string", "format": "date" }
             },
             "relation": "gebieden:buurten",
             "description": "De buurt waar het bouwblok in ligt."
@@ -82,12 +70,8 @@
             "shortname": "lgtInBrt",
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:buurten",
             "description": "De buurt waar het bouwblok in ligt."
@@ -105,9 +89,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
@@ -146,7 +128,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -169,12 +151,8 @@
           "ligtInWijk": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:wijken",
             "description": "De wijk waar de buurt in ligt."
@@ -192,9 +170,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
@@ -233,7 +209,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -256,12 +232,8 @@
           "ligtInStadsdeel": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:stadsdelen",
             "description": "Het stadsdeel waar de wijk in ligt."
@@ -279,9 +251,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
@@ -320,7 +290,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -354,9 +324,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
@@ -395,7 +363,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -414,12 +382,8 @@
           "ligtInStadsdeel": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:stadsdelen",
             "description": "Het stadsdeel waar het ggwgebied in ligt."
@@ -429,20 +393,10 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "integer"
-                },
-                "beginGeldigheid": {
-                  "type": "string",
-                  "format": "date"
-                },
-                "eindGeldigheid": {
-                  "type": "string",
-                  "format": "date"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" },
+                "beginGeldigheid": { "type": "string", "format": "date" },
+                "eindGeldigheid": { "type": "string", "format": "date" }
               }
             },
             "relation": "gebieden:buurten",
@@ -455,5 +409,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/gebieden_auth.json
+++ b/tests/files/datasets/gebieden_auth.json
@@ -15,9 +15,7 @@
       "auth": "LEVEL/B",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
@@ -39,7 +37,7 @@
             "type": "string",
             "format": "date",
             "auth": "LEVEL/C",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -57,12 +55,8 @@
           "ligtInBuurt": {
             "type": "object",
             "properties": {
-                "identificatie": {
-                    "type": "string"
-                },
-                "volgnummer": {
-                    "type": "integer"
-                }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:buurten",
             "provenance": "ligtinbuurt",
@@ -78,9 +72,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
@@ -119,7 +111,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -142,12 +134,8 @@
           "ligtInWijk": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:wijken",
             "description": "De wijk waar de buurt in ligt."
@@ -165,9 +153,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
@@ -193,7 +179,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -207,15 +193,13 @@
         }
       }
     },
-{
+    {
       "id": "ggwgebieden",
       "type": "table",
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
@@ -240,7 +224,7 @@
           "begingeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindgeldigheid": {
             "type": "string",
@@ -253,12 +237,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "integer"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
               }
             },
             "auth": "LEVEL/E",
@@ -269,12 +249,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "diemen": {
-                  "type": "string"
-                },
-                "zaanstad": {
-                  "type": "integer"
-                }
+                "diemen": { "type": "string" },
+                "zaanstad": { "type": "integer" }
               }
             },
             "auth": "LEVEL/F",
@@ -283,5 +259,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/gebieden_auth.json
+++ b/tests/files/datasets/gebieden_auth.json
@@ -37,7 +37,7 @@
             "type": "string",
             "format": "date",
             "auth": "LEVEL/C",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -111,7 +111,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -179,7 +179,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -224,7 +224,7 @@
           "begingeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindgeldigheid": {
             "type": "string",

--- a/tests/files/datasets/gebieden_auth_list.json
+++ b/tests/files/datasets/gebieden_auth_list.json
@@ -15,9 +15,7 @@
       "auth": ["LEVEL/B1", "LEVEL/B2"],
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
@@ -39,7 +37,7 @@
             "type": "string",
             "format": "date",
             "auth": ["LEVEL/C1", "LEVEL/C2"],
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -62,9 +60,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
@@ -103,7 +99,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -126,12 +122,8 @@
           "ligtInWijk": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "gebieden:wijken",
             "description": "De wijk waar de buurt in ligt."
@@ -149,9 +141,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
@@ -177,7 +167,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -191,5 +181,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/gebieden_auth_list.json
+++ b/tests/files/datasets/gebieden_auth_list.json
@@ -37,7 +37,7 @@
             "type": "string",
             "format": "date",
             "auth": ["LEVEL/C1", "LEVEL/C2"],
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -99,7 +99,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -167,7 +167,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",

--- a/tests/files/datasets/gebieden_sep_tables/bouwblokken/v1.0.0.json
+++ b/tests/files/datasets/gebieden_sep_tables/bouwblokken/v1.0.0.json
@@ -1,47 +1,47 @@
 {
-    "id": "bouwblokken",
-    "mainGeometry": "geometrie",
-    "type": "table",
-    "version": "1.0.0",
-    "temporal": {
-      "identifier": "volgnummer",
-      "dimensions": {
-        "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-      }
-    },
-    "schema": {
-      "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "object",
-      "additionalProperties": false,
-      "identifier": ["id"],
-      "required": ["schema", "id"],
-      "display": "id",
-      "properties": {
-        "schema": {
-          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-        },
-        "id": {
-          "type": "string",
-          "description": "Unieke identificatie voor dit object, inclusief volgnummer"
-        },
-        "beginGeldigheid": {
-          "type": "string",
-          "format": "date",
-          "description": "De datum waarop het object is gecreëerd."
-        },
-        "eindGeldigheid": {
-          "type": "string",
-          "format": "date",
-          "description": "De datum waarop het object is komen te vervallen.",
-          "provenance": "eindgeldigheid"
-        },
-        "ligtInBuurt": {
-          "type": "string",
-          "relation": "gebieden_sep_tables:buurten",
-          "provenance": "ligtinbuurt",
-          "description": "De buurt waar het bouwblok in ligt."
-        }
+  "id": "bouwblokken",
+  "mainGeometry": "geometrie",
+  "type": "table",
+  "version": "1.0.0",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": ["id"],
+    "required": ["schema", "id"],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "id": {
+        "type": "string",
+        "description": "Unieke identificatie voor dit object, inclusief volgnummer"
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "De datum waarop het object is gecreëerd."
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "De datum waarop het object is komen te vervallen.",
+        "provenance": "eindgeldigheid"
+      },
+      "ligtInBuurt": {
+        "type": "string",
+        "relation": "gebieden_sep_tables:buurten",
+        "provenance": "ligtinbuurt",
+        "description": "De buurt waar het bouwblok in ligt."
       }
     }
   }
+}

--- a/tests/files/datasets/gebieden_sep_tables/buurten/v1.0.0.json
+++ b/tests/files/datasets/gebieden_sep_tables/buurten/v1.0.0.json
@@ -1,55 +1,55 @@
 {
-    "id": "buurten",
-    "type": "table",
-    "version": "1.0.0",
+  "id": "buurten",
+  "type": "table",
+  "version": "1.0.0",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "primaireGeometrie",
+    "identifier": "identificatie",
+    "required": ["schema", "identificatie", "volgnummer"],
+    "display": "naam",
+    "properties": {
       "schema": {
-      "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "object",
-      "additionalProperties": false,
-      "mainGeometry": "primaireGeometrie",
-      "identifier": "identificatie",
-      "required": ["schema", "identificatie", "volgnummer"],
-      "display": "naam",
-      "properties": {
-        "schema": {
-          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-        },
-        "registratiedatum": {
-          "type": "string",
-          "format": "date-time",
-          "description": "De datum waarop de toestand is geregistreerd."
-        },
-        "identificatie": {
-          "type": "string",
-          "description": "Unieke identificatie van het object."
-        },
-        "naam": {
-          "type": "string",
-          "description": "De naam van het object."
-        },
-        "code": {
-          "type": "string",
-          "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
-        },
-        "volgnummer": {
-            "type": "integer",
-            "description": ""
-        },
-        "beginGeldigheid": {
-           "type": "string",
-           "format": "date",
-           "description": "De datum waarop het object is gecreëerd."
-        },
-        "eindGeldigheid": {
-          "type": "string",
-          "format": "date",
-          "description": "De datum waarop het object is komen te vervallen."
-        },
-        "primaireGeometrie": {
-          "$ref": "https://geojson.org/schema/Geometry.json",
-          "description": "Geometrische beschrijving van een object."
-        }
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Unieke identificatie van het object."
+      },
+      "naam": {
+        "type": "string",
+        "description": "De naam van het object."
+      },
+      "code": {
+        "type": "string",
+        "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": ""
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "De datum waarop het object is gecreëerd."
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "De datum waarop het object is komen te vervallen."
+      },
+      "primaireGeometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Geometrische beschrijving van een object."
       }
     }
+  }
 }

--- a/tests/files/datasets/ggwgebieden.json
+++ b/tests/files/datasets/ggwgebieden.json
@@ -13,9 +13,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
@@ -54,7 +52,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -77,12 +75,8 @@
           "ligtInWijk": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "ggwgebieden:wijken",
             "description": "De wijk waar de buurt in ligt."
@@ -100,9 +94,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
@@ -128,7 +120,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -148,9 +140,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["begingeldigheid", "eindgeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["begingeldigheid", "eindgeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
@@ -188,7 +178,7 @@
           "begingeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindgeldigheid": {
             "type": "string",
@@ -204,12 +194,8 @@
             "relation": "ggwgebieden:stadsdelen",
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "description": "Het stadsdeel waar het gebied in ligt."
           },
@@ -219,12 +205,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "integer"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
               }
             },
             "description": "De buurten waaruit het object bestaat."
@@ -238,9 +220,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
@@ -266,7 +246,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecreëerd."
+            "description": "De datum waarop het object is gecre\u00eberd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -280,5 +260,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/ggwgebieden.json
+++ b/tests/files/datasets/ggwgebieden.json
@@ -52,7 +52,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -120,7 +120,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",
@@ -178,7 +178,7 @@
           "begingeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindgeldigheid": {
             "type": "string",
@@ -246,7 +246,7 @@
           "beginGeldigheid": {
             "type": "string",
             "format": "date",
-            "description": "De datum waarop het object is gecre\u00eberd."
+            "description": "De datum waarop het object is gecreëerd."
           },
           "eindGeldigheid": {
             "type": "string",

--- a/tests/files/datasets/hr.json
+++ b/tests/files/datasets/hr.json
@@ -33,11 +33,7 @@
             "shortname": "sbiMaatschappelijk",
             "items": {
               "type": "object",
-              "properties": {
-                "bronwaarde": {
-                  "type": "integer"
-                }
-              }
+              "properties": { "bronwaarde": { "type": "integer" } }
             },
             "description": "De omschrijving van de activiteiten die de maatschappelijke activiteit uitoefent."
           },
@@ -46,11 +42,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "sbiActiviteitNummer": {
-                  "type": "integer"
-                }
-              }
+              "properties": { "sbiActiviteitNummer": { "type": "integer" } }
             },
             "relation": "hr:sbiactiviteiten",
             "description": "De omschrijving van de activiteiten die de onderneming uitoefent."
@@ -59,11 +51,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "bronwaarde": {
-                  "type": "integer"
-                }
-              }
+              "properties": { "bronwaarde": { "type": "integer" } }
             },
             "$comment": "relation hr:vestigingen",
             "description": "Een vestiging is gebouw of een complex van gebouwen waar duurzame uitoefening van activiteiten van een Onderneming of Rechtspersoon plaatsvindt."
@@ -74,12 +62,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "integer"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
               }
             },
             "relation": "verblijfsobjecten:verblijfsobjecten",
@@ -90,12 +74,8 @@
             "type": "object",
             "shortname": "gevestigdIn",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
             },
             "relation": "verblijfsobjecten:verblijfsobjecten",
             "description": "Relatie naar verblijfsobject",
@@ -128,5 +108,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/hr_auth.json
+++ b/tests/files/datasets/hr_auth.json
@@ -25,9 +25,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "identifier": {
-            "type": "string"
-          },
+          "identifier": { "type": "string" },
           "sbiActiviteitNummer": {
             "type": "string",
             "description": "Samenstelling van KvK-nummer en/of Vestigingsnummer of {BSN- of RSIN-nummer}",
@@ -42,5 +40,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/id_auth.json
+++ b/tests/files/datasets/id_auth.json
@@ -14,36 +14,23 @@
       "id": "base",
       "type": "table",
       "title": "Base",
-      "auth": [
-        "BASE"
-      ],
-      "reasonsNonPublic": [
-        "nader te bepalen"
-      ],
+      "auth": ["BASE"],
+      "reasonsNonPublic": ["nader te bepalen"],
       "version": "1.2.4",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "identifier": [
-          "id"
-        ],
-        "required": [
-          "schema",
-          "id"
-        ],
+        "identifier": ["id"],
+        "required": ["schema", "id"],
         "display": "title",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "id": {
-            "auth": [
-              "BASE/ID"
-            ],
-            "reasonsNonPublic": [
-              "nader te bepalen"
-            ],
+            "auth": ["BASE/ID"],
+            "reasonsNonPublic": ["nader te bepalen"],
             "type": "integer",
             "description": "Unieke aanduiding van het record."
           },

--- a/tests/files/datasets/id_type.json
+++ b/tests/files/datasets/id_type.json
@@ -19,13 +19,8 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "identifier": [
-          "uniqid"
-        ],
-        "required": [
-          "schema",
-          "uniqid"
-        ],
+        "identifier": ["uniqid"],
+        "required": ["schema", "uniqid"],
         "display": "uniqid",
         "properties": {
           "schema": {

--- a/tests/files/datasets/idcomposite.json
+++ b/tests/files/datasets/idcomposite.json
@@ -19,15 +19,8 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "identifier": [
-          "uniqid",
-          "sequenceNumber"
-        ],
-        "required": [
-          "schema",
-          "uniqid",
-          "sequenceNumber"
-        ],
+        "identifier": ["uniqid", "sequenceNumber"],
+        "required": ["schema", "uniqid", "sequenceNumber"],
         "display": "uniqid",
         "properties": {
           "schema": {
@@ -42,8 +35,8 @@
             "description": "Sequence number"
           },
           "id": {
-              "type": "integer",
-              "description": "Some external identifier"
+            "type": "integer",
+            "description": "Some external identifier"
           }
         }
       }

--- a/tests/files/datasets/identifier_ref.json
+++ b/tests/files/datasets/identifier_ref.json
@@ -18,20 +18,16 @@
         "identifier": "foobar",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "fubar",
-          "schema"
-        ],
+        "required": ["fubar", "schema"],
         "display": "fubar",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "fubar": {
-            "type": "string"
-          }
+          "fubar": { "type": "string" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/kadastraleobjecten.json
+++ b/tests/files/datasets/kadastraleobjecten.json
@@ -14,9 +14,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
@@ -68,12 +66,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": {
-                  "type": "string"
-                },
-                "volgnummer": {
-                  "type": "integer"
-                }
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
               }
             },
             "relation": "brk:kadastraleobjecten",
@@ -83,5 +77,6 @@
         "mainGeometry": "geometrie"
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/long_ids.json
+++ b/tests/files/datasets/long_ids.json
@@ -18,20 +18,16 @@
         "identifier": "fubar",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "fubar",
-          "schema"
-        ],
+        "required": ["fubar", "schema"],
         "display": "fubar",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "fubar": {
-            "type": "string"
-          }
+          "fubar": { "type": "string" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/meetbouten.json
+++ b/tests/files/datasets/meetbouten.json
@@ -21,27 +21,15 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "identificatie": {
-            "type": "integer"
-          },
+          "identificatie": { "type": "integer" },
           "ligtInBuurt": {
             "relation": "gebieden:buurten",
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              },
-              "beginGeldigheid": {
-                "type": "string",
-                "format": "date"
-              },
-              "eindGeldigheid": {
-                "type": "string",
-                "format": "date"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date" },
+              "eindGeldigheid": { "type": "string", "format": "date" }
             },
             "description": "De buurt waarbinnen de meetbout ligt"
           },
@@ -92,11 +80,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "identificatie": {
-                  "type": "string"
-                }
-              }
+              "properties": { "identificatie": { "type": "string" } }
             },
             "description": "De referentiepunten waar de metingen aan worden opgehangen"
           }
@@ -130,5 +114,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/meldingen.json
+++ b/tests/files/datasets/meldingen.json
@@ -33,5 +33,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/metaschema2.json
+++ b/tests/files/datasets/metaschema2.json
@@ -1,22 +1,24 @@
 {
+  "id": "metaschema2",
   "type": "dataset",
-  "id": "stadsdelen",
-  "title": "gebieden",
   "status": "beschikbaar",
-  "version": "0.0.1",
+  "version": "2.0.0",
+  "default_version": "2.0.0",
   "crs": "EPSG:28992",
+  "publisher": {
+    "$ref": "/publishers/HARRY"
+  },
   "tables": [
     {
-      "id": "stadsdelen",
-      "mainGeometry": "geometrie",
+      "id": "tabelleke",
       "type": "table",
       "version": "1.0.0",
       "schema": {
-        "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
+        "$id": "https://github.com/Amsterdam/schemas/tabelleke/referentiepunten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "identifier": ["id"],
+        "identifier": "identificatie",
         "required": ["schema", "id"],
         "display": "id",
         "properties": {
@@ -25,16 +27,14 @@
           },
           "id": {
             "type": "string",
-            "description": "Unieke identificatie voor dit object, inclusief volgnummer"
+            "description": "Unieke identificatie voor dit object"
           },
-          "ligtInGemeente": {
+          "identificatie": {
             "type": "string",
-            "$comment": "relation brk:gemeentes *stringify*",
-            "description": "De gemeente waar het stadsdeel in ligt."
+            "description": "Unieke identificatie van de meting"
           }
         }
       }
     }
-  ],
-  "publisher": "unknown"
+  ]
 }

--- a/tests/files/datasets/missing_properties.json
+++ b/tests/files/datasets/missing_properties.json
@@ -23,15 +23,12 @@
           },
           "broken_array": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "exclusiveMaximum": 11,
-              "minimum": 1
-              },
+            "items": { "type": "object", "exclusiveMaximum": 11, "minimum": 1 },
             "description": "This array is incorrect because it is missing a 'properties' object."
           }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/multirelation.json
+++ b/tests/files/datasets/multirelation.json
@@ -13,9 +13,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/woonplaatsen.json",
@@ -28,26 +26,18 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string"
-          },
+          "id": { "type": "string" },
           "hasFkRelation": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "string"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "string" }
             },
             "relation": "gebieden:buurten"
           },
           "hasNMRelation": {
             "type": "array",
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "relation": "baseDataset:internalRelated"
           }
         }
@@ -68,11 +58,10 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string"
-          }
+          "id": { "type": "string" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/parkeervakken.json
+++ b/tests/files/datasets/parkeervakken.json
@@ -17,10 +17,7 @@
         "identifier": ["id"],
         "required": ["id", "schema"],
         "properties": {
-          "id": {
-            "type": "string",
-            "description": ""
-          },
+          "id": { "type": "string", "description": "" },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
           },
@@ -29,25 +26,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "soort": {
-                  "type": "string",
-                  "description": ""
-                },
-                "eType": {
-                  "type": "string",
-                  "description": ""
-                },
-                "dagen": {
-                  "type": "array",
-                  "entity": {
-                    "type": "string"
-                  }
-                }
+                "soort": { "type": "string", "description": "" },
+                "eType": { "type": "string", "description": "" },
+                "dagen": { "type": "array", "entity": { "type": "string" } }
               }
             }
           }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/rel_auth.json
+++ b/tests/files/datasets/rel_auth.json
@@ -21,10 +21,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "stop": {
-            "type": "string",
-            "description": "U can't touch this."
-          }
+          "stop": { "type": "string", "description": "U can't touch this." }
         }
       }
     },
@@ -43,10 +40,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string",
-            "description": "Whatever"
-          },
+          "id": { "type": "string", "description": "Whatever" },
           "rel": {
             "type": "string",
             "description": "This should not be allowed",
@@ -55,5 +49,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/repetitive/repetitiveTable/v1.0.0.json
+++ b/tests/files/datasets/repetitive/repetitiveTable/v1.0.0.json
@@ -7,13 +7,8 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "identifier": [
-      "id"
-    ],
-    "required": [
-      "id",
-      "schema"
-    ],
+    "identifier": ["id"],
+    "required": ["id", "schema"],
     "display": "id",
     "properties": {
       "id": {

--- a/tests/files/datasets/schema_ref_validation.json
+++ b/tests/files/datasets/schema_ref_validation.json
@@ -17,18 +17,13 @@
         "identifier": "foo",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "foo",
-          "schema"
-        ],
+        "required": ["foo", "schema"],
         "display": "foo",
         "properties": {
           "schema": {
             "$ref": "https://invalid.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "foo": {
-            "type": "string"
-          }
+          "foo": { "type": "string" }
         }
       }
     },
@@ -43,20 +38,16 @@
         "identifier": "bar",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "bar",
-          "schema"
-        ],
+        "required": ["bar", "schema"],
         "display": "bar",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "bar": {
-            "type": "string"
-          }
+          "bar": { "type": "string" }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/verblijfsobjecten.json
+++ b/tests/files/datasets/verblijfsobjecten.json
@@ -13,9 +13,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/verblijfsobjecten.json",
@@ -38,31 +36,15 @@
             "type": "integer",
             "description": "Uniek volgnummer van de toestand van het object."
           },
-          "beginGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "eindGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          },
+          "beginGeldigheid": { "type": "string", "format": "date-time" },
+          "eindGeldigheid": { "type": "string", "format": "date-time" },
           "ligtInBuurt": {
             "type": "object",
             "properties": {
-              "identificatie": {
-                "type": "string"
-              },
-              "volgnummer": {
-                "type": "integer"
-              },
-              "beginGeldigheid": {
-                "type": "string",
-                "format": "date"
-              },
-              "eindGeldigheid": {
-                "type": "string",
-                "format": "date"
-              }
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date" },
+              "eindGeldigheid": { "type": "string", "format": "date" }
             },
             "relation": "gebieden:buurten",
             "description": "Buurt waarin het verblijfsobject ligt."
@@ -86,5 +68,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/woningbouwplannen.json
+++ b/tests/files/datasets/woningbouwplannen.json
@@ -46,7 +46,7 @@
           },
           "avarageSalesPriceIncorrectZero": {
             "type": "number",
-            "multipleOf": 0.00,
+            "multipleOf": 0.0,
             "description": "Gemiddelde verkoopprijs (test)"
           },
           "buurten": {
@@ -54,24 +54,19 @@
             "relation": "gebieden:buurten",
             "items": {
               "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              }
+              "properties": { "id": { "type": "string" } }
             },
             "description": "Buurten waarin het woningbouwplan ligt"
           },
           "buurtenAsScalar": {
             "type": "array",
             "relation": "gebieden:buurten",
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "description": "Buurten waarin het woningbouwplan ligt, simply as scalar"
           }
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/datasets/woonplaatsen.json
+++ b/tests/files/datasets/woonplaatsen.json
@@ -13,9 +13,7 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": {
-          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-        }
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/woonplaatsen.json",
@@ -28,9 +26,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string"
-          },
+          "id": { "type": "string" },
           "statusCode": {
             "type": "integer",
             "provenance": "$.status.code",
@@ -74,5 +70,6 @@
         }
       }
     }
-  ]
+  ],
+  "publisher": "unknown"
 }

--- a/tests/files/publishers/GLEBZ.json
+++ b/tests/files/publishers/GLEBZ.json
@@ -1,0 +1,1 @@
+{"name": "Datateam Glebz", "id": "GLEBZ", "shortname": "braft", "tags": {"costcenter": "12345.6789"}}

--- a/tests/files/publishers/HARRY.json
+++ b/tests/files/publishers/HARRY.json
@@ -1,0 +1,1 @@
+{"name": "Datateam Harry", "id": "HARRY", "shortname": "harhar", "tags": {"team": "taggy", "costcenter": "123456789.4321.13519"}}

--- a/tests/files/publishers/INCORRECT.json
+++ b/tests/files/publishers/INCORRECT.json
@@ -1,0 +1,1 @@
+{"name": "Datateam incorrect", "id": "NOTTHESAMEASFILENAME", "shortname": "nono", "tags": {"team": "taggy", "costcenter": "1236789.4321.13519"}}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,22 @@
+def test_load_all_publishers(schema_loader):
+    pubs = schema_loader.get_all_publishers()
+    assert pubs == {
+        "GLEBZ": {
+            "id": "GLEBZ",
+            "name": "Datateam Glebz",
+            "shortname": "braft",
+            "tags": {"costcenter": "12345.6789"},
+        },
+        "HARRY": {
+            "id": "HARRY",
+            "name": "Datateam Harry",
+            "shortname": "harhar",
+            "tags": {"costcenter": "123456789.4321.13519", "team": "taggy"},
+        },
+        "NOTTHESAMEASFILENAME": {
+            "id": "NOTTHESAMEASFILENAME",
+            "name": "Datateam incorrect",
+            "shortname": "nono",
+            "tags": {"costcenter": "1236789.4321.13519", "team": "taggy"},
+        },
+    }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -52,6 +52,7 @@ def test_datasetschema_from_file_not_a_dataset(schema_loader) -> None:
         # v1.0.0.json is a DatasetRow, not a DatasetSchema.
         schema_loader.get_dataset_from_file("gebieden_sep_tables/bouwblokken/v1.0.0.json")
 
+    error_msg = "Invalid JSON file"
     with pytest.raises(ValueError, match=error_msg):
         # not_a_json_file.txt is not a JSON file. We should still get our ValueError.
         schema_loader.get_dataset_from_file("not_a_json_file.txt")
@@ -260,3 +261,16 @@ def test_raise_exception_on_missing_properties_in_array(schema_loader):
         KeyError, match=r"Key 'properties' not defined in 'meetbouten.broken_array'"
     ):
         schema.get_table_by_id("meetbouten")
+
+
+def test_load_publisher_object_from_dataset(schema_loader):
+    """Test that we can retrieve a publisher object from a DatasetSchema
+    as defined by metaschema 2.0"""
+    schema = schema_loader.get_dataset_from_file("metaschema2.json")
+
+    assert schema.publisher == {
+        "name": "Datateam Harry",
+        "id": "HARRY",
+        "shortname": "harhar",
+        "tags": {"team": "taggy", "costcenter": "123456789.4321.13519"},
+    }


### PR DESCRIPTION
* Support for loading and validating publishers from the schema server as top-level objects
* Support for inlining  and validating referenced publisher objects inside datasets as defined in metaschema 2

The main idea is that the publishers location is a well known directory which can be derived from SCHEMA_URL (i.e. a /publishers directory at the same level as /datasets).

I will release a new schema-tools version in a separate PR because we need to deploy metaschema 2 with the properly structured publishers directory first. 

All commands have been tested against a local amsterdam-schema devserver

Also, all test fixtures had to be updated because (ofcourse) they were not compliant with the metaschema