### PR TITLE
Add compatibilty for python 3.13

### DIFF
--- a/.github/workflows/deplic.yaml
+++ b/.github/workflows/deplic.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install tools
       run: |
         sudo apt install -y jq

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'  # matches what .pre-commit-config.yaml has
+        python-version: '3.13'  # matches what .pre-commit-config.yaml has
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     services:
       db:
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -y
-        sudo apt install -y libgdal30
+        sudo apt install -y libgdal34t64
         python -m pip install --upgrade pip
         python -m pip install .[django,tests]
     - name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,10 @@
 # Supported hooks: https://pre-commit.com/hooks.html
 # Running "make format" fixes most issues for you
 default_language_version:
-  python: python3.11
+  python: python3.13
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -17,20 +17,20 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args:
-        - --py310-plus
+        - --py313-plus
         - --keep-runtime-typing
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.21.0"
+    rev: "1.22.2"
     hooks:
       - id: django-upgrade
         args:
           - --target-version=3.2
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.8.6
     hooks:
       - id: ruff
         args:
@@ -39,6 +39,6 @@ repos:
         - --config=pyproject.toml
         - --exit-non-zero-on-fix
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm
+FROM python:3.13-bookworm
 
 RUN useradd --user-group --system datapunt
 RUN apt-get update && apt install -y libgdal32

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 [options]
 package_dir =
     = src


### PR DESCRIPTION
Updated all references to python 3.13, also added python 3.12 to the test matrix.

Since the last successful test workflow on Github the `ubuntu:latest` image was updated from 22.04 to 24.04, which required an update to the gdal package. Should we pin the version of the test container to prevent this from happening again?