### PR TITLE
Remove json_encoder dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     deepdiff
     jsonlines
     jsonschema[format] >= 3.2.0
-    json-encoder
     shapely>=1.8.0
     python-string-utils
     python-dateutil

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
 import operator
 import os
@@ -17,7 +18,6 @@ import jsonschema
 import requests
 import sqlalchemy
 from deepdiff import DeepDiff
-from json_encoder import json
 from jsonschema import draft7_format_checker
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import SQLAlchemyError

--- a/tests/test_ckan.py
+++ b/tests/test_ckan.py
@@ -1,6 +1,6 @@
+import json
 import re
 
-import json_encoder.json
 import pytest
 
 from schematools import ckan
@@ -26,7 +26,7 @@ from schematools.types import DatasetSchema
 def test_convert(here, name):
     filename = here / f"files/datasets/{name}.json"
     with open(filename) as f:
-        schema = DatasetSchema.from_dict(json_encoder.json.load(f))
+        schema = DatasetSchema.from_dict(json.load(f))
 
     data = ckan.from_dataset(schema, name)
 


### PR DESCRIPTION
This package has no license, copyright or homepage on PyPI, and hasn't been updated since 2016. I'm not sure why we're using it at all.