### PR TITLE
Implement logic to recover from failed event messages

### DIFF
--- a/tests/test_events_full.py
+++ b/tests/test_events_full.py
@@ -1,6 +1,8 @@
 """Event tests."""
 from datetime import date, datetime
 
+import pytest
+
 from schematools.events.full import EventsProcessor
 
 # pytestmark = pytest.mark.skip("all tests disabled")
@@ -13,7 +15,7 @@ def test_event_process_insert(here, db_schema, tconn, local_metadata, gebieden_s
         [gebieden_schema], tconn, local_metadata=local_metadata, truncate=True
     )
     importer.load_events_from_file(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from gebieden_bouwblokken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM gebieden_bouwblokken")]
     assert len(records) == 2
     assert records[0]["code"] == "AA01"
     assert records[1]["code"] == "AA02"
@@ -30,7 +32,7 @@ def test_event_process_insert_object(
         [nap_schema, gebieden_schema], tconn, local_metadata=local_metadata, truncate=True
     )
     importer.load_events_from_file(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
     assert records[0]["status_code"] == 3
     assert records[0]["status_omschrijving"] == "Vervallen"
 
@@ -42,7 +44,7 @@ def test_event_process_update(here, tconn, local_metadata, gebieden_schema):
         [gebieden_schema], tconn, local_metadata=local_metadata, truncate=True
     )
     importer.load_events_from_file(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from gebieden_bouwblokken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM gebieden_bouwblokken")]
     assert len(records) == 1
     assert records[0]["code"] == "AA01"
     assert records[0]["begin_geldigheid"] == date(2020, 2, 5)
@@ -56,7 +58,7 @@ def test_event_process_delete(here, tconn, local_metadata, gebieden_schema):
         [gebieden_schema], tconn, local_metadata=local_metadata, truncate=True
     )
     importer.load_events_from_file(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from gebieden_bouwblokken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM gebieden_bouwblokken")]
     assert len(records) == 1
     assert records[0]["code"] == "AA01"
 
@@ -82,7 +84,7 @@ def test_event_process_relation_update_parent_table(
     events_path = here / "files" / "data" / "peilmerken.gobevents"
     importer = EventsProcessor([nap_schema, gebieden_schema], tconn, local_metadata=local_metadata)
     importer.load_events_from_file_using_bulk(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
 
     # Imported objects without relations
     assert len(records) == 1
@@ -93,8 +95,8 @@ def test_event_process_relation_update_parent_table(
     events_path = here / "files" / "data" / "peilmerken_ligt_in_bouwblok.gobevents"
     importer = EventsProcessor([nap_schema, gebieden_schema], tconn, local_metadata=local_metadata)
     importer.load_events_from_file_using_bulk(events_path)
-    rel_records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken_ligt_in_bouwblok")]
-    parent_records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    rel_records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken_ligt_in_bouwblok")]
+    parent_records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
 
     # Should have inserted the rel and updated relation columns in  parent (object) table
     assert len(rel_records) == 1
@@ -107,8 +109,8 @@ def test_event_process_relation_update_parent_table(
     events_path = here / "files" / "data" / "peilmerken_ligt_in_bouwblok.delete.gobevents"
     importer = EventsProcessor([nap_schema, gebieden_schema], tconn, local_metadata=local_metadata)
     importer.load_events_from_file_using_bulk(events_path)
-    rel_records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken_ligt_in_bouwblok")]
-    parent_records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    rel_records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken_ligt_in_bouwblok")]
+    parent_records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
 
     # Rel table row should be deleted, fields in parent table should be set to None again
     assert len(rel_records) == 0
@@ -143,17 +145,17 @@ def test_event_process_full_load_sequence(
 
     # 1.
     load_events("peilmerken.gobevents")
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
     assert len(records) == 1
     assert records[0]["identificatie"] == "70780001"
 
     # 2.
     load_events("peilmerken_full_load_sequence_start.gobevents")
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
     assert len(records) == 1
     assert records[0]["identificatie"] == "70780001"
 
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken_full_load")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken_full_load")]
     assert len(records) == 3
     assert records[0]["identificatie"] == "70780002"
     assert records[1]["identificatie"] == "70780003"
@@ -161,7 +163,7 @@ def test_event_process_full_load_sequence(
 
     # 3.
     load_events("peilmerken_full_load_sequence_end.gobevents")
-    records = [dict(r) for r in tconn.execute("SELECT * from nap_peilmerken")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM nap_peilmerken")]
     assert len(records) == 4
     assert records[0]["identificatie"] == "70780002"
     assert records[1]["identificatie"] == "70780003"
@@ -186,9 +188,470 @@ def test_event_process_geometry_attrs(
         [brk_schema_without_bag_relations], tconn, local_metadata=local_metadata
     )
     importer.load_events_from_file_using_bulk(events_path)
-    records = [dict(r) for r in tconn.execute("SELECT * from brk_kadastraleobjecten")]
+    records = [dict(r) for r in tconn.execute("SELECT * FROM brk_kadastraleobjecten")]
 
     assert len(records) == 1
     record = records[0]
     assert record["bijpijling_geometrie"] is not None
     assert record["geometrie"] is not None
+
+
+def _create_peilmerken_event(id: str, jaar: int, type: str = "ADD", **kwargs) -> tuple[dict, dict]:
+    """Creates a peilmerken event. Use 'jaar' to make sure the event is unique."""
+
+    return (
+        {
+            "event_type": type,
+            "dataset_id": "nap",
+            "table_id": "peilmerken",
+            **kwargs,
+        },
+        {
+            "identificatie": id,
+            "hoogte_tov_nap": -2.6954,
+            "jaar": jaar,
+            "merk": {
+                "code": "7",
+                "omschrijving": "Bijzondere merktekens bijvoorbeeld zeskantige bout, "
+                "stalen pen etc.",
+            },
+            "omschrijving": "Gemaal aan de Ringvaart gelegen aan de Schipholweg. Vervallen?",
+            "windrichting": "Z",
+            "x_coordinaat_muurvlak": 84,
+            "y_coordinaat_muurvlak": 37,
+            "rws_nummer": "25D0039",
+            "geometrie": "01010000204071000000000000C05FFC400000000050601D41",
+            "status": {"code": 3, "omschrijving": "Vervallen"},
+            "vervaldatum": "2018-04-23",
+            "ligt_in_bouwblok_id": None,
+            "ligt_in_bouwblok_identificatie": None,
+            "ligt_in_bouwblok_volgnummer": None,
+            "publiceerbaar": False,
+        },
+    )
+
+
+def _assert_have_peilmerken(
+    id_years: list[tuple[str, int]], tconn, check_full_load_table: bool = False
+):
+    tablename = "nap_peilmerken" if not check_full_load_table else "nap_peilmerken_full_load"
+    records = [dict(r) for r in tconn.execute(f"SELECT * FROM {tablename}")]  # noqa: S608
+    assert len(records) == len(id_years)
+
+    for record, (id, year) in zip(records, id_years):
+        assert record["identificatie"] == id
+        assert record["jaar"] == year
+
+
+def _import_assert_result_expect_exception(
+    importer, events, expected_result, recovery_mode=False, check_full_load_table=False
+):
+    with pytest.raises(Exception):
+        importer.process_events(events, recovery_mode)
+    _assert_have_peilmerken(expected_result, importer.conn, check_full_load_table)
+
+
+def _import_assert_result(
+    importer, events, expected_result, recovery_mode=False, check_full_load_table=False
+):
+    importer.process_events(events, recovery_mode)
+    _assert_have_peilmerken(expected_result, importer.conn, check_full_load_table)
+
+
+def test_event_process_recovery_regular(
+    db_schema, engine, local_metadata, nap_schema, gebieden_schema
+):
+    """Tests adding of regular events (that are not part of a full load sequence) with
+    and without recovery mode enabled.
+
+    Initialise database with some rows.
+
+    Try to add rows:
+    - 1. One that already exists, with recovery_mode = False. Should raise an error.
+    - 2. One that doesn't exist, with recovery_mode = False. Should be added.
+    - 3. One that already exists, with recovery_mode = True. Should be ignored.
+    - 4. One that doesn't exist, with recovery_mode = True. Should be added.
+    """
+    with engine.connect() as conn:
+        importer = EventsProcessor(
+            [nap_schema, gebieden_schema], conn, local_metadata=local_metadata
+        )
+
+        # Init
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("1", 2018),
+                _create_peilmerken_event("2", 2019),
+            ],
+            [("1", 2018), ("2", 2019)],
+        )
+
+        # 1. One that already exists, with recovery_mode = False. Should raise an error.
+        _import_assert_result_expect_exception(
+            importer, [_create_peilmerken_event("1", 2017)], [("1", 2018), ("2", 2019)]
+        )
+
+        # 2. One that doesn't exist, with recovery_mode = False. Should be added.
+        _import_assert_result(
+            importer,
+            [_create_peilmerken_event("3", 2020)],
+            [("1", 2018), ("2", 2019), ("3", 2020)],
+        )
+
+        # 3. One that already exists, with recovery_mode = True. Should be ignored.
+        _import_assert_result(
+            importer,
+            [_create_peilmerken_event("3", 2019)],
+            [("1", 2018), ("2", 2019), ("3", 2020)],
+            recovery_mode=True,
+        )
+
+        # 4. One that doesn't exist, with recovery_mode = True. Should be added.
+        _import_assert_result(
+            importer,
+            [_create_peilmerken_event("4", 2021)],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021)],
+            recovery_mode=True,
+        )
+        conn.close()
+
+
+def test_event_process_recovery_full_load_first(
+    db_schema, engine, local_metadata, nap_schema, gebieden_schema
+):
+    """Tests adding of events that are part of a full load sequence and where the first
+    event is the first in the sequence.
+
+    Initialise full load with some rows.
+
+    Try to add multiple rows, where the first one:
+    - Already exists, with recovery_mode = False. New rows should be added.
+    - Doesn't exist, with recovery_mode = False. New rows should be added.
+    - Already exists, with recovery_mode = True. New rows should be added.
+    - Doesn't exist, with recovery_mode = True. New rows should be added.
+
+    Note: When the first event to handle in this case is the first in the sequence, the
+    _full_load table is always truncated. This means that in every case we replace the
+    table.
+
+    """
+    with engine.connect() as conn:
+        importer = EventsProcessor(
+            [nap_schema, gebieden_schema], conn, local_metadata=local_metadata
+        )
+
+        # Init
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "1", 2018, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("2", 2019, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019)],
+            check_full_load_table=True,
+        )
+
+        # 1. Already exists, with recovery_mode = False. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "1", 2020, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("2", 2021, full_load_sequence=True),
+            ],
+            [("1", 2020), ("2", 2021)],
+            check_full_load_table=True,
+        )
+
+        # 2. Doesn't exist, with recovery_mode = False. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "3", 2020, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("4", 2021, full_load_sequence=True),
+            ],
+            [("3", 2020), ("4", 2021)],
+            check_full_load_table=True,
+        )
+
+        # 3. Already exists, with recovery_mode = True. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "3", 2022, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("4", 2023, full_load_sequence=True),
+            ],
+            [("3", 2022), ("4", 2023)],
+            check_full_load_table=True,
+            recovery_mode=True,
+        )
+
+        # 4. Doesn't exist, with recovery_mode = True. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "5", 2020, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("6", 2021, full_load_sequence=True),
+            ],
+            [("5", 2020), ("6", 2021)],
+            check_full_load_table=True,
+            recovery_mode=True,
+        )
+
+
+def test_event_process_recovery_full_load_no_first_no_last(
+    db_schema, engine, local_metadata, nap_schema, gebieden_schema
+):
+    """Tests adding of events that are part of a full load sequence and where events to
+    be added are neither the first nor the last in the sequence.
+
+    Initialise full load with some rows.
+
+    Try to add multiple rows, where the first one:
+    - Already exists, with recovery_mode = False. Should raise an error.
+    - Doesn't exist, with recovery_mode = False. New rows should be added.
+    - Already exists, with recovery_mode = True. Rows should be ignored.
+    - Doesn't exist, with recovery_mode = True. New rows should be added.
+
+    """
+    with engine.connect() as conn:
+        importer = EventsProcessor(
+            [nap_schema, gebieden_schema], conn, local_metadata=local_metadata
+        )
+
+        # Init
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event(
+                    "1", 2018, full_load_sequence=True, first_of_sequence=True
+                ),
+                _create_peilmerken_event("2", 2019, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019)],
+            check_full_load_table=True,
+        )
+
+        # 1. Already exists, with recovery_mode = False. Should raise an error.
+        _import_assert_result_expect_exception(
+            importer,
+            [
+                _create_peilmerken_event("1", 2022, full_load_sequence=True),
+                _create_peilmerken_event("2", 2023, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019)],
+            check_full_load_table=True,
+        )
+
+        # 2. Doesn't exist, with recovery_mode = False. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("3", 2020, full_load_sequence=True),
+                _create_peilmerken_event("4", 2021, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021)],
+            check_full_load_table=True,
+        )
+
+        # 3. Already exists, with recovery_mode = True. Rows should be ignored.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("1", 2022, full_load_sequence=True),
+                _create_peilmerken_event("2", 2023, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021)],
+            check_full_load_table=True,
+            recovery_mode=True,
+        )
+
+        # 4. Doesn't exist, with recovery_mode = True. New rows should be added.
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("5", 2022, full_load_sequence=True),
+                _create_peilmerken_event("6", 2023, full_load_sequence=True),
+            ],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021), ("5", 2022), ("6", 2023)],
+            check_full_load_table=True,
+            recovery_mode=True,
+        )
+
+
+def test_event_process_recovery_full_load_last_table_empty(
+    db_schema, engine, local_metadata, nap_schema, gebieden_schema
+):
+    """Tests adding of events that are part of a full load sequence and where the last
+    event is the last in the sequence and the _full_load table is empty.
+
+    No full load initialisation; table should be empty
+
+    Try to add multiple rows, where the first one:
+    - Doesn't exist, with recovery_mode = False. New rows should be added and object table
+      replaced.
+    - Doesn't exist, with recovery_mode = True. Everything in this message should be ignored
+
+    """
+    with engine.connect() as conn:
+        importer = EventsProcessor(
+            [nap_schema, gebieden_schema], conn, local_metadata=local_metadata
+        )
+
+        def _init_empty_full_load_table(importer):
+            # Init and truncate right after to get inconsistent state
+            _import_assert_result(
+                importer,
+                [
+                    _create_peilmerken_event(
+                        "1", 2018, full_load_sequence=True, first_of_sequence=True
+                    ),
+                    _create_peilmerken_event("2", 2019, full_load_sequence=True),
+                ],
+                [("1", 2018), ("2", 2019)],
+                check_full_load_table=True,
+            )
+            importer.conn.execute("TRUNCATE TABLE nap_peilmerken_full_load")
+
+        # 1. Doesn't exist, with recovery_mode = False. New rows should be added and object
+        #    table replaced.
+        _init_empty_full_load_table(importer)
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("1", 2018, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "2", 2019, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [
+                ("1", 2018),
+                ("2", 2019),
+            ],
+        )
+
+        # 2. Doesn't exist, with recovery_mode = True. Everything in this message should
+        #    be ignored
+        _init_empty_full_load_table(importer)
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("3", 2018, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "4", 2019, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [
+                ("1", 2018),
+                ("2", 2019),
+            ],
+            recovery_mode=True,
+        )
+
+
+def test_event_process_recovery_full_load_last_table_not_empty(
+    db_schema, engine, local_metadata, nap_schema, gebieden_schema
+):
+    """Tests adding of events that are part of a full load sequence and where the last event is
+    the last in the sequence and the _full_load table is not empty.
+
+    Initialise full load with some rows.
+
+    Try to add multiple rows, where the first one:
+    - Already exists, with recovery_mode = False. Should raise an error.
+    - Doesn't exist, with recovery_mode = False. New rows should be added and object table
+      replaced.
+    - Already exists, with recovery_mode = True. Rows should be ignored. Object table replaced.
+    - Doesn't exist, with recovery_mode = True. Rows should be added. Object table replaced.
+
+    """
+    with engine.connect() as conn:
+        importer = EventsProcessor(
+            [nap_schema, gebieden_schema], conn, local_metadata=local_metadata
+        )
+
+        def _init_full_load_table(importer):
+            try:
+                importer.conn.execute("TRUNCATE TABLE nap_peilmerken_full_load")
+            except Exception:  # noqa: S110
+                pass
+
+            _import_assert_result(
+                importer,
+                [
+                    _create_peilmerken_event(
+                        "1", 2018, full_load_sequence=True, first_of_sequence=True
+                    ),
+                    _create_peilmerken_event("2", 2019, full_load_sequence=True),
+                ],
+                [("1", 2018), ("2", 2019)],
+                check_full_load_table=True,
+            )
+
+        # 1. Already exists, with recovery_mode = False. Should raise an error.
+        _init_full_load_table(importer)
+        _import_assert_result_expect_exception(
+            importer,
+            [
+                _create_peilmerken_event("1", 2022, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "2", 2023, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [("1", 2018), ("2", 2019)],
+            check_full_load_table=True,
+        )
+
+        # 2. Doesn't exist, with recovery_mode = False. New rows should be added and
+        #    object table replaced.
+        _init_full_load_table(importer)
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("3", 2020, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "4", 2021, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021)],
+        )
+
+        # 3. Already exists, with recovery_mode = True. Rows should be ignored. Object
+        #    table replaced.
+        _init_full_load_table(importer)
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("1", 2023, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "2", 2024, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [("1", 2018), ("2", 2019)],
+            recovery_mode=True,
+        )
+
+        # 4. Doesn't exist, with recovery_mode = True. Rows should be added. Object table
+        #    replaced.
+        _init_full_load_table(importer)
+        _import_assert_result(
+            importer,
+            [
+                _create_peilmerken_event("3", 2020, full_load_sequence=True),
+                _create_peilmerken_event(
+                    "4", 2021, full_load_sequence=True, last_of_sequence=True
+                ),
+            ],
+            [("1", 2018), ("2", 2019), ("3", 2020), ("4", 2021)],
+            recovery_mode=True,
+        )


### PR DESCRIPTION
This new logic makes sure that when a message is redelivered, we can recover from it and the database state after having processed the redelivered message would be the same as if the message would have been processed correctly the first time.