### PR TITLE
AB#101824 Add helper method to userscopes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2023-12-20 (5.21.0)
+
+* Added an extra helper method to user-scopes to determine
+  if one of the fields has a scope that is blocking access.
+
 # 2023-12-15 (5.20.1)
 
 * Some old definitions (gebieden.stadsdelen) are using temporal relations

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.20.1
+version = 5.21.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -104,6 +104,10 @@ class UserScopes:
         # which includes mandatory filtersets.
         return self._has_table_auth_access(table) or self._has_table_profile_access(table)
 
+    def has_table_fields_access(self, table: DatasetTableSchema) -> bool:
+        """Tell whether all fields of a table can be accessed."""
+        return all(self.has_field_access(field) for field in table.fields)
+
     def has_field_access(self, field: DatasetFieldSchema) -> Permission:
         """Tell whether a field may be read."""
         # Again, when a field "auth" scope is satisfied, no further checks are done.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,6 +312,11 @@ def gebieden_schema(schema_loader) -> DatasetSchema:
 
 
 @pytest.fixture
+def id_auth_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("id_auth.json")
+
+
+@pytest.fixture
 def nap_schema(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("nap.json")
 

--- a/tests/test_permissions_auth.py
+++ b/tests/test_permissions_auth.py
@@ -154,3 +154,13 @@ class TestFieldAccess:
         assert user_scopes.has_field_access(table.get_field_by_id("volgnummer")) == expect
         assert user_scopes.has_field_access(table.get_field_by_id("identificatie")) == expect
         assert user_scopes.has_field_access(table.get_field_by_id("registratiedatum")) == expect
+
+    def test_has_table_fields_access(self, id_auth_schema):
+        """Prove that a table with one protected field cannot be accessed with OPENBAAR scope."""
+
+        user_scopes = UserScopes(
+            {},
+            request_scopes=["OPENBAAR"],
+        )
+        table = id_auth_schema.get_table_by_id("base")
+        assert not user_scopes.has_table_fields_access(table)


### PR DESCRIPTION
To determine if the user an access all fields of a particular table. This new method is needed, because on Azure the postgresql columns can have individual scope-based access. Django collects the full set of columns (select * from) when accessing a FK or M2M relation. This leads to permission error at the database level when accessing the API.

So, more specific access of columns is needed,
hence the extra helper method on userscopes.