### PR TITLE
Adapt permissions apply to prefer scopes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-02-06 (6.3)
+
+* The get_all_dataset_scopes function now prefers Scopes (with a fallback on old-school auth
+  strings). These are used to create the grants.
+
 # 2025-02-05 (6.2.2)
 
 * Scope objects have fields for productiePackage en nonProductiePackage.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 6.2.2
+version = 6.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -310,7 +310,15 @@ def permissions_apply(
         # profiles = profile_defs_from_url(profiles_url=profile_url)
         profiles = None
 
-    if auto or (role and scope):
+    if not (auto or (role and scope)):
+        click.echo(
+            "Choose --auto or specify both a --role and a --scope to be able to grant permissions"
+        )
+    elif revoke and not (set_read_permissions and set_write_permissions):
+        click.echo(
+            "Using --revoke without setting both read and write permissions is destructive."
+        )
+    else:
         apply_schema_and_profile_permissions(
             engine,
             pg_schema,
@@ -325,10 +333,6 @@ def permissions_apply(
             revoke,
             verbose=verbose,
             additional_grants=additional_grants,
-        )
-    else:
-        click.echo(
-            "Choose --auto or specify both a --role and a --scope to be able to grant permissions"
         )
 
 

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -206,7 +206,7 @@ class CachedSchemaLoader(SchemaLoader):
         return scope
 
     def get_all_scopes(self) -> dict[str, Scope]:
-        """Load all publishers, and fill the cache"""
+        """Load all scopes, and fill the cache"""
         if not self._has_all_scopes:
             if self._loader is None:
                 raise RuntimeError("This dataset collection can't retrieve new scopes")

--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -695,8 +695,5 @@ def _get_sequence_name(session: Session, table_name: str, column: str) -> str | 
 
 def scope_to_role(scope: str | Scope) -> str:
     """Return rolename for the postgres database."""
-    if isinstance(scope, str):
-        return f"scope_{scope.lower().replace('/', '_')}"
-    # productiePackage has the pattern "EM4W-DATA-schemascope-p-scope_some_auth_level".
-    # We need the last part including the "scope_" prefix.
-    return scope.productiePackage.split("-")[-1]
+    id = scope.id if isinstance(scope, Scope) else scope
+    return f"scope_{id.lower().replace('/', '_')}"

--- a/src/schematools/permissions/db.py
+++ b/src/schematools/permissions/db.py
@@ -20,9 +20,7 @@ from schematools.types import DatasetSchema, Scope
 logger = logging.getLogger(__name__)
 
 existing_roles = set()  # note: used as global cache!
-existing_sequences = {}  #
-
-PUBLIC_SCOPE_OBJECT = Scope({"id": PUBLIC_SCOPE})
+existing_sequences = {}
 
 
 def is_remote(table_name: str) -> bool:
@@ -274,6 +272,7 @@ def get_all_dataset_scopes(
 
     all_scopes = []
     dataset_scopes = ams_schema.scopes
+    PUBLIC_SCOPE_OBJECT = Scope({"id": PUBLIC_SCOPE})
     public_scopes = {PUBLIC_SCOPE_OBJECT, PUBLIC_SCOPE}
 
     for table in ams_schema.get_tables(include_nested=True, include_through=True):

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2324,6 +2324,14 @@ class Scope(SchemaType):
     def __str__(self) -> str:
         return self.id
 
+    def __eq__(self, other):
+        if not isinstance(other, Scope):
+            return False
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
     @property
     def name(self) -> str:
         return self.get("name", "")

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -404,11 +404,10 @@ class DatasetSchema(SchemaType):
     def _find_scope_by_id(self, id):
         all_scopes = self.loader.get_all_scopes()
         name = id.replace("/", "_").lower()
-        if name not in all_scopes:
-            # TODO: return the string value for now, should not be necessary with live data.
-            # Tests rely on scope strings that do not exist in reality.
-            return id
-        return all_scopes.get(name, None)
+        # TODO: return the string value if the scope is not in the selection for now,
+        # this should not be necessary with live data.
+        # Tests rely on scope strings that do not exist in reality.
+        return all_scopes.get(name, id)
 
     @cached_property
     def scopes(self) -> frozenset[Scope] | frozenset[str]:
@@ -421,7 +420,7 @@ class DatasetSchema(SchemaType):
             return frozenset(
                 [s if isinstance(s, Scope) else self._find_scope_by_id(s) for s in scopes]
             )
-        return frozenset({_PUBLIC_SCOPE})
+        return frozenset({self._find_scope_by_id(_PUBLIC_SCOPE)})
 
     @cached_property
     def auth(self) -> frozenset[str]:
@@ -1152,7 +1151,7 @@ class DatasetTableSchema(SchemaType):
             return frozenset(
                 [s if isinstance(s, Scope) else self.schema._find_scope_by_id(s) for s in scopes]
             )
-        return frozenset({_PUBLIC_SCOPE})
+        return frozenset({self.schema._find_scope_by_id(_PUBLIC_SCOPE)})
 
     @cached_property
     def auth(self) -> frozenset[str]:
@@ -1857,7 +1856,7 @@ class DatasetFieldSchema(JsonDict):
             return frozenset(
                 [s if isinstance(s, Scope) else self.schema._find_scope_by_id(s) for s in scopes]
             )
-        return frozenset({_PUBLIC_SCOPE})
+        return frozenset({self.schema._find_scope_by_id(_PUBLIC_SCOPE)})
 
     @cached_property
     def auth(self) -> frozenset[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,6 +350,11 @@ def gebieden_schema_auth(schema_loader) -> DatasetSchema:
 
 
 @pytest.fixture
+def gebieden_schema_scopes(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("gebieden_auth_scopes.json")
+
+
+@pytest.fixture
 def gebieden_schema_auth_list(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("gebieden_auth_list.json")
 

--- a/tests/files/datasets/gebieden_auth_scopes.json
+++ b/tests/files/datasets/gebieden_auth_scopes.json
@@ -1,0 +1,270 @@
+{
+  "type": "dataset",
+  "id": "gebieden",
+  "title": "gebieden",
+  "auth": {
+    "$ref": "scopes/HARRY/harryscope1"
+  },
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "bouwblokken",
+      "mainGeometry": "geometrie",
+      "type": "table",
+      "version": "1.0.0",
+      "auth": {
+        "$ref": "scopes/HARRY/harryscope2"
+      },
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["id"],
+        "required": ["schema", "id"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unieke identificatie voor dit object, inclusief volgnummer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "auth": {
+              "$ref": "scopes/HARRY/harryscope3"
+            },
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen.",
+            "provenance": "eindgeldigheid"
+          },
+          "ligtInBuurtLoose": {
+            "type": "string",
+            "relation": "gebieden:buurten",
+            "provenance": "ligtinbuurt",
+            "auth": "LEVEL/D",
+            "description": "De buurt waar het bouwblok in ligt."
+          },
+          "ligtInBuurt": {
+            "type": "object",
+            "properties": {
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
+            },
+            "relation": "gebieden:buurten",
+            "provenance": "ligtinbuurt",
+            "auth": "LEVEL/D",
+            "description": "De buurt waar het bouwblok in ligt."
+          }
+        }
+      }
+    },
+    {
+      "id": "buurten",
+      "type": "table",
+      "version": "1.0.0",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "registratiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De datum waarop de toestand is geregistreerd."
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "naam": {
+            "type": "string",
+            "description": "De naam van het object."
+          },
+          "code": {
+            "type": "string",
+            "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "documentdatum": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "documentnummer": {
+            "type": "string",
+            "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "cbsCode": {
+            "type": "string",
+            "description": "De CBS-code van het object."
+          },
+          "ligtInWijk": {
+            "type": "object",
+            "properties": {
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" }
+            },
+            "relation": "gebieden:wijken",
+            "description": "De wijk waar de buurt in ligt."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Geometrische beschrijving van een object."
+          }
+        }
+      }
+    },
+    {
+      "id": "wijken",
+      "type": "table",
+      "version": "1.0.0",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Polygon.json",
+            "description": "Geometrische beschrijving van een object."
+          }
+        }
+      }
+    },
+    {
+      "id": "ggwgebieden",
+      "type": "table",
+      "version": "1.0.0",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "id", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "begingeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindgeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "bestaatUitBuurten": {
+            "relation": "gebieden:buurten",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
+              }
+            },
+            "auth": "LEVEL/E",
+            "description": "De buurten waaruit het object bestaat."
+          },
+          "gebiedsGrenzen": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "diemen": { "type": "string" },
+                "zaanstad": { "type": "integer" }
+              }
+            },
+            "auth": "LEVEL/F",
+            "description": "De gemeentes waaraan het gebied grenst. Fictief veld ivm nested."
+          }
+        }
+      }
+    }
+  ],
+  "publisher": "unknown"
+}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -38,47 +38,53 @@ def test_publisher_url():
     assert loader._get_publisher_url() == "https://foo.bar/baz/publishers"
 
 
+GLEBZ_SCOPE = Scope(
+    {
+        "name": "GLEBZscope",
+        "id": "GLEBZ",
+        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
+        "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
+        "owner": {"$ref": "publishers/GLEBZ"},
+    }
+)
+HARRY_ONE_SCOPE = Scope(
+    {
+        "name": "HARRYscope1",
+        "id": "HARRY/ONE",
+        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
+        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
+        "owner": {"$ref": "publishers/HARRY"},
+    }
+)
+HARRY_TWO_SCOPE = Scope(
+    {
+        "name": "HARRYscope2",
+        "id": "HARRY/TWO",
+        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
+        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
+        "owner": {"$ref": "publishers/HARRY"},
+    }
+)
+HARRY_THREE_SCOPE = Scope(
+    {
+        "name": "HARRYscope3",
+        "id": "HARRY/THREE",
+        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
+        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
+        "owner": {"$ref": "publishers/HARRY"},
+    }
+)
+
+
 def test_load_all_scopes_file_loader(schema_loader):
     scopes = schema_loader.get_all_scopes()
     # Unclear why this needs the Scope() objects, while the test_load_all_publishers
     # test does not need the Publisher() objects.
     assert scopes == {
-        "GLEBZ": Scope(
-            {
-                "name": "GLEBZscope",
-                "id": "GLEBZ",
-                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
-                "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
-                "owner": {"$ref": "publishers/GLEBZ"},
-            }
-        ),
-        "HARRY/ONE": Scope(
-            {
-                "name": "HARRYscope1",
-                "id": "HARRY/ONE",
-                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
-                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
-                "owner": {"$ref": "publishers/HARRY"},
-            }
-        ),
-        "HARRY/TWO": Scope(
-            {
-                "name": "HARRYscope2",
-                "id": "HARRY/TWO",
-                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
-                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
-                "owner": {"$ref": "publishers/HARRY"},
-            }
-        ),
-        "HARRY/THREE": Scope(
-            {
-                "name": "HARRYscope3",
-                "id": "HARRY/THREE",
-                "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
-                "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
-                "owner": {"$ref": "publishers/HARRY"},
-            }
-        ),
+        "GLEBZ": GLEBZ_SCOPE,
+        "HARRY/ONE": HARRY_ONE_SCOPE,
+        "HARRY/TWO": HARRY_TWO_SCOPE,
+        "HARRY/THREE": HARRY_THREE_SCOPE,
     }
 
 


### PR DESCRIPTION
`permissions apply` gebruikte de strings die op de auth velden zaten, maar prefereert nu scope objecten. 

- types DatasetSchema, DatasetTableSchema en DatasetFieldSchema hebben een aparte scopes property gekregen
- get_all_dataset_scopes gebruikt die .scopes properties om de scopes in te lezen. 
- rollen worden gebaseerd op de productiePackage veldnaam (waar we alleen het laatste gedeelte van gebruiken, dus exclusief de -p- van productie). 
- fallback op auth strings in stand gehouden ivm backwards compatibility