### PR TITLE
Exclude all array fields for exports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-04-04 (5.8.5)
+
+* Exclude all array-type fields during exports.
+
 # 2023-04-03 (5.8.4)
 
 * Add cli commands to list schemas and tables.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.8.4
+version = 5.8.5
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -82,7 +82,7 @@ class BaseExporter:
 def _get_fields(dataset_schema: DatasetSchema, table: DatasetTableSchema, scopes: list[str]):
     parent_scopes = set(dataset_schema.auth | table.auth) - {_PUBLIC_SCOPE}
     for field in table.fields:
-        if field.nm_relation is not None:
+        if field.is_array:
             continue
         if parent_scopes | set(field.auth) - {_PUBLIC_SCOPE} <= set(scopes):
             yield field


### PR DESCRIPTION
Export is now crashing for nested fields,
because the sql that is generated for ogr2ogr contains fields that are not part of the table.