### PR TITLE
AB#101824 Fix auth property for subfields.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2023-12-28 (5.21.1)
+
+* Fix auth property for subfields. The subfields do not have
+  scopes, however, a scope can be defined on the parent field.
+
 # 2023-12-20 (5.21.0)
 
 * Added an extra helper method to user-scopes to determine

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.21.0
+version = 5.21.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1734,7 +1734,13 @@ class DatasetFieldSchema(DatasetType):
 
     @property
     def auth(self) -> frozenset[str]:
-        """Auth of the field, or OPENBAAR."""
+        """Auth of the field, or OPENBAAR.
+
+        When the field is a subfield, the auth has been defined on
+        the parent field, so we need to return the auth of the parent field.
+        """
+        if self.is_subfield:
+            return self.parent_field.auth
         return _normalize_scopes(self.get("auth"))
 
     @cached_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,11 @@ def id_auth_schema(schema_loader) -> DatasetSchema:
 
 
 @pytest.fixture
+def subfield_auth_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("subfield_auth.json")
+
+
+@pytest.fixture
 def nap_schema(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("nap.json")
 

--- a/tests/files/datasets/kadastraleobjecten.json
+++ b/tests/files/datasets/kadastraleobjecten.json
@@ -46,6 +46,7 @@
               "format": "json"
           },
           "soortCultuurOnbebouwd": {
+              "auth": ["BRK/RO"],
               "type": "object",
               "properties": {
                   "code": {

--- a/tests/files/datasets/subfield_auth.json
+++ b/tests/files/datasets/subfield_auth.json
@@ -1,0 +1,55 @@
+{
+  "id": "subfieldauth",
+  "type": "dataset",
+  "description": "Dataset with auth on an field with subfields",
+  "license": "public",
+  "status": "niet_beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["id"],
+        "required": ["schema", "id"],
+        "display": "title",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "auth": ["BASE/ID"],
+            "reasonsNonPublic": ["nader te bepalen"],
+            "type": "integer",
+            "description": "Unieke aanduiding van het record."
+          },
+          "title": {
+            "type": "string",
+            "description": "Titel van het record."
+          },
+          "soortCultuurOnbebouwd": {
+            "auth": ["BRK/RO"],
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "omschrijving": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_permissions_auth.py
+++ b/tests/test_permissions_auth.py
@@ -164,3 +164,14 @@ class TestFieldAccess:
         )
         table = id_auth_schema.get_table_by_id("base")
         assert not user_scopes.has_table_fields_access(table)
+
+    def test_subfields_have_protection(self, subfield_auth_schema):
+        """Prove that the subfields of a protected field are also protected."""
+
+        user_scopes = UserScopes(
+            {},
+            request_scopes=["OPENBAAR"],
+        )
+        table = subfield_auth_schema.get_table_by_id("base")
+        subfield = table.get_field_by_id("soortCultuurOnbebouwd").subfields[0]
+        assert not user_scopes.has_field_access(subfield)


### PR DESCRIPTION
Field with subfields were not protected by the scope of the main field.

E.g. 

```
  "soortCultuurOnbebouwd": {
    "auth": ["BRK/RO"],
    "type": "object",
    "properties": {
      "code": {
        "type": "string"
      },
      "omschrijving": {
        "type": "string"
      }
    }
```


Whe accessing the subfield `soortCultuurOnbebouwdCode`, the scope
"BRK/RO" should be applied, however, it was not.

This PR fixes that bug.