### PR TITLE
Resolve refs in auth fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-01-31 (6.2.1)
+
+* Auth fields can now accomodate references to separately defined scope
+  objects.
+
 # 2025-01-29 (6.2)
 
 * Added a `validate_scopes` command to use in the Amsterdam Schema

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 6.2
+version = 6.2.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -340,7 +340,7 @@ class _FileBasedSchemaLoader(SchemaLoader):
         return result
 
     def get_scope(self, ref: str) -> Scope:
-        return Scope.from_dict(_read_json_path(self.root.parent / (ref + ".json")))
+        return Scope.from_dict(_read_json_path(self.root.parent / f"{ref}.json"))
 
     def get_all_scopes(self) -> dict[str, Scope]:
         result = {}

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -387,10 +387,25 @@ class DatasetSchema(SchemaType):
         Defaults to True, in order to stay backwards compatible."""
         return self.default_version == self.version
 
+    def _resolve_auth(self, auth):
+        """Auth may contain a reference to a scope, or a list of such references.
+
+        It may also be a string or list of strings.
+        """
+        if isinstance(auth, dict) and "$ref" in auth:
+            if self.loader is None:
+                raise RuntimeError(f"{self!r} has no loader defined, can't resolve auth.")
+            return self.loader.get_scope(auth["$ref"])
+        if isinstance(auth, list):
+            return [self._resolve_auth(a) for a in auth]
+        return auth
+
     @cached_property
     def auth(self) -> frozenset[str]:
         """Auth of the dataset, or OPENBAAR."""
-        return _normalize_scopes(self.get("auth"))
+        auth = self._resolve_auth(self.get("auth"))
+
+        return _normalize_scopes(auth)
 
     @property
     def status(self) -> DatasetSchema.Status:
@@ -416,7 +431,7 @@ class DatasetSchema(SchemaType):
             ) from None
 
         # It's assumed here that the loader is a CachedSchemaLoader,
-        # do data can be fetched multiple times.
+        # so data can be fetched multiple times.
         return self.loader.get_dataset(dataset_id)
 
     @cached_property
@@ -1100,7 +1115,19 @@ class DatasetTableSchema(SchemaType):
     @cached_property
     def auth(self) -> frozenset[str]:
         """Auth of the table, or OPENBAAR."""
-        return _normalize_scopes(self.get("auth"))
+        auth = self.get("auth")
+        if (isinstance(auth, dict) and "$ref" in auth) or (
+            isinstance(auth, list) and any("$ref" in a for a in auth)
+        ):
+            # Resolution of $ref is needed.
+            if self._parent_schema is None:
+                raise RuntimeError(
+                    f"{self!r} doesn't have a parent schema defined, can't resolve auth."
+                )
+            resolved_auth = self._parent_schema._resolve_auth(auth)
+            return _normalize_scopes(resolved_auth)
+
+        return _normalize_scopes(auth)
 
     @property
     def is_through_table(self) -> bool:
@@ -1310,6 +1337,10 @@ class DatasetFieldSchema(JsonDict):
     def parent_field(self) -> DatasetFieldSchema | None:
         """Provide access to the top-level field where it is a property for."""
         return self._parent_field
+
+    @property
+    def schema(self) -> DatasetSchema | None:
+        return self.table._parent_schema if self.table else None
 
     @cached_property
     def qualified_id(self) -> str:
@@ -1786,7 +1817,19 @@ class DatasetFieldSchema(JsonDict):
         # to avoid hitting __missing__() too many times.
         if self.is_subfield:
             return self.parent_field.auth
-        return _normalize_scopes(self.get("auth"))
+        auth = self.get("auth")
+        if (isinstance(auth, dict) and "$ref" in auth) or (
+            isinstance(auth, list) and any("$ref" in a for a in auth)
+        ):
+            # Resolution of $ref is needed.
+            if self.schema is None:
+                raise RuntimeError(
+                    f"{self!r} doesn't have a parent schema defined, can't resolve auth."
+                )
+            resolved_auth = self.schema._resolve_auth(auth)
+            return _normalize_scopes(resolved_auth)
+
+        return _normalize_scopes(auth)
 
     @cached_property
     def filter_auth(self) -> frozenset[str]:
@@ -2239,10 +2282,11 @@ def _normalize_scopes(auth: None | str | list | tuple | dict) -> frozenset[str]:
         return frozenset({_PUBLIC_SCOPE})
     elif isinstance(auth, (list, tuple, set)):
         # Multiple scopes act choices (OR match).
-        return frozenset(auth)
-    elif isinstance(auth, dict):
+        auths = [a.id if isinstance(a, Scope) else a for a in auth]
+        return frozenset(auths)
+    elif isinstance(auth, Scope):
         # Auth can be a scope object, with an id, name, and owner.
-        return frozenset({auth["id"]})
+        return frozenset({auth.id})
     else:
         # Normalize single scope to set return type too.
         return frozenset({auth})

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2245,7 +2245,7 @@ def _normalize_scopes(auth: None | str | list | tuple | dict) -> frozenset[str]:
         return frozenset({auth["id"]})
     else:
         # Normalize single scope to set return type too.
-        return frozenset({auth})
+        return frozenset({str(auth)})
 
 
 @dataclasses.dataclass

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2295,7 +2295,3 @@ class Scope(SchemaType):
     @classmethod
     def from_dict(cls, obj: Json) -> Scope:
         return cls(copy.deepcopy(obj))
-
-    @classmethod
-    def from_string(cls, id: str) -> Scope:
-        return cls({"id": id, "name": id, "owner": {}})

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2245,7 +2245,7 @@ def _normalize_scopes(auth: None | str | list | tuple | dict) -> frozenset[str]:
         return frozenset({auth["id"]})
     else:
         # Normalize single scope to set return type too.
-        return frozenset({str(auth)})
+        return frozenset({auth})
 
 
 @dataclasses.dataclass

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -396,9 +396,10 @@ class DatasetSchema(SchemaType):
             if self.loader is None:
                 raise RuntimeError(f"{self!r} has no loader defined, can't resolve auth.")
             return self.loader.get_scope(auth["$ref"])
-        if isinstance(auth, list):
+        elif isinstance(auth, list):
             return [self._resolve_auth(a) for a in auth]
-        return auth
+        else:
+            return auth
 
     @cached_property
     def auth(self) -> frozenset[str]:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2295,3 +2295,7 @@ class Scope(SchemaType):
     @classmethod
     def from_dict(cls, obj: Json) -> Scope:
         return cls(copy.deepcopy(obj))
+
+    @classmethod
+    def from_string(cls, id: str) -> Scope:
+        return cls({"id": id, "name": id, "owner": {}})

--- a/tests/files/datasets/metaschema2.json
+++ b/tests/files/datasets/metaschema2.json
@@ -8,11 +8,17 @@
   "publisher": {
     "$ref": "/publishers/HARRY"
   },
+  "auth": {
+    "$ref": "scopes/HARRY/harryscope1"
+  },
   "tables": [
     {
       "id": "tabelleke",
       "type": "table",
       "version": "1.0.0",
+      "auth": {
+        "$ref": "scopes/HARRY/harryscope2"
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/tabelleke/referentiepunten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -26,10 +32,18 @@
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "id": {
+            "auth": [{
+              "$ref": "scopes/HARRY/harryscope1"
+            }, {
+              "$ref": "scopes/HARRY/harryscope2"
+            }],
             "type": "string",
             "description": "Unieke identificatie voor dit object"
           },
           "identificatie": {
+            "auth": {
+              "$ref": "scopes/HARRY/harryscope3"
+            },
             "type": "string",
             "description": "Unieke identificatie van de meting"
           }

--- a/tests/files/scopes/HARRY/harryscope3.json
+++ b/tests/files/scopes/HARRY/harryscope3.json
@@ -1,0 +1,7 @@
+{
+    "name": "HARRYscope3",
+    "id": "HARRY/THREE",
+    "owner": {
+        "$ref": "publishers/HARRY"
+    }
+}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -62,6 +62,13 @@ def test_load_all_scopes(schema_loader):
                 "owner": {"$ref": "publishers/HARRY"},
             }
         ),
+        "HARRY/THREE": Scope(
+            {
+                "name": "HARRYscope3",
+                "id": "HARRY/THREE",
+                "owner": {"$ref": "publishers/HARRY"},
+            }
+        ),
     }
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -303,6 +303,40 @@ def test_load_publisher_object_from_dataset(schema_loader):
     }
 
 
+def test_load_scope_object_from_dataset(schema_loader):
+    """Test that we can retrieve a scope object from a DatasetSchema
+    as defined by metaschema 2.0"""
+    schema = schema_loader.get_dataset_from_file("metaschema2.json")
+
+    assert schema.auth == frozenset({"HARRY/ONE"})
+
+
+def test_load_scope_object_from_table(schema_loader):
+    """Test that we can retrieve a scope object from a DatasetSchema
+    as defined by metaschema 2.0"""
+    schema = schema_loader.get_dataset_from_file("metaschema2.json")
+
+    assert schema.tables[0].auth == frozenset({"HARRY/TWO"})
+
+
+def test_load_scope_object_from_field(schema_loader):
+    """Test that we can retrieve a scope object from a DatasetSchema
+    as defined by metaschema 2.0"""
+    schema = schema_loader.get_dataset_from_file("metaschema2.json")
+    field = schema.tables[0].get_field_by_id("identificatie")
+
+    assert field.auth == frozenset({"HARRY/THREE"})
+
+
+def test_load_multiple_scope_objects(schema_loader):
+    """Test that we can retrieve a scope object from a DatasetSchema
+    as defined by metaschema 2.0"""
+    schema = schema_loader.get_dataset_from_file("metaschema2.json")
+    field = schema.tables[0].get_field_by_id("id")
+
+    assert field.auth == frozenset({"HARRY/ONE", "HARRY/TWO"})
+
+
 def test_repr_broken_schema():
     """Regression test: __repr__ and __missing__ performed infinite mutual recursion
     when dealing with broken schemas.


### PR DESCRIPTION
NB [#570] eerst mergen. ✅ 

Deze zorgt ervoor dat we voor de auth velden nu ook een ref naar een scope object kunnen verwerken. 
Voor nu houdt dit de bestaande return value `frozenset[str]` voor de auth velden in stand. 