### PR TITLE
Better error messages from schema batch-validate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-01-16 (5.5.1)
+
+* ``schema batch-validate`` now produces more readable error messages.
+
 # 2023-01-13 (5.5.0)
 
 * Bugfix in CLI batch_validate that caused validation to stop at the first invalid schema

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.5.0
+version = 5.5.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -578,7 +578,7 @@ def batch_validate(
                 )
             except (jsonschema.ValidationError, jsonschema.SchemaError) as struct_error:
                 errors[schema_file][meta_schema_version].append(
-                    f"{struct_error.message}: ({', '.join(struct_error.path)})"
+                    f"{struct_error}: ({', '.join(struct_error.path)})"
                 )
 
             for sem_error in validation.run(dataset, schema_file):


### PR DESCRIPTION
`jsonschema.ValidationError.message` is much less informative than its `__str__`. The former is also squashed into a single line that gets trimmed down by GitHub Actions so that only a part of the schema JSON appears in the UI.