### PR TITLE
Update scope types in schema tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2025-02-12 (6.4)
+
+* The scope objects are now rearranged and contain an `accessPackages` field which in turn have
+  packages for each relevant environment. `productionPackage` and `nonProductionPackage`
+  properties are added as well, but these are not required in the schema.
+
 # 2025-02-06 (6.3)
 
 * The get_all_dataset_scopes function now prefers Scopes (with a fallback on old-school auth

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 6.3
+version = 6.4
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2388,12 +2388,16 @@ class Scope(SchemaType):
         return self.get("owner", {})
 
     @property
-    def productiePackage(self) -> str:
-        return self.get("productiePackage", "")
+    def accessPackages(self) -> dict[str, str]:
+        return self.get("accessPackages", {})
 
     @property
-    def nonProductiePackage(self) -> str:
-        return self.get("nonProductiePackage", "")
+    def productionPackage(self) -> str:
+        return self.accessPackages.get("production", "")
+
+    @property
+    def nonProductionPackage(self) -> str:
+        return self.accessPackages.get("nonProduction", "")
 
     @classmethod
     def from_file(cls, filename: str) -> Scope:

--- a/tests/files/scopes/GLEBZ/glebzscope.json
+++ b/tests/files/scopes/GLEBZ/glebzscope.json
@@ -1,8 +1,10 @@
 {
     "name": "GLEBZscope",
     "id": "GLEBZ",
-    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
-    "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
+    "accessPackages": {
+        "production": "EM4W-DATA-schemascope-p-scope_glebz",
+        "nonProduction": "EM4W-DATA-schemascope-ot-scope_glebz"
+    },
     "owner": {
         "$ref": "publishers/GLEBZ"
     }

--- a/tests/files/scopes/HARRY/harryscope1.json
+++ b/tests/files/scopes/HARRY/harryscope1.json
@@ -1,8 +1,10 @@
 {
     "name": "HARRYscope1",
     "id": "HARRY/ONE",
-    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
-    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
+    "accessPackages": {
+        "production": "EM4W-DATA-schemascope-p-scope_harry_one",
+        "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_one"
+    },
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/files/scopes/HARRY/harryscope2.json
+++ b/tests/files/scopes/HARRY/harryscope2.json
@@ -1,8 +1,10 @@
 {
     "name": "HARRYscope2",
     "id": "HARRY/TWO",
-    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
-    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
+    "accessPackages": {
+        "production": "EM4W-DATA-schemascope-p-scope_harry_two",
+        "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_two"
+    },
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/files/scopes/HARRY/harryscope3.json
+++ b/tests/files/scopes/HARRY/harryscope3.json
@@ -1,8 +1,10 @@
 {
     "name": "HARRYscope3",
     "id": "HARRY/THREE",
-    "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
-    "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
+    "accessPackages": {
+        "production": "EM4W-DATA-schemascope-p-scope_harry_three",
+        "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_three"
+    },
     "owner": {
         "$ref": "publishers/HARRY"
     }

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -42,8 +42,10 @@ GLEBZ_SCOPE = Scope(
     {
         "name": "GLEBZscope",
         "id": "GLEBZ",
-        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_glebz",
-        "productiePackage": "EM4W-DATA-schemascope-p-scope_glebz",
+        "accessPackages": {
+            "production": "EM4W-DATA-schemascope-p-scope_glebz",
+            "nonProduction": "EM4W-DATA-schemascope-ot-scope_glebz",
+        },
         "owner": {"$ref": "publishers/GLEBZ"},
     }
 )
@@ -51,8 +53,10 @@ HARRY_ONE_SCOPE = Scope(
     {
         "name": "HARRYscope1",
         "id": "HARRY/ONE",
-        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_one",
-        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_one",
+        "accessPackages": {
+            "production": "EM4W-DATA-schemascope-p-scope_harry_one",
+            "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_one",
+        },
         "owner": {"$ref": "publishers/HARRY"},
     }
 )
@@ -60,8 +64,10 @@ HARRY_TWO_SCOPE = Scope(
     {
         "name": "HARRYscope2",
         "id": "HARRY/TWO",
-        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_two",
-        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_two",
+        "accessPackages": {
+            "production": "EM4W-DATA-schemascope-p-scope_harry_two",
+            "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_two",
+        },
         "owner": {"$ref": "publishers/HARRY"},
     }
 )
@@ -69,8 +75,10 @@ HARRY_THREE_SCOPE = Scope(
     {
         "name": "HARRYscope3",
         "id": "HARRY/THREE",
-        "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_harry_three",
-        "productiePackage": "EM4W-DATA-schemascope-p-scope_harry_three",
+        "accessPackages": {
+            "production": "EM4W-DATA-schemascope-p-scope_harry_three",
+            "nonProduction": "EM4W-DATA-schemascope-ot-scope_harry_three",
+        },
         "owner": {"$ref": "publishers/HARRY"},
     }
 )
@@ -109,5 +117,6 @@ def test_load_all_scopes_url_loader():
     openbaar = scopes["openbaar"]
     assert isinstance(openbaar, Scope)
     assert openbaar.id == "OPENBAAR"
-    assert openbaar.productiePackage != ""
-    assert openbaar.nonProductiePackage != ""
+    assert openbaar.accessPackages != {}
+    assert openbaar.productionPackage != ""
+    assert openbaar.nonProductionPackage != ""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -346,8 +346,7 @@ def test_scopes_comparison():
             "id": "SCOPE/A",
             "name": "scope A",
             "owner": {"$ref": "publishers/BENK"},
-            "productiePackage": "p-scope_a",
-            "nonProductiePackage": "ot-scope_a",
+            "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"},
         }
     )
     scope_b = Scope.from_dict(
@@ -355,8 +354,7 @@ def test_scopes_comparison():
             "id": "SCOPE/B",
             "name": "scope B",
             "owner": {"$ref": "publishers/BENK"},
-            "productiePackage": "p-scope_b",
-            "nonProductiePackage": "ot-scope_b",
+            "accessPackages": {"production": "p-scope_b", "nonProduction": "ot-scope_b"},
         }
     )
     scope_b2 = Scope.from_dict(
@@ -364,8 +362,7 @@ def test_scopes_comparison():
             "id": "SCOPE/B",
             "name": "scope B",
             "owner": {"$ref": "publishers/BENK"},
-            "productiePackage": "p-scope_b",
-            "nonProductiePackage": "ot-scope_b",
+            "accessPackages": {"production": "p-scope_b", "nonProduction": "ot-scope_b"},
         }
     )
 


### PR DESCRIPTION
Deze [PR in amsterdam-schema](https://github.com/Amsterdam/amsterdam-schema/pull/1258) verandert de scopes objects enigszins. Deze PR matcht dat hier, zodat we in sync blijven. 