### PR TITLE
Fix Django < 4.2 pinning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2024-07-15 (6.0.1)
+
+* Fix Django<4.2 pinning.
+
 # 2024-07-11 (6.0)
 
 * Improved performance of auth checks (especially `has_field_access()`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 6.0
+version = 6.0.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ tests =
     pytest-django >= 4.7.0
     pytest-sqlalchemy
 django =
-    django >= 3.0, < 4.2
+    django >= 3.2
     django-gisserver >= 1.2.7
     django-environ
     django-db-comments


### PR DESCRIPTION
This  blocks upgrading DSO-API