### PR TITLE
AB#61561 Support object fields in amsterdam schema

### DIFF
--- a/src/schematools/contrib/django/faker/__init__.py
+++ b/src/schematools/contrib/django/faker/__init__.py
@@ -175,6 +175,7 @@ DECLARATION_LOOKUP = {
     "boolean": Faker("boolean"),
     "array": Faker("pylist", {"value_types": [str]}),
     "object": Faker("pystr"),  # needs a concatenated key field
+    "json": Faker("json"),
     "/definitions/id": Faker("pyint"),
     "/definitions/schema": Faker("text"),
     "https://geojson.org/schema/Geometry.json": GeoFaker(

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -10,7 +10,7 @@ from typing import DefaultDict, cast
 
 from geoalchemy2.types import Geometry
 from psycopg2 import sql
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Numeric, String, Time
+from sqlalchemy import JSON, BigInteger, Boolean, Date, DateTime, Float, Numeric, String, Time
 from sqlalchemy.sql.schema import Column, Index, MetaData, Table
 from sqlalchemy.types import ARRAY
 
@@ -32,6 +32,7 @@ FORMAT_MODELS_LOOKUP = {
     "date-time": DateTime,
     "uri": String,
     "email": String,
+    "json": JSON,
 }
 
 JSON_TYPE_TO_PG = {

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -172,6 +172,8 @@ class TableFieldMapper:
         elif field.id in self.inactive_relation_info:
             # Convert nested object to JSON string
             return json.dumps(value)
+        elif field.is_json_object:
+            return value
         elif isinstance(value, (dict, list)):
             raise ValueError(
                 f"Value of '{field.qualified_id}' should resolve to a scalar, not: {value!r}"

--- a/tests/files/data/kadastraleobjecten.ndjson
+++ b/tests/files/data/kadastraleobjecten.ndjson
@@ -1,2 +1,2 @@
-{"id": "10", "identificatie": "KAD.001", "volgnummer": 1, "isOntstaanUitKadastraalobject": [{"identificatie": "KAD.002", "volgnummer": 1}]}
-{"id": "11", "identificatie": "KAD.002", "volgnummer": 1, "isOntstaanUitKadastraalobject": []}
+{"id": "10", "identificatie": "KAD.001", "volgnummer": 1, "isOntstaanUitKadastraalobject": [{"identificatie": "KAD.002", "volgnummer": 1}], "soortGrootte": {"foo": 12}, "soortCultuurOnbebouwd": null}
+{"id": "11", "identificatie": "KAD.002", "volgnummer": 1, "isOntstaanUitKadastraalobject": [], "soortGrootte": null, "soortCultuurOnbebouwd": {"code": "aa", "omschrijving": "foo"}}

--- a/tests/files/datasets/kadastraleobjecten.json
+++ b/tests/files/datasets/kadastraleobjecten.json
@@ -41,6 +41,21 @@
             "type": "integer",
             "description": "Uniek volgnummer van de toestand van het object."
           },
+          "soortGrootte": {
+              "type": "object",
+              "format": "json"
+          },
+          "soortCultuurOnbebouwd": {
+              "type": "object",
+              "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "omschrijving": {
+                    "type": "string"
+                  }
+              }
+          },
           "beginGeldigheid": {
             "type": "string",
             "format": "date-time",

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -260,24 +260,30 @@ def test_ndjson_import_nm_composite_selfreferencing_keys(
     records = [dict(r) for r in engine.execute("SELECT * from brk_kadastraleobjecten order by id")]
     assert records == [
         {
-            "id": "KAD.001.1",
-            "identificatie": "KAD.001",
-            "volgnummer": 1,
             "begin_geldigheid": None,
             "eind_geldigheid": None,
+            "id": "KAD.001.1",
+            "identificatie": "KAD.001",
             "koopsom": None,
             "neuron_id": "10",
             "registratiedatum": None,
+            "soort_cultuur_onbebouwd_code": None,
+            "soort_cultuur_onbebouwd_omschrijving": None,
+            "soort_grootte": {"foo": 12},
+            "volgnummer": 1,
         },
         {
-            "id": "KAD.002.1",
-            "identificatie": "KAD.002",
-            "volgnummer": 1,
             "begin_geldigheid": None,
             "eind_geldigheid": None,
+            "id": "KAD.002.1",
+            "identificatie": "KAD.002",
             "koopsom": None,
             "neuron_id": "11",
             "registratiedatum": None,
+            "soort_cultuur_onbebouwd_code": "aa",
+            "soort_cultuur_onbebouwd_omschrijving": "foo",
+            "soort_grootte": None,
+            "volgnummer": 1,
         },
     ]
 


### PR DESCRIPTION
Objects fields that are not a relation are now 'flattened' to fit in the relational database. So, a schema definition with the following field:

```
"naamGebruik": {
  "type": "object",
  "properties": {
      "code": {
	  "type": "string"
      },
      "omschrijving": {
	  "type": "string"
      }
  }
}

```
will generate a Django model that has fields `naam_gebruik_code` and `naam_gebruik_omschrijving`.

Furthermore, a json type field has been added, so the following field:

```
"soortGrootte": {
    "type": "object",
    "format": "json"
}

```
will generate a jsonb field in the Postgres database.

NB. the structure of this json field is not validated! So, the only check is that the postgres database ensures that the data can be parsed as json.

Also the mocker has been updated to correctly supply these object fields with fake data.

The ndjson importer has been updated so that incoming ndjson records with object fields are processed in the correct way.

The relevant tests have been changed and new tests have been added.