### PR TITLE
Pin pg-grant to 0.3.2, to stay compatible with SA < 1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-02-14(5.6.8)
+
+* Pin pg-grant to 0.3.2 to stay compatible with SQLAlchemy
+
 # 2023-02-07(5.6.7)
 
 * Bugfix Dataset.json not properly dereferencing publisher property

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.7
+version = 5.6.8
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)
@@ -29,7 +29,7 @@ install_requires =
     sqlalchemy < 1.4.0
     geoalchemy2
     psycopg2
-    pg-grant
+    pg-grant == 0.3.2
     click
     deepdiff
     jsonschema[format] >= 3.2.0


### PR DESCRIPTION
Our own SQLAlchemy code is not compatible with SA >= 1.4.