### PR TITLE
AB#92275 Circumvent wrong date in bag_panden during export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2023-09-16 (5.17.2)
+
+* Fix: Cast datetime type to string, because of a out-of-range year in bag_panden.
+
 # 2023-09-16 (5.17.1)
 
 * Bugfix: Fix error when invalid table is entered in derivedFrom paramter
@@ -5,7 +9,7 @@
 
 # 2023-09-14 (5.17.0)
 
-* Feature: Added create-views command to django management commands to facilitate creating views. 
+* Feature: Added create-views command to django management commands to facilitate creating views.
 
 # 2023-09-14 (5.16.1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.17.1
+version = 5.17.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import IO
 
+import psycopg2
 from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import Connection
 
@@ -10,6 +11,28 @@ from schematools.factories import tables_factory
 from schematools.types import _PUBLIC_SCOPE, DatasetFieldSchema, DatasetSchema, DatasetTableSchema
 
 metadata = MetaData()
+
+
+def enable_datetime_cast():
+    """Register a special cast-to-string for the datetime type.
+
+    This cast is not applied at module level, otherwise this
+    cast would be enabled for all `schema-tools` code.
+    """
+
+    def cast_date(value, cur):
+        if value is None:
+            return None
+        return str(value)
+
+    # The bag_panden table had one record with a date (year = 0001)
+    # that lets the dbapi `cursor.fetchmany` crash.
+    # We need to define a custom type to handle this error,
+    # because the historical record with this particular date cannot
+    # be modified.
+    date_oid = (1184,)  # This oid. can be obtained from cursor.description
+    TIMESTAMPSTR = psycopg2.extensions.new_type(date_oid, "TIMESTAMP", cast_date)
+    psycopg2.extensions.register_type(TIMESTAMPSTR)
 
 
 class BaseExporter:

--- a/src/schematools/exports/csv.py
+++ b/src/schematools/exports/csv.py
@@ -7,7 +7,7 @@ from geoalchemy2 import functions as func  # ST_AsEWKT
 from sqlalchemy import MetaData, Table, select
 from sqlalchemy.engine import Connection
 
-from schematools.exports import BaseExporter
+from schematools.exports import BaseExporter, enable_datetime_cast
 from schematools.naming import toCamelCase
 from schematools.types import DatasetSchema
 
@@ -43,5 +43,6 @@ def export_csvs(
     size: int,
 ):
     """Utility function to wrap the Exporter."""
+    enable_datetime_cast()
     exporter = CsvExporter(connection, dataset_schema, output, table_ids, scopes, size)
     exporter.export_tables()

--- a/src/schematools/exports/jsonlines.py
+++ b/src/schematools/exports/jsonlines.py
@@ -10,6 +10,7 @@ from sqlalchemy import MetaData, Table, select
 from sqlalchemy.engine import Connection
 
 from schematools.exports import BaseExporter
+from schematools.exports.csv import enable_datetime_cast
 from schematools.naming import toCamelCase
 from schematools.types import DatasetSchema, DatasetTableSchema
 
@@ -70,5 +71,6 @@ def export_jsonls(
     size: int,
 ):
     """Utility function to wrap the Exporter."""
+    enable_datetime_cast()
     exporter = JsonLinesExporter(connection, dataset_schema, output, table_ids, scopes, size)
     exporter.export_tables()


### PR DESCRIPTION
The bag_panden table had a historical record with a year of 0001. The dbapi.fetchmany function cannot handle this year, so we need a way to circumvent this problem. Luckily, in psycopg2 we are able to define custom handlers for specific column types. So, we convert datetimes to string, which is done anyway during the export.