### PR TITLE
Validate enum types in schemas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * The ``schema validate`` command was fixed to work with v2 publishers.
 * Validation errors are reporting in a hopefully more readable format.
+* ``enum`` values in schemas are now type-checked during validation.
 
 # 2023-02-22 (5.6.10)
 

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -102,6 +102,29 @@ def _camelcase_ident(ident: str) -> str | None:
     return f"{ident} does not survive conversion to snake case and back; suggestion: {camel}"
 
 
+@_register_validator("enum type error")
+def _enum_types(dataset: DatasetSchema, location: str | None) -> Iterator[str]:
+    for table in dataset.tables:
+        for field in table.fields:
+            enum = field.get("enum")
+            if not enum:
+                continue
+
+            if field.type == "integer":
+                typ = int
+                a = "an"
+            elif field.type == "string":
+                typ = str
+                a = "a"
+            else:
+                yield f"{field.id}: enum of type {field.type} not possible"
+                continue
+
+            for v in enum:
+                if not isinstance(v, typ):
+                    yield f"value {v!r} in field {field.id} is not {a} {field.type}"
+
+
 @_register_validator("ID does not match file path")
 def _id_matches_path(dataset: DatasetSchema, location: str | None) -> Iterator[str]:
     """Dataset Identifiers should equal the parent paths to assure uniqueness.

--- a/tests/files/datasets/enum_types.json
+++ b/tests/files/datasets/enum_types.json
@@ -1,0 +1,49 @@
+{
+  "id": "enumtypes",
+  "type": "dataset",
+  "description": "Dataset with enum errors",
+  "license": "public",
+  "status": "niet_beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["id"],
+        "required": ["schema", "id"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke aanduiding van het record."
+          },
+          "enumInts": {
+            "type": "integer",
+            "enum": [0, 1, "foo"]
+          },
+          "enumStrs": {
+            "type": "string",
+            "enum": ["foo", "bar", 2]
+          },
+          "enumFloats": {
+            "type": "number",
+            "enum": [2.718281828459045, 3.141592653589793]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -35,6 +35,26 @@ def test_camelcase() -> None:
         assert error.endswith(f"suggestion: {suggest}")
 
 
+def test_enum_types(schema_loader) -> None:
+    dataset = schema_loader.get_dataset_from_file("enum_types.json")
+
+    errors = validation.run(dataset)
+
+    error = next(errors)
+    assert error.validator_name == "enum type error"
+    assert error.message == "value 'foo' in field enumInts is not an integer"
+
+    error = next(errors)
+    assert error.validator_name == "enum type error"
+    assert error.message == "value 2 in field enumStrs is not a string"
+
+    error = next(errors)
+    assert error.validator_name == "enum type error"
+    assert error.message == "enumFloats: enum of type number not possible"
+
+    assert list(errors) == []
+
+
 def test_id_auth(schema_loader) -> None:
     dataset = schema_loader.get_dataset_from_file("id_auth.json")
 


### PR DESCRIPTION
From now on, enums are only allowed with types string and integer. The schema spec has no rule for this, so we could allow object enums in theory, but I'm not sure those are actually implemented. Change this if someone does want an object enum.

Fixes [AB#52842](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/52842).