### PR TITLE
Fix semantic validator that assures dataset id is identical to dataset file directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-# 2023-01- 23(5.6.0)
+# 2023-01-24 23(5.6.1)
+
+* Bugfix for regression which caused dataset id to be matched with the path of a table
+when the validated schemafile is a table.
+
+# 2023-01-23 (5.6.0)
 
 * Feature added to enable use of object fields in amsterdam schema.
   Those fields are flattened in the relational schema (added to the parent table).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.0
+version = 5.6.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -581,7 +581,7 @@ def batch_validate(
                     f"{struct_error}: ({', '.join(struct_error.path)})"
                 )
 
-            for sem_error in validation.run(dataset, schema_file):
+            for sem_error in validation.run(dataset, main_file):
                 errors[schema_file][meta_schema_version].append(str(sem_error))
 
             if not errors[schema_file][meta_schema_version]:

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -109,6 +109,8 @@ def _id_matches_path(dataset: DatasetSchema, location: str | None) -> Iterator[s
     For datasets is subdirectories the path components should match the id like:
     'my/nested/location/dataset.json' -> 'myNestedLocation'
 
+    Arguments:
+        location: Location of the dataset file (relative to root or absolute)
     """
     if location is not None:
         path = Path(location)


### PR DESCRIPTION
This is a regression that was introduced when we added functionality to support validating schemafiles that are tables, because `validation.run` implicitly assumed that the passed location was always the dataset file location