### PR TITLE
Fix condition for 1-N through tables.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-03-28 (5.8.2)
+
+* Fix condition for through tables for a 1-N relation.
+
 # 2023-03-22 (5.8.1)
 
 * Pin SQLAlchemy to >= 1.4, < 2.0 to make schematools usable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.8.1
+version = 5.8.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -860,7 +860,6 @@ class DatasetTableSchema(SchemaType):
             if field_schema.is_composite_key or (
                 field_schema.is_nested_object and not field_schema.is_json_object
             ):
-                #     breakpoint()
                 # Temporal date fields are excluded, they shouldn't be part into the main table.
                 yield from (
                     subfield
@@ -1640,9 +1639,12 @@ class DatasetFieldSchema(DatasetType):
         """Checks if field is a possible through table.
 
         NM tables always are through tables. For 1N tables, there is a through
-        tables if the relations has additional attributes that are not part of the key.
+        tables if the relations has additional attributes that are not part of the key,
+        or if the relation is temporal.
         """
-        return self.nm_relation is not None or self.relation_attributes
+        return (
+            self.nm_relation is not None or self.relation_attributes or self.is_relation_temporal
+        )
 
     @cached_property
     def relation_attributes(self) -> set[str]:


### PR DESCRIPTION
The condition that determines if 1-N relation gets a through tables was change to only depend on the fact if the relation has extra fields.

However, for a 1-N relation to a temporary table *without* extra field, we still need to have a through table, so the code has been changed occordingly.