### PR TITLE
Block deepcopy() of serializer objects, as it's very slow

### DIFF
--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -1,4 +1,5 @@
 """Module implementing an event processor, that processes full events."""
+
 from __future__ import annotations
 
 import logging
@@ -96,10 +97,11 @@ class LastEventIds:
     BENK_DATASET = "benk"
     LASTEVENTIDS_TABLE = "lasteventids"
 
-    def __init__(self):
-        loader = get_schema_loader()
-        self.dataset = loader.get_dataset(self.BENK_DATASET)
-        self.lasteventids_table = self.dataset.get_table_by_id(self.LASTEVENTIDS_TABLE)
+    def __init__(self, benk_dataset=None):
+        if benk_dataset is None:
+            loader = get_schema_loader()
+            benk_dataset = loader.get_dataset(self.BENK_DATASET)
+        self.lasteventids_table = benk_dataset.get_table_by_id(self.LASTEVENTIDS_TABLE)
         self.lasteventid_column = self.lasteventids_table.get_field_by_id("lastEventId")
 
         self.cache = defaultdict(int)
@@ -157,6 +159,7 @@ class EventsProcessor:
         connection: Connection,
         local_metadata=None,
         truncate=False,
+        benk_dataset=None,
     ) -> None:
         """Construct the event processor.
 
@@ -170,7 +173,7 @@ class EventsProcessor:
                 in unit tests.
             truncate: indicates if the relational tables need to be truncated
         """
-        self.lasteventids = LastEventIds()
+        self.lasteventids = LastEventIds(benk_dataset=benk_dataset)
         benk_dataset = self.lasteventids.lasteventids_table.dataset
         self.datasets = {benk_dataset.id: benk_dataset} | {ds.id: ds for ds in datasets}
         self.conn = connection

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -199,6 +199,12 @@ class JsonDict(UserDict):
     def json_data(self) -> Json:
         return json.loads(self.json())
 
+    def __deepcopy__(self, memo):
+        # This took a massive performance hit, as DRF was copying all attached objects.
+        raise NotImplementedError(
+            "Deepcopy of schema objects is not supported due to performance issues."
+        )
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -199,15 +199,18 @@ class JsonDict(UserDict):
     def json_data(self) -> Json:
         return json.loads(self.json())
 
-
-class SchemaType(JsonDict):
-    """Base class for top-level schema objects (dataset, table, profile, publisher)."""
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 
     def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self.__class__.__name__}")
+        raise KeyError(f"No field named '{key}' exists in {self!r}")
+
+
+class SchemaType(JsonDict):
+    """Base class for top-level schema objects (dataset, table, profile, publisher).
+
+    Each object should have an "id" and "type" property.
+    """
 
     def __hash__(self) -> int:
         return id(self)  # allow usage in lru_cache()
@@ -235,16 +238,6 @@ class SchemaType(JsonDict):
     @classmethod
     def from_dict(cls: type[ST], obj: Json) -> ST:
         return cls(copy.deepcopy(obj))
-
-
-class DatasetType(JsonDict):
-    """Base class for child elements of the schema."""
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.data!r})"
-
-    def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self!r}")
 
 
 class DatasetSchema(SchemaType):
@@ -1253,7 +1246,7 @@ class TableVersions(Mapping[str, DatasetTableSchema]):
         return len(self._version_paths)
 
 
-class DatasetFieldSchema(DatasetType):
+class DatasetFieldSchema(JsonDict):
     """A single field (column) in a table."""
 
     def __init__(
@@ -1815,7 +1808,7 @@ class DatasetFieldSchema(DatasetType):
         return not destination_type_set <= source_type_set
 
 
-class AdditionalRelationSchema(DatasetType):
+class AdditionalRelationSchema(JsonDict):
     """Data class describing the additional relation block."""
 
     def __init__(self, _id: str, _parent_table: DatasetTableSchema | None = None, **kwargs):
@@ -2017,7 +2010,7 @@ class ProfileSchema(SchemaType):
         }
 
 
-class ProfileDatasetSchema(DatasetType):
+class ProfileDatasetSchema(JsonDict):
     """A schema inside the profile dataset.
 
     It grants :attr:`permissions` to a dataset on a global level,
@@ -2058,7 +2051,7 @@ class ProfileDatasetSchema(DatasetType):
         }
 
 
-class ProfileTableSchema(DatasetType):
+class ProfileTableSchema(JsonDict):
     """A single table in the profile.
 
     This grants :attr:`permissions` to a specific table,

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1,4 +1,5 @@
 """Python types for the Amsterdam Schema JSON file contents."""
+
 from __future__ import annotations
 
 import copy

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -2,7 +2,7 @@ from sqlalchemy import MetaData, create_engine, inspect
 
 from schematools import MAX_TABLE_NAME_LENGTH, TABLE_INDEX_POSTFIX
 from schematools.importer.base import BaseImporter
-from schematools.types import DatasetSchema, SchemaType
+from schematools.types import DatasetSchema
 
 
 def test_index_creation(engine, db_schema):
@@ -333,8 +333,7 @@ def test_size_of_index_name(engine, db_schema):
     }
 
     data = test_data
-    parent_schema = SchemaType(data)
-    dataset_schema = DatasetSchema(parent_schema)
+    dataset_schema = DatasetSchema(data)
     table = dataset_schema.get_table_by_id("child_test_size")
 
     importer = BaseImporter(dataset_schema, engine)
@@ -345,7 +344,7 @@ def test_size_of_index_name(engine, db_schema):
     meta_data = MetaData(bind=conn)
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
-    indexes = metadata_inspector.get_indexes(f"{parent_schema['id']}_{table['id']}", schema=None)
+    indexes = metadata_inspector.get_indexes(f"{data['id']}_{table['id']}", schema=None)
     indexes_name = []
 
     for index in indexes:
@@ -365,9 +364,8 @@ def test_index_creation_db_schema2(engine, stadsdelen_schema):
     meta_data = MetaData(bind=engine)
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
-    parent_schema = SchemaType(stadsdelen_schema)
     indexes = metadata_inspector.get_indexes(
-        f"{parent_schema['id']}_stadsdelen", schema="schema_foo_bar"
+        f"{stadsdelen_schema['id']}_stadsdelen", schema="schema_foo_bar"
     )
     index_names = {index["name"] for index in indexes}
     assert index_names == {"stadsdelen_stadsdelen_identifier_idx"}


### PR DESCRIPTION
A deepcopy() happened because the schema objects were assigned as attributes to Django REST Framework fields. DRF will deepcopy all statically declared fields to request data and parent-fields can be assigned to the whole tree. That operation easily took more then 14sec.

This change is there to avoid such pitfall in the future, as the copy operation is simply too slow in its present form.