### PR TITLE
Pin GeoAlchemy2 to 1.12.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+# 2023-02-22(5.6.10)
+* Require SqlAlchemy <= 1.12.5
 # 2023-02-21(5.6.9)
 
 * Fix structural validation of publisher references by not inlining them in the json held against the metaschema.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.9
+version = 5.6.10
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >= 3.9
 install_requires =
     sqlalchemy < 1.4.0
-    geoalchemy2
+    geoalchemy2 <=1.12.5
     psycopg2
     pg-grant == 0.3.2
     click


### PR DESCRIPTION
The next version (1.13.0) requires  sqlalchemy >=1.4.0 Where we require sqlalchemy < 1.4.0