### PR TITLE
Support running DSO-API unittests against schematools

### DIFF
--- a/.github/test/action.yml
+++ b/.github/test/action.yml
@@ -1,0 +1,10 @@
+name: 'Test schematools'
+description: 'Run schematools unit tests or DSO-API unittests against schematools'
+inputs:
+  testdir:
+    description: 'What to test. Schematools or DSO-API'
+runs:
+  using: 'docker'
+  image: '../../Dockerfile'
+  args:
+    - ${{ inputs.testdir }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,18 +30,25 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt install -y libgdal30
-        python -m pip install --upgrade pip
-        python -m pip install .[django,tests]
-    - name: Test
-      run: |
-        pytest tests
-      env:
-        DATABASE_URL: postgresql://dataservices:insecure@localhost:5432/cicd
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt install -y libgdal30
+          python -m pip install --upgrade pip
+          python -m pip install .[django,tests]
+      - name: Test schematools
+        run: |
+          pytest tests
+        env:
+          DATABASE_URL: postgresql://dataservices:insecure@localhost:5432/cicd
+      - name: Test schematools against latest DSO-API
+        if: ${{ github.ref_type == 'tag' && matrix.python-version == '3.11' }}
+        uses: ./.github/test
+        with:
+          testdir: /app/dso-api/src
+        id: test_schematools_against_dso_api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,41 @@
-FROM amsterdam/python:3.9-buster
+# The image is meant to be used as an executable that invokes pytest
+# on schematools by default.
+# To test schematools against the DSO-API, run:
+# docker run <image_name> /app/dso-api/src
+FROM python:3.11-slim-bullseye AS builder
+RUN apt update && apt install --no-install-recommends -y \
+    build-essential \
+    libgeos-dev \
+    libpq-dev \
+    git
 
-WORKDIR /app
-COPY . ./
-RUN pip install -e ".[django,tests]"
+RUN git clone https://github.com/Amsterdam/dso-api /app/dso-api
+# Dependencies are resolved during requirements compilation
+RUN pip install --no-deps -r /app/dso-api/src/requirements.txt --no-cache-dir
+
 # So we can use local schemas
-RUN git clone https://github.com/Amsterdam/amsterdam-schema.git /tmp/ams-schema
+RUN git clone https://github.com/Amsterdam/amsterdam-schema.git /app/ams-schema
 
-USER datapunt
+FROM python:3.11-slim-bullseye
+RUN apt update && apt install --no-install-recommends -y \
+    curl \
+    libgdal28 \
+    libgeos-c1v5 \
+    libpq5 \
+    media-types \
+    netcat-openbsd
+
+# Copy python build artifacts from builder image
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
+COPY --from=builder /app/dso-api /app/dso-api
+COPY --from=builder /app/ams-schema /app/ams-schema
+
+COPY . /app/schema-tools
+RUN pip install -e /app/schema-tools[tests] --no-cache-dir
+
+
+ENV DSO_STATIC_DIR=/static
+WORKDIR /app/schema-tools
+
+ENTRYPOINT ["pytest"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ install:
 
 .PHONY: test
 test:
-	pytest -v
+	docker compose run tests
+	docker compose run tests /app/dso-api/src
 
 .PHONY: restest
 retest:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ To exclude files or directories use `exclude` with pattern.
 Hence, we should not only bump version numbers on updates to this package,
 but also commit a tag with the version number; see below.
 
+## Testing the project
+
+Testing a schematools version x consists of 2 steps:
+
+1. running the unit-tests of the package at version x itself
+2. running the unit-tests of the latest version of DSO-API (the tip of master on Github) against x.
+
+For this purpose, there is a Dockerfile that can be run locally with:
+
+`make test`
+
+and is also used by a Github Action in CI.
+
 ## Doing a release
 
 (This is for schema-tools developers.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
-# This compose file is supplied for local dev
-# Since there is no running process, it just starts a bash
-# session in order to run tests etc.
-version: "3.0"
+# This compose file is supplied for local testrunning.
+version: "3.7"
 services:
   database:
     image: amsterdam/postgres11
@@ -11,18 +9,21 @@ services:
       POSTGRES_DB: dataservices
       POSTGRES_USER: dataservices
       POSTGRES_PASSWORD: insecure
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 2s
+      timeout: 1s
+      retries: 3
+      start_period: 3s
 
-  app:
+  tests:
     build: .
-    links:
-      - database
+    depends_on:
+      database:
+        condition: service_healthy
     environment:
       SECRET_KEY: insecure
       # In order to use local datasets
-      SCHEMA_URL: /tmp/ams-schema/datasets
+      SCHEMA_URL: /app/ams-schema/datasets
       DATABASE_URL: "postgresql://dataservices:insecure@database/dataservices"
     env_file: .env
-    volumes:
-      - ".:/app"
-    command: >
-      bash


### PR DESCRIPTION
This PR adds tools for testing schematools against DSO.

The main idea is that we have a Dockerfile which is used locally (thru docker compose) and in an Github Action, to test schematools against the latest DSO (defined to be the tip of master). Since DSO is only compatible with >= python 3.11, we only run these itegration tests for mentioned python version. The compose file has been updated and modernized a bit to act as an executable for testing.

The Github action DSO-test is triggered for all tag push events, including major version releases. But since we usually release packages "manually", a tag push to master is actually too late. It is at the discretion of the devs to make sure that no minor/patch version that breaks DSO is released.

**WARNING**: DSO is currently not compatible with the newest version of schematools, so merging this will "break" master.