### PR TITLE
Metaschema aware schematools

### DIFF
--- a/src/schematools/__init__.py
+++ b/src/schematools/__init__.py
@@ -31,3 +31,8 @@ SRID_3D: Final[List[int]] = [
     4979,  # WGS84 + height
     4978,  # WGS84 + geocentric height
 ]
+# The meta-schema major versions in amsterdam-schema that this
+# package version is compatible with. This means that it
+# can only handle schema objects that are compliant
+# under at least one of these versions.
+COMPATIBLE_METASCHEMAS = [1, 2]

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -465,12 +465,10 @@ def validate_publishers(schema_url: str, meta_schema_url: tuple[str]) -> None:
         SCHEMA_URL=https://example.com/datasets, the publishers are extracted from
         https://example.com/publishers.
     """  # noqa: D301,D412,D417
-    ordered = sorted(
-        [(u, version_from_metaschema_url(u)) for u in set(meta_schema_url)],
-        key=lambda t: t[1],
+    for meta_schema_version, url in sorted(
+        [(version_from_metaschema_url(u), u) for u in set(meta_schema_url)],
         reverse=True,
-    )
-    for url, meta_schema_version in ordered:
+    ):
         meta_schema = _fetch_json(url)
         if meta_schema_version.major not in COMPATIBLE_METASCHEMAS:
             raise IncompatibleMetaschema(

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -399,12 +399,10 @@ def validate(
     for schema in additional_schemas:
         _get_dataset_schema(schema, schema_url)
 
-    ordered = sorted(
-        [(u, version_from_metaschema_url(u)) for u in set(meta_schema_url)],
-        key=lambda t: t[1],
+    for meta_schema_version, url in sorted(
+        [(version_from_metaschema_url(u), u) for u in set(meta_schema_url)],
         reverse=True,
-    )
-    for url, meta_schema_version in ordered:
+    ):
         click.echo(f"Validating against metaschema {meta_schema_version}")
         meta_schema = _fetch_json(url)
         if meta_schema_version.major not in COMPATIBLE_METASCHEMAS:

--- a/src/schematools/exceptions.py
+++ b/src/schematools/exceptions.py
@@ -16,3 +16,13 @@ class DatasetTableNotFound(SchemaObjectNotFound):
 
 class DatasetFieldNotFound(SchemaObjectNotFound):
     """The field could not be found."""
+
+
+class IncompatibleMetaschema(ValueError):
+    """This package version of schema-tools
+    is being used with a metaschema that it is
+    not compatible with."""
+
+
+class PendingMetaschemaDeprecation(PendingDeprecationWarning):
+    """The used metaschema is marked for deprecation."""

--- a/src/schematools/exceptions.py
+++ b/src/schematools/exceptions.py
@@ -18,7 +18,7 @@ class DatasetFieldNotFound(SchemaObjectNotFound):
     """The field could not be found."""
 
 
-class IncompatibleMetaschema(ValueError):
+class IncompatibleMetaschema(Exception):
     """This package version of schema-tools
     is being used with a metaschema that it is
     not compatible with."""

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -210,10 +210,18 @@ def _repetitive_naming(dataset: DatasetSchema) -> Iterator[str]:
     for table in dataset.tables:
         if table.id != dataset.id and table.id.startswith(dataset.id):
             yield f"table name {table.id!r} should not start with {dataset.id!r}"
-        for field in table.fields:
-            for prefix in [dataset.id, table.id]:
-                if field.id.startswith(prefix):
-                    yield f"field name {field.id!r} should not start with {prefix!r}"
+        # NOTE: The code below is temporarily commented out because a lot of datasets are not
+        # compliant with this rule (the precommit hook in ams-schema was
+        # misconfigured, causing it to bypass checks on a lot of schemas for a long time).
+        #
+        # Making all datasets compliant with this is a lot of work and there is no known
+        # component downstream which breaks because of violation of this rule, so until
+        # we get all datasets compliant, we bypass this check.
+
+        # for field in table.fields:
+        # for prefix in [dataset.id, table.id]:
+        # if field.id.startswith(prefix):
+        # yield f"field name {field.id!r} should not start with {prefix!r}"
 
 
 @_register_validator("identifier properties")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from schematools import validation
 from schematools.permissions import PUBLIC_SCOPE
 from schematools.types import DatasetSchema
@@ -246,6 +248,7 @@ def test_rel_auth_field(here: Path) -> None:
     assert any("requires scopes ['HAMMERTIME']" in str(e) for e in errors)
 
 
+@pytest.mark.skip(reason="See comment in validator function")
 def test_repetitive_naming(here: Path, schema_loader) -> None:
     dataset = schema_loader.get_dataset("repetitive")
     errors = {str(e) for e in validation.run(dataset)}


### PR DESCRIPTION
* Schematools now defines which metaschemas it can work with and restricts its usage to these versions
* The validation logic is updated to support validation attempts on multiple metaschema versions so we can transition datasets from one major version to another in amsterdam-schema
* `DatasetTableSchema.validate` and `DatasetTableSchema._resolve` have been removed because they are remnants of an abandoned atempt to make datase-schema an table-schema compliant JSON schemas