### PR TITLE
Fix performance of "auth" field access

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     requests
     jinja2
     mappyfile
-    methodtools
     jsonpath-rw
     orjson
     more-ds

--- a/src/schematools/_utils.py
+++ b/src/schematools/_utils.py
@@ -1,0 +1,31 @@
+"""Internal utils, not meant to be used outside schematools."""
+
+import functools
+import weakref
+
+
+def cached_method(*lru_args, **lru_kwargs):
+    """A simple lru-cache per object.
+    This removed the need for methodtools.lru_cache(), which uses wirerope for purity.
+    The usage of wirerope started showing up as 5% of the request time, hence it's significant to remove.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def initial_wrapped_func(self, *args, **kwargs):
+            # Not storing the wrapped method inside the instance. If we had
+            # a strong reference to self the instance would never die.
+            self_weak = weakref.ref(self)
+
+            @functools.wraps(func)
+            @functools.lru_cache(*lru_args, **lru_kwargs)
+            def cached_method(*args, **kwargs):
+                return func(self_weak(), *args, **kwargs)
+
+            # Assigns to the self reference (preserving the cache), and optimizes the next access.
+            setattr(self, func.__name__, cached_method)
+            return cached_method(*args, **kwargs)
+
+        return initial_wrapped_func
+
+    return decorator

--- a/src/schematools/events/full.py
+++ b/src/schematools/events/full.py
@@ -1,4 +1,5 @@
 """Module implementing an event processor, that processes full events."""
+
 from __future__ import annotations
 
 import logging
@@ -96,10 +97,11 @@ class LastEventIds:
     BENK_DATASET = "benk"
     LASTEVENTIDS_TABLE = "lasteventids"
 
-    def __init__(self):
-        loader = get_schema_loader()
-        self.dataset = loader.get_dataset(self.BENK_DATASET)
-        self.lasteventids_table = self.dataset.get_table_by_id(self.LASTEVENTIDS_TABLE)
+    def __init__(self, benk_dataset=None):
+        if benk_dataset is None:
+            loader = get_schema_loader()
+            benk_dataset = loader.get_dataset(self.BENK_DATASET)
+        self.lasteventids_table = benk_dataset.get_table_by_id(self.LASTEVENTIDS_TABLE)
         self.lasteventid_column = self.lasteventids_table.get_field_by_id("lastEventId")
 
         self.cache = defaultdict(int)
@@ -157,6 +159,7 @@ class EventsProcessor:
         connection: Connection,
         local_metadata=None,
         truncate=False,
+        benk_dataset=None,
     ) -> None:
         """Construct the event processor.
 
@@ -170,7 +173,7 @@ class EventsProcessor:
                 in unit tests.
             truncate: indicates if the relational tables need to be truncated
         """
-        self.lasteventids = LastEventIds()
+        self.lasteventids = LastEventIds(benk_dataset=benk_dataset)
         benk_dataset = self.lasteventids.lasteventids_table.dataset
         self.datasets = {benk_dataset.id: benk_dataset} | {ds.id: ds for ds in datasets}
         self.conn = connection

--- a/src/schematools/permissions/auth.py
+++ b/src/schematools/permissions/auth.py
@@ -3,12 +3,12 @@
 The :class:`UserScopes` class handles whether a dataset, table or field can be accessed.
 The other classes in this module ease to retrieval of permission objects.
 """
+
 from __future__ import annotations
 
 from typing import Iterable, Iterator
 
-import methodtools
-
+from schematools._utils import cached_method
 from schematools.types import (
     DatasetFieldSchema,
     DatasetSchema,
@@ -74,7 +74,7 @@ class UserScopes:
         """
         self._query_param_names.extend(params)
 
-    @methodtools.lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def has_all_scopes(self, needed_scopes: frozenset[str]) -> bool:
         """Check whether the request has all scopes.
 
@@ -82,7 +82,7 @@ class UserScopes:
         """
         return self._scopes.issuperset(needed_scopes)
 
-    @methodtools.lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def has_any_scope(self, needed_scopes: frozenset[str]) -> bool:
         """Check whether the request grants one of the given scopes.
 
@@ -151,7 +151,7 @@ class UserScopes:
         else:
             return Permission.none
 
-    @methodtools.lru_cache()
+    @cached_method()
     def _has_dataset_profile_access(self, dataset_id: str) -> Permission:
         """Give the permission access level for a dataset, as defined by the profile."""
         return max(
@@ -162,7 +162,7 @@ class UserScopes:
             default=Permission.none,
         )
 
-    @methodtools.lru_cache()
+    @cached_method()
     def _has_table_profile_access(self, table: DatasetTableSchema) -> Permission:
         """Give the permission level for a table.
 
@@ -239,7 +239,7 @@ class UserScopes:
 
         return max_permission
 
-    @methodtools.lru_cache()
+    @cached_method()
     def get_active_profile_datasets(self, dataset_id: str) -> list[ProfileDatasetSchema]:
         """Find all profiles that mention a dataset and match the scopes.
 
@@ -260,7 +260,7 @@ class UserScopes:
             and (profile_dataset := profile.datasets.get(dataset_id)) is not None
         ]
 
-    @methodtools.lru_cache()
+    @cached_method()
     def get_active_profile_tables(
         self, dataset_id: str, table_id: str
     ) -> list[ProfileTableSchema]:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -199,6 +199,12 @@ class JsonDict(UserDict):
     def json_data(self) -> Json:
         return json.loads(self.json())
 
+    def __deepcopy__(self, memo):
+        # This took a massive performance hit, as DRF was copying all attached objects.
+        raise NotImplementedError(
+            "Deepcopy of schema objects is not supported due to performance issues."
+        )
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -199,15 +199,18 @@ class JsonDict(UserDict):
     def json_data(self) -> Json:
         return json.loads(self.json())
 
-
-class SchemaType(JsonDict):
-    """Base class for top-level schema objects (dataset, table, profile, publisher)."""
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 
     def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self.__class__.__name__}")
+        raise KeyError(f"No field named '{key}' exists in {self!r}")
+
+
+class SchemaType(JsonDict):
+    """Base class for top-level schema objects (dataset, table, profile, publisher).
+
+    Each object should have an "id" and "type" property.
+    """
 
     def __hash__(self) -> int:
         return id(self)  # allow usage in lru_cache()
@@ -235,16 +238,6 @@ class SchemaType(JsonDict):
     @classmethod
     def from_dict(cls: type[ST], obj: Json) -> ST:
         return cls(copy.deepcopy(obj))
-
-
-class DatasetType(JsonDict):
-    """Base class for child elements of the schema."""
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.data!r})"
-
-    def __missing__(self, key: str) -> NoReturn:
-        raise KeyError(f"No field named '{key}' exists in {self!r}")
 
 
 class DatasetSchema(SchemaType):
@@ -1253,7 +1246,7 @@ class TableVersions(Mapping[str, DatasetTableSchema]):
         return len(self._version_paths)
 
 
-class DatasetFieldSchema(DatasetType):
+class DatasetFieldSchema(JsonDict):
     """A single field (column) in a table."""
 
     def __init__(
@@ -1815,7 +1808,7 @@ class DatasetFieldSchema(DatasetType):
         return not destination_type_set <= source_type_set
 
 
-class AdditionalRelationSchema(DatasetType):
+class AdditionalRelationSchema(JsonDict):
     """Data class describing the additional relation block."""
 
     def __init__(self, _id: str, _parent_table: DatasetTableSchema | None = None, **kwargs):
@@ -2017,7 +2010,7 @@ class ProfileSchema(SchemaType):
         }
 
 
-class ProfileDatasetSchema(DatasetType):
+class ProfileDatasetSchema(JsonDict):
     """A schema inside the profile dataset.
 
     It grants :attr:`permissions` to a dataset on a global level,
@@ -2058,7 +2051,7 @@ class ProfileDatasetSchema(DatasetType):
         }
 
 
-class ProfileTableSchema(DatasetType):
+class ProfileTableSchema(JsonDict):
     """A single table in the profile.
 
     This grants :attr:`permissions` to a specific table,

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -29,9 +29,8 @@ from typing import (
     cast,
 )
 
-from methodtools import lru_cache
-
 from schematools import MAX_TABLE_NAME_LENGTH
+from schematools._utils import cached_method
 from schematools.exceptions import (
     DatasetFieldNotFound,
     DatasetTableNotFound,
@@ -492,7 +491,7 @@ class DatasetSchema(SchemaType):
         if include_through:
             yield from self.through_tables
 
-    @lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def get_table_by_id(
         self, table_id: str, include_nested: bool = True, include_through: bool = True
     ) -> DatasetTableSchema:
@@ -931,7 +930,7 @@ class DatasetTableSchema(SchemaType):
                 continue
             yield field
 
-    @lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def get_field_by_id(self, field_id: str) -> DatasetFieldSchema:
         """Get a fields based on the ids of the field."""
         for field_schema in self.fields:
@@ -940,7 +939,7 @@ class DatasetTableSchema(SchemaType):
 
         raise DatasetFieldNotFound(f"Field '{field_id}' does not exist in table '{self.id}'.")
 
-    @lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def get_additional_relation_by_id(self, relation_id: str) -> AdditionalRelationSchema:
         """Get the reverse relation based on the ids of the relation."""
         for additional_relation in self.additional_relations:
@@ -1631,7 +1630,7 @@ class DatasetFieldSchema(JsonDict):
         """Return the item definition for an array type."""
         return self.get("items", {}) if self.is_array else None
 
-    @lru_cache()  # type: ignore[misc]
+    @cached_method()  # type: ignore[misc]
     def get_field_by_id(self, field_id: str) -> DatasetFieldSchema:
         """Finds and returns the subfield with the given id.
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1,4 +1,5 @@
 """Python types for the Amsterdam Schema JSON file contents."""
+
 from __future__ import annotations
 
 import copy

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -215,6 +215,12 @@ class JsonDict(UserDict):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 
+    def __setitem__(self, key, value):
+        if key in self.data and key in self.__dict__:
+            # Clear the @cached_property cache value
+            del self.__dict__[key]
+        super().__setitem__(key, value)
+
     if IS_DEBUGGER:
 
         def __missing__(self, key: str) -> NoReturn:
@@ -373,7 +379,7 @@ class DatasetSchema(SchemaType):
         Defaults to True, in order to stay backwards compatible."""
         return self.default_version == self.version
 
-    @property
+    @cached_property
     def auth(self) -> frozenset[str]:
         """Auth of the dataset, or OPENBAAR."""
         return _normalize_scopes(self.get("auth"))
@@ -759,7 +765,7 @@ class DatasetTableSchema(SchemaType):
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self.qualified_id}>"
 
-    @property
+    @cached_property
     def qualified_id(self) -> str:
         """The fully qualified ID (for debugging)"""
         prefix = ""
@@ -1084,7 +1090,7 @@ class DatasetTableSchema(SchemaType):
 
         return None
 
-    @property
+    @cached_property
     def auth(self) -> frozenset[str]:
         """Auth of the table, or OPENBAAR."""
         return _normalize_scopes(self.get("auth"))
@@ -1298,7 +1304,7 @@ class DatasetFieldSchema(JsonDict):
         """Provide access to the top-level field where it is a property for."""
         return self._parent_field
 
-    @property
+    @cached_property
     def qualified_id(self) -> str:
         """The fully qualified ID (for debugging)"""
         prefix = ""
@@ -1759,13 +1765,15 @@ class DatasetFieldSchema(JsonDict):
             self.is_composite_key or self.related_table.is_temporal
         )
 
-    @property
+    @cached_property
     def auth(self) -> frozenset[str]:
         """Auth of the field, or OPENBAAR.
 
         When the field is a subfield, the auth has been defined on
         the parent field, so we need to return the auth of the parent field.
         """
+        # As this call is made so many times, this is a cached_property
+        # to avoid hitting __missing__() too many times.
         if self.is_subfield:
             return self.parent_field.auth
         return _normalize_scopes(self.get("auth"))
@@ -2016,7 +2024,7 @@ class ProfileSchema(SchemaType):
         """Name of Profile (if set)"""
         return self.get("name")
 
-    @property
+    @cached_property
     def scopes(self) -> frozenset[str]:
         """All these scopes should match in order to activate the profile."""
         return _normalize_scopes(self.get("scopes"))

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -2,7 +2,7 @@ from sqlalchemy import MetaData, create_engine, inspect
 
 from schematools import MAX_TABLE_NAME_LENGTH, TABLE_INDEX_POSTFIX
 from schematools.importer.base import BaseImporter
-from schematools.types import DatasetSchema, SchemaType
+from schematools.types import DatasetSchema
 
 
 def test_index_creation(engine, db_schema):
@@ -333,8 +333,7 @@ def test_size_of_index_name(engine, db_schema):
     }
 
     data = test_data
-    parent_schema = SchemaType(data)
-    dataset_schema = DatasetSchema(parent_schema)
+    dataset_schema = DatasetSchema(data)
     table = dataset_schema.get_table_by_id("child_test_size")
 
     importer = BaseImporter(dataset_schema, engine)
@@ -345,7 +344,7 @@ def test_size_of_index_name(engine, db_schema):
     meta_data = MetaData(bind=conn)
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
-    indexes = metadata_inspector.get_indexes(f"{parent_schema['id']}_{table['id']}", schema=None)
+    indexes = metadata_inspector.get_indexes(f"{data['id']}_{table['id']}", schema=None)
     indexes_name = []
 
     for index in indexes:
@@ -365,9 +364,8 @@ def test_index_creation_db_schema2(engine, stadsdelen_schema):
     meta_data = MetaData(bind=engine)
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
-    parent_schema = SchemaType(stadsdelen_schema)
     indexes = metadata_inspector.get_indexes(
-        f"{parent_schema['id']}_stadsdelen", schema="schema_foo_bar"
+        f"{stadsdelen_schema['id']}_stadsdelen", schema="schema_foo_bar"
     )
     index_names = {index["name"] for index in indexes}
     assert index_names == {"stadsdelen_stadsdelen_identifier_idx"}


### PR DESCRIPTION
See individual commits, it improves all aspects which showed up during DSO-API profiling.
The major improvement is no longer calling `__missing__()` for 800+ "auth" field access, which called `repr(self.data)` for a missing key.

It also includes the deepcopy-preventative measure, so DSO-API or any other code won't accidentally perform a `deepcopy()` of the schema data. In its current form this is too slow.