### PR TITLE
Disable versioning that creates postgres schemas for new tables.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2023-04-20 (5.9.3)
+
+* Disable the versioning that creates postgresql schemas for new tables.
+  This functionality is not fully completed and accepted and is now
+  blocking the event processing code.
+
 # 2023-04-13 (5.9.2)
 
 * Skip index creation on temporary full load table from event importer.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.9.2
+version = 5.9.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -407,6 +407,10 @@ class BaseImporter:
     def is_versioned_dataset(self) -> bool:
         """Returns whether versioning will be employed for the current dataset.
 
+        NB. Because the versioning has not been fully completed yet,
+        this method always return False for now.
+
+
         Strictly speaking datasets are not directly (as in: on the dataset level) versioned
         anymore. Its tables, however, are! That is, in the Amsterdam Schema corresponding to the
         dataset. Whether we employ versioning on the DB level depends on whether we are dealing
@@ -416,14 +420,17 @@ class BaseImporter:
             * a dataset in a dataset specific PostgreSQL schema
             * a brand new dataset with no current DB representation.
 
-        Versioning will be used for the latter two. Not for the first one.
-        """
-        with self.engine.connect() as connection:
-            is_versioned = cast(
-                bool,
-                connection.scalar(IS_VERSIONED_DATASET_SQL, dataset_name=self.dataset_schema.id),
-            )
-        return is_versioned
+        Versioning will be used for the latter two. Not for the first one."""
+        return False
+
+        # XXX Disabled until the decision has been made how to continue with versioning!
+
+        # with self.engine.connect() as connection:
+        #     is_versioned = cast(
+        #         bool,
+        #         connection.scalar(IS_VERSIONED_DATASET_SQL, dataset_name=self.dataset_schema.id),
+        #     )
+        # return is_versioned
 
     def create_schema(self, db_schema_name: str) -> None:
         """Create DB Schema.


### PR DESCRIPTION
This functionality has not been fully completed yet. And the decision still has to be made how to continue with versioning. So, for now we disable this functionality,
because the event processor cannot work at the moment.