### PR TITLE
Two bugfixes: Don't use engine.execute() anymore and use column names instead of column positions in INSERT INTO query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 2023-06-09 (5.12.3)
 
 * Bugfix: Use engine.connect() instead of engine.execute() directly. Not supported anymore in SQLAlchemy 1.4.
+* Bugfix: Use column names in INSERT INTO statement instead of column positions.
 
 # 2023-06-08 (5.12.2)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-06-09 (5.12.3)
+
+* Bugfix: Use engine.connect() instead of engine.execute() directly. Not supported anymore in SQLAlchemy 1.4.
+
 # 2023-06-08 (5.12.2)
 
 * Fix bug in event processor. Use shortname attribute when updating parent table.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.12.2
+version = 5.12.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -209,7 +209,7 @@ class EventsProcessor:
             and event_type == "ADD"
             and self._row_exists_in_database(run_configuration, id_value)
         ):
-            logger.info("Row with id %s already exists in database. Skipping.", row)
+            logger.info("Row with id %s already exists in database. Skipping.", row["id"])
             return
 
         db_operation_name, needs_select = EVENT_TYPE_MAPPINGS[event_type]

--- a/src/schematools/factories.py
+++ b/src/schematools/factories.py
@@ -173,21 +173,7 @@ def tables_factory(
             else:
                 db_schema_name = DATABASE_SCHEMA_NAME_DEFAULT
 
-        columns = []
-        for field in dataset_table.get_fields(include_subfields=True):
-
-            # Exclude nested and nm_relation fields,
-            # and fields that are added only for temporality
-            if (
-                field.type.endswith("#/definitions/schema")
-                or field.nm_relation
-                or field.is_array_of_objects
-                or field.is_nested_table
-                or field.is_temporal_range
-            ):
-                continue
-
-            columns.append(_column_factory(field))
+        columns = [_column_factory(field) for field in dataset_table.get_db_fields()]
 
         alchemy_table = Table(
             db_table_name,

--- a/src/schematools/importer/base.py
+++ b/src/schematools/importer/base.py
@@ -178,7 +178,8 @@ class BaseImporter:
                 continue
 
             self.pk_colname_lookup[table_name] = pk_name
-            pks = {getattr(r, pk_name) for r in self.engine.execute(table.select())}
+            with self.engine.connect() as conn:
+                pks = {getattr(r, pk_name) for r in conn.execute(table.select())}
 
             self.pk_values_lookup[table_name] = pks
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -871,6 +871,22 @@ class DatasetTableSchema(SchemaType):
                     if not subfield.is_temporal_range
                 )
 
+    def get_db_fields(self) -> Iterator[DatasetFieldSchema]:
+        """Get the fields for this table that are included in the main table."""
+        for field in self.get_fields(include_subfields=True):
+
+            # Exclude nested and nm_relation fields,
+            # and fields that are added only for temporality
+            if (
+                field.type.endswith("#/definitions/schema")
+                or field.nm_relation
+                or field.is_array_of_objects
+                or field.is_nested_table
+                or field.is_temporal_range
+            ):
+                continue
+            yield field
+
     @lru_cache()  # type: ignore[misc]
     def get_field_by_id(self, field_id: str) -> DatasetFieldSchema:
         """Get a fields based on the ids of the field."""


### PR DESCRIPTION
Two bugfixes:
- Replace use of engine.execute() in BaseImporter with engine.connect() - not supported anymore in SQLAlchemy 1.4
- Use column names in INSERT INTO statement instead of column positions.