### PR TITLE
Do not write export files if not columns are selected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2024-01-06 (5.24.0)
+
+* Do not write an empty export file if no columns are selected.
+  Also fix the export to only use active records for jsonlines.
+
 # 2024-01-31 (5.23.4)
 
 * Bugfix in _is_valid_sql
@@ -9,7 +14,7 @@
 # 2024-01-23 (5.23.2)
 
 * Fix to the _get_scopes to return the correct scopes for both dataset, table
-  and table fields. 
+  and table fields.
 
 # 2024-01-22 (5.23.1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 5.23.4
+version = 5.24.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import IO
+from typing import IO, Iterable
 
 import psycopg2
-from sqlalchemy import MetaData, Table
+from sqlalchemy import Column, MetaData, Table
 from sqlalchemy.engine import Connection
+from sqlalchemy.sql.elements import ClauseElement
 
 from schematools.factories import tables_factory
 from schematools.types import _PUBLIC_SCOPE, DatasetFieldSchema, DatasetSchema, DatasetTableSchema
@@ -78,7 +79,7 @@ class BaseExporter:
         )
         self.sa_tables = tables_factory(dataset_schema, metadata)
 
-    def _get_column(self, sa_table: Table, field: DatasetFieldSchema):
+    def _get_column(self, sa_table: Table, field: DatasetFieldSchema) -> Column:
         column = getattr(sa_table.c, field.db_name)
         # apply all processors
         for processor in self.processors:
@@ -86,17 +87,16 @@ class BaseExporter:
 
         return column
 
-        # processor = self.geo_modifier if field.is_geo else lambda col, _fn: col
-        # return processor(column, field.db_name)
-
-    def _get_columns(self, sa_table: Table, table: DatasetTableSchema):
+    def _get_columns(self, sa_table: Table, table: DatasetTableSchema) -> Iterable[Column]:
         for field in _get_fields(self.dataset_schema, table, self.scopes):
             try:
                 yield self._get_column(sa_table, field)
             except AttributeError:
                 pass  # skip unavailable columns
 
-    def _get_temporal_clause(self, sa_table: Table, table: DatasetTableSchema):
+    def _get_temporal_clause(
+        self, sa_table: Table, table: DatasetTableSchema
+    ) -> ClauseElement | None:
         if not table.is_temporal:
             return None
         temporal = table.temporal
@@ -112,13 +112,27 @@ class BaseExporter:
             if table.has_geometry_fields and srid is None:
                 raise ValueError("Table has geo fields, but srid is None.")
             sa_table = self.sa_tables[table.id]
+            columns = list(self._get_columns(sa_table, table))
+            if not columns:
+                return
             with open(
                 self.base_dir / f"{table.db_name}.{self.extension}", "w", encoding="utf8"
             ) as file_handle:
-                self.write_rows(file_handle, table, sa_table, srid)
+                self.write_rows(
+                    file_handle,
+                    table,
+                    columns,
+                    self._get_temporal_clause(sa_table, table),
+                    srid,
+                )
 
-    def write_rows(
-        self, file_handle: IO[str], table: DatasetTableSchema, sa_table: Table, srid: str
+    def write_rows(  # noqa: D102
+        self,
+        file_handle: IO[str],
+        table: DatasetTableSchema,
+        columns: Iterable[Column],
+        temporal_clause: ClauseElement | None,
+        srid: str,
     ):
         raise NotImplementedError
 

--- a/src/schematools/exports/csv.py
+++ b/src/schematools/exports/csv.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import csv
 from datetime import date
-from typing import IO
+from typing import IO, Iterable
 
 from geoalchemy2 import functions as gfunc  # ST_AsEWKT
-from sqlalchemy import MetaData, Table, func, select
+from sqlalchemy import Column, MetaData, Table, func, select
 from sqlalchemy.engine import Connection
+from sqlalchemy.sql.elements import ClauseElement
 
 from schematools.exports import BaseExporter, enable_datetime_cast
 from schematools.naming import toCamelCase
-from schematools.types import DatasetFieldSchema, DatasetSchema
+from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema
 
 metadata = MetaData()
 
@@ -43,15 +44,19 @@ class CsvExporter(BaseExporter):  # noqa: D101
     processors = (geo_modifier, id_modifier, datetime_modifier)
 
     def write_rows(  # noqa: D102
-        self, file_handle: IO[str], table: DatasetSchema, sa_table: Table, srid: str
+        self,
+        file_handle: IO[str],
+        table: DatasetTableSchema,
+        columns: Iterable[Column],
+        temporal_clause: ClauseElement | None,
+        srid: str,
     ):
-        columns = list(self._get_columns(sa_table, table))
+
         field_names = [c.name for c in columns]
         writer = csv.DictWriter(file_handle, field_names, extrasaction="ignore")
         # Use capitalize() on headers, because csv export does the same
         writer.writerow({fn: toCamelCase(fn).capitalize() for fn in field_names})
-        query = select(self._get_columns(sa_table, table))
-        temporal_clause = self._get_temporal_clause(sa_table, table)
+        query = select(columns)
         if temporal_clause is not None:
             query = query.where(temporal_clause)
         if self.size is not None:

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -46,6 +46,8 @@ def export_geopackages(
             for field in _get_fields(dataset_schema, table, scopes)
             if field.db_name != "schema"
         )
+        if not field_names.seq:
+            return
         table_name = sql.Identifier(table.db_name)
         query = sql.SQL("SELECT {field_names} from {table_name}").format(
             field_names=field_names, table_name=table_name


### PR DESCRIPTION
Sometimes zero columns are selected. Only open data is exported, so when columns are protected by a scope, those columns are not exported.

Furthermore, the temporal aspect was not added to the jsonlines export, so the whole history was exported.