### PR TITLE
Fix code to enable attributes on a relation

### DIFF
--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -210,9 +210,10 @@ class TableFieldMapper:
         """Process a composite foreign key"""
         # Flatten subfields, as they are part of the same record.
         fk_value_parts = []
+        relation_attributes = rel_field.relation_attributes
         for subfield in rel_field.subfields:
             # Any date-ranges of a composite key are not inlined in the main object
-            if subfield.is_temporal_range:
+            if subfield.is_temporal_range or subfield.id in relation_attributes:
                 continue
 
             if value is None:

--- a/tests/files/data/brk_aantek_rechten.ndjson
+++ b/tests/files/data/brk_aantek_rechten.ndjson
@@ -1,0 +1,1 @@
+{"id": "01", "identificatie": "01", "isGebaseerdOpStukdeel": {"identificatie": "013", "beginGeldigheid": "2012-01-01"}}

--- a/tests/files/datasets/brk.json
+++ b/tests/files/datasets/brk.json
@@ -14,7 +14,9 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
@@ -28,7 +30,10 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": { "type": "string", "description": "Neuron ID" },
+          "id": {
+            "type": "string",
+            "description": "Neuron ID"
+          },
           "volgnummer": {
             "type": "integer",
             "description": "Uniek volgnummer van de toestand van het object."
@@ -58,7 +63,10 @@
             "type": "integer",
             "description": "Volgnummer van het Appartementsrecht"
           },
-          "gemeente": { "type": "string", "description": "" },
+          "gemeente": {
+            "type": "string",
+            "description": ""
+          },
           "soortGrootteCode": {
             "type": "string",
             "provenance": "$.soortGrootte.code",
@@ -88,8 +96,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "code": { "type": "string" },
-                "omschrijving": { "type": "string" }
+                "code": {
+                  "type": "string"
+                },
+                "omschrijving": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -165,8 +177,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": { "type": "string" },
-                "volgnummer": { "type": "string" }
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
               }
             },
             "relation": "verblijfsobjecten:verblijfsobjecten",
@@ -182,7 +198,9 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/zakelijkerechten.json",
@@ -226,8 +244,12 @@
           "rustOpKadastraalobject": {
             "type": "object",
             "properties": {
-              "identificatie": { "type": "string" },
-              "volgnummer": { "type": "string" }
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "string"
+              }
             },
             "relation": "brk:kadastraleobjecten",
             "description": "Het kadastraal object en volgnummer waarop het zakelijk recht rust"
@@ -578,7 +600,9 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
@@ -596,10 +620,21 @@
             "type": "string",
             "description": "De identificatie is een uniek nummer aan deze tenaamstelling binnen de kadastrale registratie."
           },
-          "volgnummer": { "type": "integer", "description": "" },
+          "volgnummer": {
+            "type": "integer",
+            "description": ""
+          },
           "vanKadastraalsubject": {
             "type": "object",
-            "properties": { "identificatie": { "type": "string" } },
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
             "relation": "brk:kadastralesubjecten",
             "description": "Het Subject waarvoor deze tenaamstelling geldt."
           },
@@ -653,12 +688,19 @@
             "provenance": "$.verkregenNamensSamenwerkingsverband.omschrijving",
             "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. omschrijving"
           },
-          "inOnderzoek": { "type": "string", "description": "" },
+          "inOnderzoek": {
+            "type": "string",
+            "description": ""
+          },
           "vanZakelijkrecht": {
             "type": "object",
             "properties": {
-              "identificatie": { "type": "string" },
-              "volgnummer": { "type": "string" }
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "string"
+              }
             },
             "relation": "brk:zakelijkerechten",
             "description": "Het Zakelijk recht waarover deze tenaamstelling gaat."
@@ -687,7 +729,10 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": { "type": "string", "description": "Neuron ID" },
+          "id": {
+            "type": "string",
+            "description": "Neuron ID"
+          },
           "identificatie": {
             "type": "string",
             "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
@@ -715,13 +760,27 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": { "identificatie": { "type": "string" } }
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              }
             },
             "relation": "brk:kadastralesubjecten",
             "description": "Identificatie van het betrokken subject"
           },
           "isGebaseerdOpStukdeel": {
-            "type": "string",
+            "shortname": "isGbsdOpSdl",
+            "type": "object",
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
             "relation": "brk:stukdelen",
             "description": "Identificatie van het betrokken stukdeel"
           },
@@ -744,7 +803,9 @@
       "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
-        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
       },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenkadastraleobjecten.json",
@@ -799,7 +860,11 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": { "identificatie": { "type": "string" } }
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              }
             },
             "relation": "brk:kadastralesubjecten",
             "description": "Identificatie van het betrokken subject"
@@ -807,8 +872,12 @@
           "heeftBetrekkingOpKadastraalObject": {
             "type": "object",
             "properties": {
-              "identificatie": { "type": "string" },
-              "volgnummer": { "type": "string" }
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "string"
+              }
             },
             "relation": "brk:kadastraleobjecten",
             "description": "Identificatie van het kadastrale object (onroerende zaak)"
@@ -874,8 +943,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": { "type": "string" },
-                "volgnummer": { "type": "string" }
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
               }
             },
             "relation": "brk:aantekeningenkadastraleobjecten",
@@ -885,7 +958,11 @@
             "type": "array",
             "items": {
               "type": "object",
-              "properties": { "identificatie": { "type": "string" } }
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              }
             },
             "relation": "brk:aantekeningenrechten",
             "description": "Geeft weer welke aantekening recht is ontstaan op basis van dit stukdeel"
@@ -895,8 +972,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "identificatie": { "type": "string" },
-                "volgnummer": { "type": "string" }
+                "identificatie": {
+                  "type": "string"
+                },
+                "volgnummer": {
+                  "type": "string"
+                }
               }
             },
             "relation": "brk:zakelijkerechten",
@@ -1057,7 +1138,10 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": { "type": "integer", "description": "" },
+          "id": {
+            "type": "integer",
+            "description": ""
+          },
           "kennisgevingsdatum": {
             "type": "string",
             "format": "date-time",
@@ -1092,7 +1176,11 @@
           },
           "isOnderdeelVanKadastralegemeentecode": {
             "type": "object",
-            "properties": { "identificatie": { "type": "string" } },
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              }
+            },
             "relation": "brk:kadastralegemeentecodes",
             "description": "Een alfanumerieke aanduiding van de kadastrale gemeentecode, deel van de kadastrale aanduiding van de onroerende zaak. (bv. ASD02)."
           },
@@ -1126,7 +1214,11 @@
           },
           "isOnderdeelVanKadastralegemeente": {
             "type": "object",
-            "properties": { "identificatie": { "type": "string" } },
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              }
+            },
             "relation": "brk:kadastralegemeentes",
             "description": "De kadastrale gemeente waar de kadastrale gemeentecode onderdeel van is (bv. Sloten)."
           },
@@ -1160,7 +1252,11 @@
           },
           "ligtInGemeente": {
             "type": "object",
-            "properties": { "identificatie": { "type": "string" } },
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              }
+            },
             "relation": "brk:gemeentes",
             "description": "De burgelijke gemeente waarin de kadastrale gemeente ligt."
           },

--- a/tests/files/datasets/gebieden.json
+++ b/tests/files/datasets/gebieden.json
@@ -233,7 +233,9 @@
             "type": "object",
             "properties": {
               "identificatie": { "type": "string" },
-              "volgnummer": { "type": "integer" }
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date-time" },
+              "eindGeldigheid": { "type": "string", "format": "date-time" }
             },
             "relation": "gebieden:stadsdelen",
             "description": "Het stadsdeel waar de wijk in ligt."
@@ -383,7 +385,9 @@
             "type": "object",
             "properties": {
               "identificatie": { "type": "string" },
-              "volgnummer": { "type": "integer" }
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date-time" },
+              "eindGeldigheid": { "type": "string", "format": "date-time" }
             },
             "relation": "gebieden:stadsdelen",
             "description": "Het stadsdeel waar het ggwgebied in ligt."

--- a/tests/files/datasets/hr.json
+++ b/tests/files/datasets/hr.json
@@ -75,7 +75,8 @@
             "shortname": "gevestigdIn",
             "properties": {
               "identificatie": { "type": "string" },
-              "volgnummer": { "type": "integer" }
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date-time" }
             },
             "relation": "verblijfsobjecten:verblijfsobjecten",
             "description": "Relatie naar verblijfsobject",

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -467,6 +467,31 @@ def test_ndjson_import_with_shortnames_in_identifier(here, engine, hr_schema, db
     assert records == [{"sbi_act_nr": "12"}, {"sbi_act_nr": "16"}]
 
 
+def test_ndjson_import_with_attributes_on_relation(
+    here, engine, brk_schema, verblijfsobjecten_schema, dbsession
+):
+    """Prove that extra attributes on a relation do not interfere with ndjson import."""
+    ndjson_path = here / "files" / "data" / "brk_aantek_rechten.ndjson"
+    importer = NDJSONImporter(brk_schema, engine)
+    importer.generate_db_objects("aantekeningenrechten", truncate=True, ind_extra_index=False)
+    importer.load_file(ndjson_path)
+
+    records = [dict(r) for r in engine.execute("SELECT * from brk_aantekeningenrechten")]
+    assert records == [
+        {
+            "aard_code": None,
+            "aard_omschrijving": None,
+            "betrokken_tenaamstelling_id": None,
+            "einddatum": None,
+            "id": "01",
+            "identificatie": "01",
+            "is_gbsd_op_sdl_id": "013",
+            "omschrijving": None,
+            "toestandsdatum": None,
+        }
+    ]
+
+
 def test_provenance_for_schema_field_ids_equal_to_ndjson_keys(
     here, engine, woonplaatsen_schema, dbsession
 ):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -309,3 +309,9 @@ def test_repr_broken_schema():
         DatasetTableSchema({}, parent_schema=None)
     except KeyError:  # KeyError is ok, RecursionError isn't.
         pass
+
+
+def test_relation_with_extra_properties_has_through_table(gebieden_schema):
+    """Prove that a 1-N relation with extra properties on the relates add a through table."""
+    tables_including_through = {t.id for t in gebieden_schema.get_tables(include_through=True)}
+    assert "ggwgebieden_ligtInStadsdeel" in tables_including_through


### PR DESCRIPTION
For the BenK datasets relations can have their own "geldigheid". To store this extra information, a through table is needed.

This is already in place for NM relations and for
1-N relations having a temporal table as the target.

However, for 1-N relations to a non-temporal table no through table is being created.

The condition that was in place to determine if a 1-N relation needs a through table was based on the temporality of the target. This condition has been changed now. The new condition is as follows. If the relation does contains fields that are not part of the key a through table will be defined for this relation.

An example:
The table `brk.tenaamstelling` has the following 1-N relation field:

  "isGebaseerdOpStukdeel": {
    "type": "object",
    "properties": {
      "identificatie": {
        "type": "string"
      },
      "beginGeldigheid": {
        "type": "string",
        "format": "date-time"
      }
    },
    "relation": "brk:stukdelen"
  }

The target table `brk:stukdelen` only has a single PK `identificatie`. So, there is an extra non-key field `beginGeldigheid` on the relation. This will define a through table for this 1-N relation.