### PR TITLE
Replace UnlimitedCharField with our own implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,6 @@ tests =
     pytest-sqlalchemy
 django =
     django >= 3.0, < 4.2
-    django-postgres-unlimited-varchar >= 1.1.1
     django-gisserver >= 1.2.3
     django-environ
     django-db-comments

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -10,10 +10,10 @@ from django.contrib.gis.db import models as gis_models
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import CheckConstraint, Q
 from django.db.models.base import ModelBase
-from django_postgres_unlimited_varchar import UnlimitedCharField
 
 from schematools import SRID_3D
 from schematools.contrib.django import app_config, signals
+from schematools.contrib.django.fields import UnlimitedCharField
 from schematools.naming import to_snake_case, toCamelCase
 from schematools.types import DatasetFieldSchema, DatasetTableSchema
 

--- a/src/schematools/contrib/django/fields.py
+++ b/src/schematools/contrib/django/fields.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+
+class UnlimitedCharField(models.CharField):
+    # When we switch to Django 4.2, replace this with CharField(max_length=None).
+    description = "CharField without length limit"
+    max_length = (1 << 31) - 1  # Big limit to fool validation code.
+
+    def __init__(self, *args, **kwargs):
+        if "max_length" in kwargs:
+            raise Exception("max_length not supported, use an ordinary CharField")
+        super().__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return "varchar"

--- a/src/schematools/contrib/django/management/commands/dump_models.py
+++ b/src/schematools/contrib/django/management/commands/dump_models.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
     path_aliases: list[tuple[str, str]] = [
         ("django.db.models.", "models."),
         ("django.contrib.gis.db.models.fields.", ""),
-        ("django_postgres_unlimited_varchar.", ""),
+        ("schematools.contrib.django.fields.", ""),
     ]
 
     def add_arguments(self, parser: ArgumentParser) -> None:

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -4,9 +4,9 @@ from django.core.management import call_command
 from django.db import IntegrityError, connection
 from django.db.models.base import ModelBase
 from django.db.models.fields import DateTimeField
-from django_postgres_unlimited_varchar import UnlimitedCharField
 
 from schematools.contrib.django.factories import model_factory, schema_models_factory
+from schematools.contrib.django.fields import UnlimitedCharField
 from schematools.contrib.django.models import (
     Dataset,
     LooseRelationField,


### PR DESCRIPTION
... because django_postgres_unlimited_varchar has no license, so it's unclear what we can use it for.