### PR TITLE
Patch release 5.6.9: Dont inline publishers in structural validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-02-21(5.6.9)
+
+* Fix structural validation of publisher references by not inlining them in the json held against the metaschema.
+
 # 2023-02-14(5.6.8)
 
 * Pin pg-grant to 0.3.2 to stay compatible with SQLAlchemy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.8
+version = 5.6.9
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -572,7 +572,7 @@ def batch_validate(
             meta_schema = _fetch_json(url)
             try:
                 jsonschema.validate(
-                    instance=dataset.json_data(inline_tables=True, inline_publishers=True),
+                    instance=dataset.json_data(inline_tables=True, inline_publishers=False),
                     schema=meta_schema,
                     format_checker=draft7_format_checker,
                 )


### PR DESCRIPTION
The metaschema enforces a $ref in the publishers reference but the json we hold against it is inlining them. Not so good.