### PR TITLE
Fix repr of SchemaType in case of missing keys

### DIFF
--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -205,7 +205,7 @@ class SchemaType(JsonDict):
         return f"{self.__class__.__name__}({self.data!r})"
 
     def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self!r}")
+        raise KeyError(f"No field named '{key}' exists in {self.__class__.__name__}")
 
     def __hash__(self) -> int:
         return id(self)  # allow usage in lru_cache()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,14 @@ import operator
 import pytest
 
 from schematools.exceptions import SchemaObjectNotFound
-from schematools.types import DatasetSchema, Permission, PermissionLevel, ProfileSchema, SemVer
+from schematools.types import (
+    DatasetSchema,
+    DatasetTableSchema,
+    Permission,
+    PermissionLevel,
+    ProfileSchema,
+    SemVer,
+)
 
 
 def test_permission_level_ordering() -> None:
@@ -292,3 +299,13 @@ def test_load_publisher_object_from_dataset(schema_loader):
         "shortname": "harhar",
         "tags": {"team": "taggy", "costcenter": "123456789.4321.13519"},
     }
+
+
+def test_repr_broken_schema():
+    """Regression test: __repr__ and __missing__ performed infinite mutual recursion
+    when dealing with broken schemas.
+    """
+    try:
+        DatasetTableSchema({}, parent_schema=None)
+    except KeyError:  # KeyError is ok, RecursionError isn't.
+        pass


### PR DESCRIPTION
I just got a "maximum recursion depth exceeded" error from a broken schema. The issue is that exceptions use its __repr__, which calls qualified_id, which looks up the 'id', which causes a trap to __missing__, which again calls __repr__. This cycle is now broken.