### PR TITLE
Pin SQLAlchemy to >=1.4, < 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2023-03-22 (5.8.1)
+
+* Pin SQLAlchemy to >= 1.4, < 2.0 to make schematools usable
+  from Airflow 2.4.1.
+
 # 2023-03-22 (5.8.0)
 
 * Add export cli commands to export geopackages, csv and jsonlines.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.8.0
+version = 5.8.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)
@@ -26,10 +26,10 @@ package_dir =
 packages = find:
 python_requires = >= 3.9
 install_requires =
-    sqlalchemy < 1.4.0
-    geoalchemy2 <=0.11.1
+    sqlalchemy >= 1.4, < 2.0
+    geoalchemy2
     psycopg2
-    pg-grant == 0.3.2
+    pg-grant
     click
     deepdiff
     jsonlines

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -5,6 +5,7 @@ import json
 import logging
 from collections import defaultdict
 
+from sqlalchemy import inspect
 from sqlalchemy.engine import Connection
 
 from schematools.events import metadata
@@ -231,6 +232,7 @@ class EventsProcessor:
         self.conn = connection
         _metadata = local_metadata or metadata  # mainly for testing
         _metadata.bind = connection.engine
+        inspector = inspect(connection.engine)
         self.tables = {}
         for dataset_id, dataset in self.datasets.items():
             base_tables_ids = {dataset_table.id for dataset_table in dataset.tables}
@@ -243,7 +245,7 @@ class EventsProcessor:
             }
             self.geo_fields = defaultdict(lambda: defaultdict(list))
             for table_id, table in tfac.items():
-                if not table.exists():
+                if not inspector.has_table(table.name):
                     table.create()
                 elif truncate:
                     with self.conn.begin():


### PR DESCRIPTION
Because schematools is used from Airflow and the
current Airflow needs SA >= 1.4

Also bumped geoalchemy2 and unpinned pg-grant.

Bumping SQ to >= 2.0 creates a lot of imcompatibilities, so let's stick with < 2.0 for now.