### PR TITLE
Add a option to mocking to process only a subset of the tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2023-07-24 (5.13.2)
+
+* Bugfix: nullable_int faker did not play well with enums, is now fixed.
+* Added cli option to mocker to limit the tables.
+
 # 2023-07-13 (5.13.1)
 
 * Feature: EventProcessor: Track processed event ids now for full load sequences as well.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.13.1
+version = 5.13.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/faker/__init__.py
+++ b/src/schematools/contrib/django/faker/__init__.py
@@ -137,6 +137,8 @@ class NullableIntFaker(Faker):
 
     def get_call_param_modifiers(self, field) -> tuple(Any, dict[str, Any]):
         arg, kwargs = super().get_call_param_modifiers(field)
+        if arg == "random_element":  # for enums, we return here
+            return arg, kwargs
         if (min_ := field.get("minimum")) is not None:
             kwargs["min_"] = min_
         if (max_ := field.get("maximum")) is not None:

--- a/src/schematools/contrib/django/faker/create.py
+++ b/src/schematools/contrib/django/faker/create.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import List
 
@@ -11,9 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 def create_data_for(
-    *datasets: Dataset, start_at: int = 1, size: int = 50, sql: bool = False
+    *datasets: Dataset,
+    start_at: int = 1,
+    size: int = 50,
+    sql: bool = False,
+    tables: List[str] | None = None,
 ) -> List[str]:
     """Create mock data for the indicated datasets."""
+    limit_tables_to = set(tables) if tables is not None else set()
     for dataset in datasets:
         if not dataset.enable_db:
             logger.warning("Skipping `%s`, `enable_db` is False", dataset.name)
@@ -24,6 +31,8 @@ def create_data_for(
         }
 
         for mock_model in model_mockers.values():
+            if limit_tables_to and mock_model._meta.model.__name__ not in limit_tables_to:
+                continue
             if start_at > 1:
                 mock_model._setup_next_sequence = lambda: start_at
             if sql:


### PR DESCRIPTION
And fix a bug in nullable_int combined with enum.