### PR TITLE
Fix premature leave of the export loop.

### DIFF
--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -114,7 +114,7 @@ class BaseExporter:
             sa_table = self.sa_tables[table.id]
             columns = list(self._get_columns(sa_table, table))
             if not columns:
-                return
+                continue
             with open(
                 self.base_dir / f"{table.db_name}.{self.extension}", "w", encoding="utf8"
             ) as file_handle:

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -47,7 +47,7 @@ def export_geopackages(
             if field.db_name != "schema"
         )
         if not field_names.seq:
-            return
+            continue
         table_name = sql.Identifier(table.db_name)
         query = sql.SQL("SELECT {field_names} from {table_name}").format(
             field_names=field_names, table_name=table_name


### PR DESCRIPTION
The loop through the tables of a dataset during export was prematurely being left when a table was empty (because it has no open data).