### PR TITLE
Fix scope db and python name

### DIFF
--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -220,7 +220,9 @@ class Dataset(models.Model):
             path = name
         obj = cls(
             name=name,
-            schema_data=schema.json(inline_tables=True, inline_publishers=True),
+            schema_data=schema.json(
+                inline_tables=True, inline_publishers=True, inline_scopes=True
+            ),
             view_data=schema.get_view_sql(),
             auth=" ".join(schema.auth),
             path=path,
@@ -243,7 +245,9 @@ class Dataset(models.Model):
 
     def save_for_schema(self, schema: DatasetSchema):
         """Update this model with schema data"""
-        self.schema_data = schema.json(inline_tables=True, inline_publishers=True)
+        self.schema_data = schema.json(
+            inline_tables=True, inline_publishers=True, inline_scopes=True
+        )
         self.view_data = schema.get_view_sql()
         self.auth = " ".join(schema.auth)
         self.enable_api = Dataset.has_api_enabled(schema)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -399,10 +399,12 @@ class DatasetSchema(SchemaType):
 
         It may also be a string or list of strings.
         """
-        if isinstance(auth, dict) and "$ref" in auth:
-            if self.loader is None:
-                raise RuntimeError(f"{self!r} has no loader defined, can't resolve auth.")
-            return self.loader.get_scope(auth["$ref"])
+        if isinstance(auth, dict):
+            if "$ref" in auth:
+                if self.loader is None:
+                    raise RuntimeError(f"{self!r} has no loader defined, can't resolve auth.")
+                return self.loader.get_scope(auth["$ref"])
+            return Scope(auth)
         elif isinstance(auth, list):
             return [self._resolve_scope(a) for a in auth]
         else:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -342,10 +342,19 @@ class DatasetSchema(SchemaType):
             data["auth"] = [s.json_data() if isinstance(s, Scope) else s for s in self.scopes]
         return json.dumps(data)
 
-    def json_data(self, inline_tables: bool = False, inline_publishers: bool = False) -> Json:
+    def json_data(
+        self,
+        inline_tables: bool = False,
+        inline_publishers: bool = False,
+        inline_scopes: bool = False,
+    ) -> Json:
         """Overwritten logic that inlines tables"""
         return json.loads(
-            self.json(inline_tables=inline_tables, inline_publishers=inline_publishers)
+            self.json(
+                inline_tables=inline_tables,
+                inline_publishers=inline_publishers,
+                inline_scopes=inline_scopes,
+            )
         )
 
     def get_view_sql(self) -> str:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -323,9 +323,14 @@ class DatasetSchema(SchemaType):
         """Parses given dict and validates the given schema."""
         return cls(obj, dataset_collection=dataset_collection)
 
-    def json(self, inline_tables: bool = False, inline_publishers: bool = False) -> str:
+    def json(
+        self,
+        inline_tables: bool = False,
+        inline_publishers: bool = False,
+        inline_scopes: bool = False,
+    ) -> str:
         """Overwritten JSON logic that allows inlining of $refs"""
-        if not inline_tables and not inline_publishers:
+        if not inline_tables and not inline_publishers and not inline_scopes:
             return json.dumps(self.data)
 
         data = self.data.copy()
@@ -333,6 +338,8 @@ class DatasetSchema(SchemaType):
             data["tables"] = [t.json_data() for t in self.tables]
         if inline_publishers and self.publisher is not None:
             data["publisher"] = self.publisher.json_data()
+        if inline_scopes and isinstance(self.scopes, frozenset[Scope]):
+            data["scopes"] = [s.json_data() for s in self.scopes]
         return json.dumps(data)
 
     def json_data(self, inline_tables: bool = False, inline_publishers: bool = False) -> Json:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -338,8 +338,8 @@ class DatasetSchema(SchemaType):
             data["tables"] = [t.json_data() for t in self.tables]
         if inline_publishers and self.publisher is not None:
             data["publisher"] = self.publisher.json_data()
-        if inline_scopes and isinstance(self.scopes, frozenset[Scope]):
-            data["scopes"] = [s.json_data() for s in self.scopes]
+        if inline_scopes:
+            data["auth"] = [s.json_data() if isinstance(s, Scope) else s for s in self.scopes]
         return json.dumps(data)
 
     def json_data(self, inline_tables: bool = False, inline_publishers: bool = False) -> Json:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -2398,6 +2398,18 @@ class Scope(SchemaType):
         return hash(self.id)
 
     @property
+    def db_name(self) -> str:
+        """The object name in a database-compatible format."""
+        return to_snake_case(self.id.lower())
+
+    @cached_property
+    def python_name(self) -> str:
+        """The 'id', but snake-cased like a python variable.
+        Some object types (e.g. dataset and table) may override this in classname notation.
+        """
+        return to_snake_case(self.id.lower())
+
+    @property
     def name(self) -> str:
         return self.get("name", "")
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -388,7 +388,7 @@ def test_scope_db_python_names():
     assert scope_a.db_name == "scope_a"
     assert scope_a.python_name == "scope_a"
 
-    
+
 def test_loading_scopes_from_dataset(schema_loader):
     schema = schema_loader.get_dataset_from_file("metaschema2.json")
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import operator
 
 import pytest
@@ -340,23 +341,25 @@ def test_load_multiple_scope_objects(schema_loader):
     assert field.auth == frozenset({"HARRY/ONE", "HARRY/TWO"})
 
 
+scope_a = Scope.from_dict(
+    {
+        "id": "SCOPE/A",
+        "name": "scope A",
+        "owner": {"$ref": "publishers/BENK"},
+        "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"},
+    }
+)
+scope_b = Scope.from_dict(
+    {
+        "id": "SCOPE/B",
+        "name": "scope B",
+        "owner": {"$ref": "publishers/BENK"},
+        "accessPackages": {"production": "p-scope_b", "nonProduction": "ot-scope_b"},
+    }
+)
+
+
 def test_scopes_comparison():
-    scope_a = Scope.from_dict(
-        {
-            "id": "SCOPE/A",
-            "name": "scope A",
-            "owner": {"$ref": "publishers/BENK"},
-            "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"},
-        }
-    )
-    scope_b = Scope.from_dict(
-        {
-            "id": "SCOPE/B",
-            "name": "scope B",
-            "owner": {"$ref": "publishers/BENK"},
-            "accessPackages": {"production": "p-scope_b", "nonProduction": "ot-scope_b"},
-        }
-    )
     scope_b2 = Scope.from_dict(
         {
             "id": "SCOPE/B",
@@ -371,6 +374,19 @@ def test_scopes_comparison():
 
     set_one = frozenset({scope_a, scope_b})
     assert set_one - {scope_b2} == frozenset({scope_a})
+
+
+def test_scope_json_data():
+    assert scope_a.json_data() == json.loads(
+        """
+        {
+            "id": "SCOPE/A",
+            "name": "scope A",
+            "owner": {"$ref": "publishers/BENK"},
+            "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"}
+        }
+    """
+    )
 
 
 def test_loading_scopes_from_dataset(schema_loader):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -384,6 +384,11 @@ def test_scope_json_data():
     }
 
 
+def test_scope_db_python_names():
+    assert scope_a.db_name == "scope_a"
+    assert scope_a.python_name == "scope_a"
+
+
 def test_loading_scopes_from_dataset(schema_loader):
     schema = schema_loader.get_dataset_from_file("metaschema2.json")
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import operator
 
 import pytest
@@ -377,16 +376,12 @@ def test_scopes_comparison():
 
 
 def test_scope_json_data():
-    assert scope_a.json_data() == json.loads(
-        """
-        {
-            "id": "SCOPE/A",
-            "name": "scope A",
-            "owner": {"$ref": "publishers/BENK"},
-            "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"}
-        }
-    """
-    )
+    assert scope_a.json_data() == {
+        "id": "SCOPE/A",
+        "name": "scope A",
+        "owner": {"$ref": "publishers/BENK"},
+        "accessPackages": {"production": "p-scope_a", "nonProduction": "ot-scope_a"},
+    }
 
 
 def test_loading_scopes_from_dataset(schema_loader):


### PR DESCRIPTION
De db_name en python_name van bestaande Scopes hadden een heleboel u_n_d_e_r_s_c_o_r_e_s, dat kwam omdat hij to_snake_case toepaste op een string met alleen maar hoofdletters. Dus eerst een .lower() toepassen. 