### PR TITLE
Add --to-snake-case flag to cli functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-05-08 (5.10.1)
+
+* Add a `--to-snake-case` option to the `schema show dataset[table]` cli functions.
+
 # 2023-05-04 (5.10.0)
 
 * Add support for loading events in batches.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.10.0
+version = 5.10.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -48,6 +48,7 @@ from schematools.introspect.db import introspect_db_schema
 from schematools.introspect.geojson import introspect_geojson_files
 from schematools.loaders import FileSystemSchemaLoader, get_schema_loader
 from schematools.maps import create_mapfile
+from schematools.naming import to_snake_case
 from schematools.permissions.db import (
     apply_schema_and_profile_permissions,
     introspect_permissions,
@@ -709,21 +710,25 @@ def show_tablenames(db_url: str) -> None:
 
 @show.command("datasets")
 @option_schema_url
-def show_datasets(schema_url: str) -> None:
+@click.option("--to-snake-case", "snake_it", is_flag=True)
+def show_datasets(schema_url: str, snake_it: bool) -> None:
     """Retrieve the ids of all the datasets."""
     loader = get_schema_loader(schema_url)
+    modifier = to_snake_case if snake_it else lambda x: x
     for dataset_schema in loader.get_all_datasets().values():
-        click.echo(dataset_schema.id)
+        click.echo(modifier(dataset_schema.id))
 
 
 @show.command("datasettables")
 @option_schema_url
 @argument_dataset_id
-def show_datasettables(schema_url: str, dataset_id: str) -> None:
+@click.option("--to-snake-case", "snake_it", is_flag=True)
+def show_datasettables(schema_url: str, dataset_id: str, snake_it: bool) -> None:
     """Retrieve the ids of the datasettables for the indicated dataset."""
     dataset_schema = _get_dataset_schema(dataset_id, schema_url, prefetch_related=False)
+    modifier = to_snake_case if snake_it else lambda x: x
     for dataset_table in dataset_schema.tables:
-        click.echo(dataset_table.id)
+        click.echo(modifier(dataset_table.id))
 
 
 @show.command("mapfile")


### PR DESCRIPTION
The `schema show dataset` and `schema show datasettable` cli function get a flag `--to-snake-case` for convenience in bash scripting.