### PR TITLE
Fix schema validate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
+# Upcoming release
+
+* The ``schema validate`` command was fixed to work with v2 publishers.
+
 # 2023-02-22(5.6.10)
-* Require SqlAlchemy <= 1.12.5
+
+* Require SQLAlchemy <= 1.12.5
+
 # 2023-02-21(5.6.9)
 
 * Fix structural validation of publisher references by not inlining them in the json held against the metaschema.
@@ -20,7 +26,7 @@
 # 2023-02-01(5.6.5)
 
 * Print error path as is from batch-validate.
-* Bugfix for loader methods get_publisher and get_all_publishers.
+* Bugfix for loader methods ``get_publisher`` and ``get_all_publishers``.
 * Dataset.publisher returns publisher object irrespective of schema version.
 
 # 2023-01-30(5.6.4)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -205,7 +205,7 @@ class SchemaType(JsonDict):
         return f"{self.__class__.__name__}({self.data!r})"
 
     def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self!r}")
+        raise KeyError(f"No field named '{key}' exists in {self.__class__.__name__}")
 
     def __hash__(self) -> int:
         return id(self)  # allow usage in lru_cache()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,14 @@ import operator
 import pytest
 
 from schematools.exceptions import SchemaObjectNotFound
-from schematools.types import DatasetSchema, Permission, PermissionLevel, ProfileSchema, SemVer
+from schematools.types import (
+    DatasetSchema,
+    DatasetTableSchema,
+    Permission,
+    PermissionLevel,
+    ProfileSchema,
+    SemVer,
+)
 
 
 def test_permission_level_ordering() -> None:
@@ -292,3 +299,13 @@ def test_load_publisher_object_from_dataset(schema_loader):
         "shortname": "harhar",
         "tags": {"team": "taggy", "costcenter": "123456789.4321.13519"},
     }
+
+
+def test_repr_broken_schema():
+    """Regression test: __repr__ and __missing__ performed infinite mutual recursion
+    when dealing with broken schemas.
+    """
+    try:
+        DatasetTableSchema({}, parent_schema=None)
+    except KeyError:  # KeyError is ok, RecursionError isn't.
+        pass


### PR DESCRIPTION
* When no META_SCHEMA_URL was given, schema validate reported invalid against all metaschemas.
* A schema that was invalid for one version was reported as invalid for all versions.
* schema validate was inconsistent with batch-validate because of differing inline_publishers settings.

For [AB#68513](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/68513).