### PR TITLE
Publisher validation precommit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,13 @@
 - id: validate-schema
-  name: Validate Schema
-  description: Validate Amsterdam Schema files
+  name: Validate Schema datasets
+  description: Validate Amsterdam Schema dataset files
   entry: schema batch-validate
   language: python
   types: ["json"]
+- id: validate-publishers
+  name: Validate Schema publishers
+  description: Validate Amsterdam Schema publisher files
+  entry: schema validate-publishers
+  language: python
+  exclude: ^.*$ # prevent passing any files
+  always_run: true

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -554,7 +554,10 @@ def batch_validate(
         if main_file in done:
             continue
 
-        for url in [meta_schema_url, extra_meta_schema_url]:
+        meta_schema_urls = [meta_schema_url]
+        if extra_meta_schema_url:
+            meta_schema_urls.append(extra_meta_schema_url)
+        for url in meta_schema_urls:
             meta_schema_version = version_from_metaschema_url(url)
             click.echo(f"Validating {main_file} against {meta_schema_version}")
 


### PR DESCRIPTION
* main feature in the title
* fixed a bug in batch_validate which assumed the presence of an optional argument

This has been tested on amsterdam-schema by using a local reference to the schematools repository in the pre commit hook config