### PR TITLE
Print error path as is from batch-validate

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -578,7 +578,7 @@ def batch_validate(
                 )
             except (jsonschema.ValidationError, jsonschema.SchemaError) as struct_error:
                 errors[schema_file][meta_schema_version].append(
-                    f"{struct_error}: ({', '.join(struct_error.path)})"
+                    f"{struct_error}: {struct_error.path}"
                 )
 
             for sem_error in validation.run(dataset, main_file):


### PR DESCRIPTION
Apparently, the path in a jsonschema.ValidationError can contain any types, as seen in the TypeError at

    https://github.com/Amsterdam/amsterdam-schema/actions/runs/4045114336/jobs/6956149861

Just print it in Python syntax. We'll figure it out.