### PR TITLE
Some small schematools fixes, needed for cli demo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-04-05 (5.8.6)
+
+* Apply some small fixes to cli commands and update template used to generate schema by introspection.
+
 # 2023-04-04 (5.8.5)
 
 * Exclude all array-type fields during exports.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.8.5
+version = 5.8.6
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -396,6 +396,8 @@ def validate(
         META_SCHEMA_URL: URL where the meta schema for Amsterdam Schema definitions can be found.
         If multiple are given, schematools will try to validate against the largest version,
         working backwards and stopping at the first version that the objects are valid against.
+
+        Usually META_SCHEMA_URL is something like: https://schemas.data.amsterdam.nl/schema@vn
     """  # noqa: D301,D412,D417
     if not meta_schema_url:
         click.echo("META_SCHEMA_URL not provided", err=True)
@@ -615,6 +617,8 @@ def batch_validate(
 def format_schema_error(e: jsonschema.SchemaError | jsonschema.ValidationError) -> str:
     s = io.StringIO()
     s.write(f"{e.json_path}, {list(e.schema_path)}")
+    if e.message and not e.context:
+        s.write("\n\t" + e.message)
     if e.context:
         for ec in e.context:
             s.write("\n\t" + ec.message.strip())
@@ -709,8 +713,8 @@ def show_tablenames(db_url: str) -> None:
 def show_datasets(schema_url: str) -> None:
     """Retrieve the ids of all the datasets."""
     loader = get_schema_loader(schema_url)
-    for dataset_schema_id in loader.get_all_datasets().keys():
-        click.echo(dataset_schema_id)
+    for dataset_schema in loader.get_all_datasets().values():
+        click.echo(dataset_schema.id)
 
 
 @show.command("datasettables")

--- a/src/schematools/introspect/db.py
+++ b/src/schematools/introspect/db.py
@@ -96,5 +96,7 @@ def introspect_db_schema(engine, dataset_id, tablenames, db_schema=None, prefix=
     dataset = copy.deepcopy(DATASET_TMPL)
     dataset["id"] = dataset_id
     dataset["title"] = dataset_id
+    dataset["description"] = dataset_id
+    dataset["version"] = "0.0.1"
     dataset["tables"] = tables
     return dataset

--- a/src/schematools/introspect/utils.py
+++ b/src/schematools/introspect/utils.py
@@ -4,8 +4,12 @@ DATASET_TMPL = {
     "title": None,
     "status": "beschikbaar",
     "description": None,
-    "version": "0.0.1",
     "crs": "EPSG:28992",
+    "auth": "OPENBAAR",
+    "authorizationGrantor": "n.v.t.",
+    "owner": "Gemeente Amsterdam",
+    "creator": "bronhouder onbekend",
+    "publisher": "Datateam xyz",
     "tables": [],
 }
 
@@ -14,6 +18,7 @@ DATASET_TMPL = {
 TABLE_TMPL = {
     "id": None,
     "type": "table",
+    "version": "0.0.1",
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -22,7 +27,7 @@ TABLE_TMPL = {
         "display": "id",
         "properties": {
             "schema": {
-                "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
             },
         },
     },

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -58,7 +58,7 @@ def test_geojson_to_table():
                 "properties": {
                     "schema": {
                         "$ref": (
-                            "https://schemas.data.amsterdam.nl/schema@v1.1.1"
+                            "https://schemas.data.amsterdam.nl/schema@v1.3.0"
                             "#/definitions/schema"
                         )
                     },


### PR DESCRIPTION
- Validate now shows an error message when context info is absent.
- Show camelCased ids for datasets
- Fix template for generating amsterdam schema by introspecting a pg table.