### PR TITLE
Remove schematools.contrib.django.default_app_config

### DIFF
--- a/src/schematools/contrib/django/__init__.py
+++ b/src/schematools/contrib/django/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "schematools.contrib.django.apps.SchematoolsAppConfig"


### PR DESCRIPTION
This is no longer needed as of [Django 3.2](https://docs.djangoproject.com/en/3.2/ref/applications/#for-application-authors). Removes the only deprecation warning given by

    python -Wa src/manage.py test

in DSO-API.