### PR TITLE
Update scope objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-02-05 (6.2.2)
+
+* Scope objects have fields for productiePackage en nonProductiePackage.
+
 # 2025-01-31 (6.2.1)
 
 * Auth fields can now accomodate references to separately defined scope

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 6.2.1
+version = 6.2.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2332,6 +2332,14 @@ class Scope(SchemaType):
     def owner(self) -> dict:
         return self.get("owner", {})
 
+    @property
+    def productiePackage(self) -> str:
+        return self.get("productiePackage", "")
+
+    @property
+    def nonProductiePackage(self) -> str:
+        return self.get("nonProductiePackage", "")
+
     @classmethod
     def from_file(cls, filename: str) -> Scope:
         with open(filename) as fh:

--- a/tests/files/scopes/GLEBZ/glebzscope.json
+++ b/tests/files/scopes/GLEBZ/glebzscope.json
@@ -1,6 +1,8 @@
 {
     "name": "GLEBZscope",
     "id": "GLEBZ",
+    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
+    "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
     "owner": {
         "$ref": "publishers/GLEBZ"
     }

--- a/tests/files/scopes/HARRY/harryscope1.json
+++ b/tests/files/scopes/HARRY/harryscope1.json
@@ -1,6 +1,8 @@
 {
     "name": "HARRYscope1",
     "id": "HARRY/ONE",
+    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
+    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/files/scopes/HARRY/harryscope2.json
+++ b/tests/files/scopes/HARRY/harryscope2.json
@@ -1,6 +1,8 @@
 {
     "name": "HARRYscope2",
     "id": "HARRY/TWO",
+    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
+    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/files/scopes/HARRY/harryscope3.json
+++ b/tests/files/scopes/HARRY/harryscope3.json
@@ -1,6 +1,8 @@
 {
     "name": "HARRYscope3",
     "id": "HARRY/THREE",
+    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
+    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -45,6 +45,8 @@ def test_load_all_scopes(schema_loader):
             {
                 "name": "GLEBZscope",
                 "id": "GLEBZ",
+                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
+                "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
                 "owner": {"$ref": "publishers/GLEBZ"},
             }
         ),
@@ -52,6 +54,8 @@ def test_load_all_scopes(schema_loader):
             {
                 "name": "HARRYscope1",
                 "id": "HARRY/ONE",
+                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
+                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
                 "owner": {"$ref": "publishers/HARRY"},
             }
         ),
@@ -59,6 +63,8 @@ def test_load_all_scopes(schema_loader):
             {
                 "name": "HARRYscope2",
                 "id": "HARRY/TWO",
+                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
+                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
                 "owner": {"$ref": "publishers/HARRY"},
             }
         ),
@@ -66,6 +72,8 @@ def test_load_all_scopes(schema_loader):
             {
                 "name": "HARRYscope3",
                 "id": "HARRY/THREE",
+                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
+                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
                 "owner": {"$ref": "publishers/HARRY"},
             }
         ),

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from schematools.exceptions import DuplicateScopeId
@@ -36,7 +38,7 @@ def test_publisher_url():
     assert loader._get_publisher_url() == "https://foo.bar/baz/publishers"
 
 
-def test_load_all_scopes(schema_loader):
+def test_load_all_scopes_file_loader(schema_loader):
     scopes = schema_loader.get_all_scopes()
     # Unclear why this needs the Scope() objects, while the test_load_all_publishers
     # test does not need the Publisher() objects.
@@ -83,3 +85,23 @@ def test_load_all_scopes(schema_loader):
 @pytest.mark.xfail(raises=DuplicateScopeId, strict=True)
 def test_load_all_scopes_fails_on_duplicates(schema_loader_duplicate_scope):
     schema_loader_duplicate_scope.get_all_scopes()
+
+
+# Skipping the following test by default, because it can be sloooow
+# run this by adding `export ONLY_LOCAL=0;` before the pytest command
+@pytest.mark.skipif(
+    os.environ.get("ONLY_LOCAL", True),
+    reason="Not running because it depends on external service.",
+)
+def test_load_all_scopes_url_loader():
+    SCHEMA_URL = "http://schemas.data.amsterdam.nl/datasets/"
+    loader = URLSchemaLoader(SCHEMA_URL)
+    scopes = loader.get_all_scopes()
+
+    assert "openbaar" in scopes
+
+    openbaar = scopes["openbaar"]
+    assert isinstance(openbaar, Scope)
+    assert openbaar.id == "OPENBAAR"
+    assert openbaar.productiePackage != ""
+    assert openbaar.nonProductiePackage != ""


### PR DESCRIPTION
Voegt de nieuwe velden toe aan de Scope class. 

Ook test geschreven voor de URL loader, aangezien deze nog niet getest werd. Wel optioneel gemaakt, want traag, we moeten evalueren of het de moeite waard is om dit bijvoorbeeld te testen in github workflow bij een merge. 