### PR TITLE
Fix authorisation on array fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2023-03-08 (5.6.12)
+
+* Security fix: authorisation on fields with subfields was incorrectly
+  handled.
+
 # 2023-02-27 (5.6.11)
 
 * The ``schema validate`` command was fixed to work with v2 publishers.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.6.11
+version = 5.6.12
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -497,7 +497,7 @@ class DatasetSchema(SchemaType):
             "originalID": field.id,
             "type": "table",
             "version": str(table.version),
-            "auth": list(field.auth | table.auth),  # pass same auth rules as field has
+            "auth": list(table.auth),
             "description": f"Auto-generated table for nested field: {table.id}.{field.id}",
             "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -507,7 +507,11 @@ class DatasetSchema(SchemaType):
                 "properties": {
                     "id": {"type": "integer/autoincrement", "description": ""},
                     "schema": {"$ref": "#/definitions/schema"},
-                    "parent": {"type": parent_fk_type, "relation": f"{self.id}:{table.id}"},
+                    "parent": {
+                        "type": parent_fk_type,
+                        "relation": f"{self.id}:{table.id}",
+                        "auth": list(field.auth),
+                    },
                     **field["items"]["properties"],
                 },
             },


### PR DESCRIPTION
Authorisation on these fields was implemented by setting an "auth" with the union of table and field scopes on the synthetic table schema for the field's database table. That means that having any of these scopes, rather than at least one of the table scopes and one of the field scopes, allowed access to the array field.

The field scopes are now set on the synthetic parent field's "auth", which is what DSO-API checks when looking for fields to omit.