### PR TITLE
AB#91240 Add extra option to permissions cli to add additional grants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# 2023-09-06 (5.15.0)
+
+* Feature: Added the option `--additional-grants` to the
+  `schema permissions apply` script to be able to set grants
+  for non-amsterdam-schema tables. This is needed for the `datasets_*` tables,
+  because on Azure these tables are accessed in PostgreSQL from a user
+  (or the anonymous) account and the `scope_openbaar` scopt has to be granted for
+  these tables.
+
 # 2023-09-05 (5.14.2)
 
 * Bugfix: For the edge case that the dataset has the id `datasets`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.14.2
+version = 5.15.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -260,6 +260,16 @@ def permissions_revoke(db_url: str, role: str, verbose: int) -> None:
     help="Before granting new permissions, revoke first all previous table and column permissions",
 )
 @click.option("-v", "--verbose", count=True)
+@click.option(
+    "-a",
+    "--additional-grants",
+    multiple=True,
+    help="""Additional grants can be defined in the following format:
+            `<table_name>:<privilege_1>[,<privilege_n>]*;<grantee_1>[,grantee_n]*`
+            Add one option for every table.
+            NB: Surround values with double quotes!
+              """,
+)
 def permissions_apply(
     db_url: str,
     schema_url: str,
@@ -276,6 +286,7 @@ def permissions_apply(
     set_write_permissions: bool,
     revoke: bool,
     verbose: int,
+    additional_grants: tuple[str] = (),
 ) -> None:
     """Set permissions for a postgres role.
 
@@ -318,6 +329,7 @@ def permissions_apply(
             create_roles,
             revoke,
             verbose=verbose,
+            additional_grants=additional_grants,
         )
     else:
         click.echo(


### PR DESCRIPTION
in the format `<table_name>:<privilege_1>[,<privilege_n>]*;<grantee_1>[,grantee_n]*`.

Be aware that this is not completely fool-proof. If not-existing tables/prvilege/grantees are used, the script will bail out.

This options has mainly been added for Azure, where acces to the internal dataset_* tables (used by Django) is done in the context of a user (or the anonymous user) and the `scope_openbaar` grant is needed for these internal tables.

Grants can be added using a `--additional-grants` flag