### PR TITLE
Yrob/fix json export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,13 @@
+# 2023-02-07(5.6.7)
+
+* Bugfix Dataset.json not properly dereferencing publisher property
+
 # 2023-02-07(5.6.6)
 
 * Fix names for the subfields of an objectfield. These names need a prefix,
   because they are exposed externally in the DSO API.
 
-# 2023-01-30(5.6.5)
+# 2023-02-01(5.6.5)
 
 * Print error path as is from batch-validate.
 * Bugfix for loader methods get_publisher and get_all_publishers.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.6
+version = 5.6.7
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -293,13 +293,9 @@ class DatasetSchema(SchemaType):
 
         data = self.data.copy()
         if inline_tables and any(t.get("$ref") for t in self["tables"]):
-            data["tables"] = [t.data for t in self.tables]
-        if inline_publishers:
-            # compatibility with metaschema 1 en 2
-            if type(self.publisher) == dict:
-                self["publisher"] = self.publisher.json_data()
-            else:
-                self["publisher"] = self["publisher"]
+            data["tables"] = [t.json_data() for t in self.tables]
+        if inline_publishers and self.publisher is not None:
+            data["publisher"] = self.publisher.json_data()
         return json.dumps(data)
 
     def json_data(self, inline_tables: bool = False, inline_publishers: bool = False) -> Json:
@@ -412,7 +408,7 @@ class DatasetSchema(SchemaType):
     @cached_property
     def publisher(self) -> Publisher | None:
         """Access the publisher within the file."""
-        raw_publisher = self.json_data()["publisher"]
+        raw_publisher = self["publisher"]
         if type(raw_publisher) == str:
             # Compatibility with meta-schemas prior to 2.0
             if self.loader is None:


### PR DESCRIPTION
# Fix dereference publisher in dataset json export

Publisher property was not dereferenced in json export.
Bump to 5.6.7