### PR TITLE
Make export to csv/jsonlines less memory hungy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.11.1
+version = 5.11.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -19,8 +19,9 @@ import requests
 import sqlalchemy
 from deepdiff import DeepDiff
 from jsonschema import draft7_format_checker
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import inspect
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.future import create_engine
 from sqlalchemy.schema import CreateTable
 
 from schematools import (

--- a/src/schematools/exports/csv.py
+++ b/src/schematools/exports/csv.py
@@ -28,8 +28,10 @@ class CsvExporter(BaseExporter):  # noqa: D101
         query = select(self._get_columns(sa_table, table))
         if self.size is not None:
             query = query.limit(self.size)
-        for r in self.connection.execute(query):
-            writer.writerow(dict(r))
+        result = self.connection.execution_options(yield_per=1000).execute(query)
+        for partition in result.partitions():
+            for r in partition:
+                writer.writerow(dict(r))
 
 
 def export_csvs(

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -22,10 +22,10 @@ def export_geopackages(
     Args:
         connection: SQLAlchemy connection object. Is needed for the `psycopg2`
         formatting.
-        dataset_schema: Schema that needs export as geopackageself.
-        output: path on the filesystem where output should be storedself.
+        dataset_schema: Schema that needs export as geopackage.
+        output: path on the filesystem where output should be stored.
         table_ids: optional parameter for a subset for the tables of the datasetself.
-        scopes: Keycloak scopes that need to be taken into accountself.
+        scopes: Keycloak scopes that need to be taken into account.
             The geopackage will be produced contains information that is only
             accessible with these scopes.
         size: To produce a subset of the rows, mainly for testing.


### PR DESCRIPTION
The SQLAlchemy `execute` is loading a full set of records in memory, leading to 4Gb of mem consumption for large datasettables like brk.kadatastraleobjecten.

The new SA 1.4 that we are using already has a nice streaming/batching mechanisme to reduce this memory consumption.

The SA engine has been changed now to be able to use the new connection. No failing tests, so it seems this change is backwards compatible.