### PR TITLE
Add major version to table names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-03-26 (7.1.0)
+
+* Add support for versioned tables. All tables will now receive a major version number in
+  their name.
+
 # 2025-03-06 (7.0.0)
 
 * Add support for Amsterdam Schema V3. Introduction of the DatasetVersionSchema to allow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3.0"
 services:
   database:
-    image: amsterdam/postgres11
+    image: postgis/postgis:14-3.2
     ports:
       - "5415:5432"
     environment:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.0.0
+version = 7.1.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -140,14 +140,11 @@ def schema_model_mockers_factory(
 
 
 def _get_model_name(table_schema: DatasetTableSchema) -> str:
-    """Returns model name for this table. Including version number, if needed."""
+    """Returns model name for this table including the version number."""
     # Using table_schema.python_name gives UpperCamelCased names, the old format is kept here.
     # This also keeps model names more readable and recognizable/linkable with db table names.
     model_name = to_snake_case(table_schema.id)
-    if table_schema.dataset.version is not None and not table_schema.dataset.is_default_version:
-        return f"{model_name}_{table_schema.dataset.version}"
-    else:
-        return model_name
+    return f"{model_name}_{table_schema.version.vmajor}"
 
 
 def model_factory(

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -139,7 +139,7 @@ def schema_model_mockers_factory(
     ]
 
 
-def _get_model_name(table_schema: DatasetTableSchema) -> str:
+def get_model_name(table_schema: DatasetTableSchema) -> str:
     """Returns model name for this table including the version number."""
     # Using table_schema.python_name gives UpperCamelCased names, the old format is kept here.
     # This also keeps model names more readable and recognizable/linkable with db table names.
@@ -210,7 +210,7 @@ def model_factory(
     )
 
     model_class = ModelBase(
-        _get_model_name(table_schema),
+        get_model_name(table_schema),
         (base_model,),
         {
             **fields,
@@ -302,7 +302,7 @@ def _fk_field_factory(field: DatasetFieldSchema) -> models.ForeignKey:
     """
     to_field = _get_fk_to_field(field)
     kwargs = {
-        "to": f"{field.related_table.dataset.id}.{_get_model_name(field.related_table)}",
+        "to": f"{field.related_table.dataset.id}.{get_model_name(field.related_table)}",
         **_get_basic_kwargs(field),
         "on_delete": models.CASCADE if field.required else models.SET_NULL,
         "db_column": field.db_name,
@@ -429,10 +429,10 @@ def _nm_field_factory(field: DatasetFieldSchema) -> models.ManyToManyField:
         related_name = f"rev_{field.table.python_name}_{field.python_name}+"
 
     kwargs = {
-        "to": f"{field.related_table.dataset.id}.{_get_model_name(field.related_table)}",
+        "to": f"{field.related_table.dataset.id}.{get_model_name(field.related_table)}",
         **_get_basic_kwargs(field),
         "related_name": related_name,
-        "through": f"{through_table.dataset.id}.{_get_model_name(through_table)}",
+        "through": f"{through_table.dataset.id}.{get_model_name(through_table)}",
         "through_fields": through_fields,
     }
 
@@ -502,7 +502,7 @@ def model_mocker_factory(
         "Meta",
         (),
         {
-            "model": f"{app_label}.{_get_model_name(table_schema)}",
+            "model": f"{app_label}.{get_model_name(table_schema)}",
             "database": "default",
         },
     )
@@ -513,7 +513,7 @@ def model_mocker_factory(
     params_cls = type("Params", (), {"table_schema": table_schema})
 
     return type(
-        f"{_get_model_name(table_schema)}_factory",
+        f"{get_model_name(table_schema)}_factory",
         (DynamicModelMocker,),
         {
             **fields,

--- a/src/schematools/contrib/django/faker/relate.py
+++ b/src/schematools/contrib/django/faker/relate.py
@@ -124,7 +124,9 @@ def relate_datasets(*datasets: Dataset) -> None:
                     through_model = m2m_descriptor.through
 
                     objs = []
-                    source_id = table.db_name_variant(with_dataset_prefix=False, postfix="_id")
+                    source_id = table.db_name_variant(
+                        with_dataset_prefix=False, with_version=False, postfix="_id"
+                    )
                     target_id = field_name + "_id"
 
                     # first delete all relations
@@ -137,7 +139,9 @@ def relate_datasets(*datasets: Dataset) -> None:
                         # the source and target side of the relation.
                         if not f.is_loose_relation:
                             attrs = add_temporal_attrs(
-                                table.db_name_variant(with_dataset_prefix=False),
+                                table.db_name_variant(
+                                    with_dataset_prefix=False, with_version=False
+                                ),
                                 source_value,
                                 attrs,
                                 table,

--- a/src/schematools/importer/ndjson.py
+++ b/src/schematools/importer/ndjson.py
@@ -267,7 +267,9 @@ class TableFieldMapper:
         self, nm_field: DatasetFieldSchema, values: list[dict], source: dict
     ) -> list[Record]:
         """Provide the records for a Many-to-Many (NM) fields."""
-        source_db_name = self.dataset_table.db_name_variant(with_dataset_prefix=False)
+        source_db_name = self.dataset_table.db_name_variant(
+            with_dataset_prefix=False, with_version=False
+        )
         src_id_value = self._get_composite_id(source)
         if not isinstance(values, list):
             values = [values]

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -196,6 +196,16 @@ class SemVer(str):
         return f"{self.major}_{self.minor}"
 
     @property
+    def vmajor(self) -> str:
+        """Return stringified major part of SemVer.
+
+        Examples:
+            >>> SemVer("v3.9.0").vmajor
+            "v3"
+        """
+        return f"v{self.major}"
+
+    @property
     def is_production_version(self):
         return self.major >= 1
 
@@ -986,7 +996,7 @@ class DatasetTableSchema(SchemaType):
             prefix = f"{self._parent_schema.id}."
         if self._parent_table is not None:
             prefix = f"{prefix}{self._parent_table.id}."
-        return f"{prefix}{self['id']}"
+        return f"{prefix}{self['id']}.{self.version.vmajor}"
 
     @property
     def python_name(self) -> str:
@@ -1360,7 +1370,7 @@ class DatasetTableSchema(SchemaType):
         self,
         *,
         with_dataset_prefix: bool = True,
-        with_version: bool = False,
+        with_version: bool = True,
         postfix: str = "",
         check_assert: bool = True,
     ) -> str:
@@ -1379,7 +1389,7 @@ class DatasetTableSchema(SchemaType):
         """
         dataset_prefix = version_postfix = ""
         if with_version:
-            version_postfix = self.version.signif
+            version_postfix = f"{self.version.vmajor}"
         if with_dataset_prefix:
             dataset_prefix = to_snake_case(self.dataset.id)
 

--- a/tests/django/test_mocking.py
+++ b/tests/django/test_mocking.py
@@ -7,7 +7,7 @@ import pytest
 
 from schematools.contrib.django.db import create_tables
 from schematools.contrib.django.factories import (
-    _get_model_name,
+    get_model_name,
     schema_model_mockers_factory,
     schema_models_factory,
 )
@@ -24,7 +24,7 @@ def test_mocking_creates_data(gebieden_schema, gebieden_dataset):
     create_data_for(gebieden_dataset, size=size)
 
     table_schemas = {
-        _get_model_name(t): t for t in gebieden_schema.get_tables(include_through=True)
+        get_model_name(t): t for t in gebieden_schema.get_tables(include_through=True)
     }
     models = {}
     for cls in schema_models_factory(gebieden_dataset, base_app_name="dso_api.dynamic_api"):

--- a/tests/django/test_model_mockers.py
+++ b/tests/django/test_model_mockers.py
@@ -23,20 +23,20 @@ def test_model_mocker_factory_registers_a_dynamic_model_in_the_app_config(afval_
     """Prove that the model_mocker_factory registers the model as Django app."""
     table_schema = afval_dataset.schema.tables[0]
     assert isinstance(table_schema, DatasetTableSchema)
-    assert str(table_schema) == "<DatasetTableSchema: afvalwegingen.containers>"
+    assert str(table_schema) == "<DatasetTableSchema: afvalwegingen.containers.v1>"
 
     # We bootstrap the DynamicModel inside the model_mocker_factory by calling the model_factory,
     # which ends with app_config.register_model.
     # So we assert that the DynamicModel is indeed registered.
     model_mocker_factory(afval_dataset, table_schema, base_app_name="dso_api.dynamic_api")
     registered_models = [f"{m._meta.app_label}.{m._meta.model_name}" for m in apps.get_models()]
-    assert "afvalwegingen.containers" in registered_models
+    assert "afvalwegingen.containers_v1" in registered_models
 
     # The afval_dataset has two tables (containers, clusters),
     # so we check the second table (i.e. second model) too.
     table_schema_with_id_as_string = afval_dataset.schema.tables[1]
     assert isinstance(table_schema_with_id_as_string, DatasetTableSchema)
-    assert str(table_schema_with_id_as_string) == "<DatasetTableSchema: afvalwegingen.clusters>"
+    assert str(table_schema_with_id_as_string) == "<DatasetTableSchema: afvalwegingen.clusters.v1>"
 
     model_mocker_factory(
         afval_dataset, table_schema_with_id_as_string, base_app_name="dso_api.dynamic_api"
@@ -44,7 +44,7 @@ def test_model_mocker_factory_registers_a_dynamic_model_in_the_app_config(afval_
     registered_models_updated = [
         f"{m._meta.app_label}.{m._meta.model_name}" for m in apps.get_models()
     ]
-    assert "afvalwegingen.clusters" in registered_models_updated
+    assert "afvalwegingen.clusters_v1" in registered_models_updated
 
 
 @pytest.mark.skip(
@@ -121,18 +121,18 @@ def test_schema_model_mockers_factory(afval_dataset):
         cls._meta.get_model_class()._meta.model_name: cls
         for cls in schema_model_mockers_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    assert "containers" in model_mockers
-    ContainersMocker = model_mockers["containers"]
+    assert "containers_v1" in model_mockers
+    ContainersMocker = model_mockers["containers_v1"]
     assert isinstance(ContainersMocker, FactoryMetaClass)
     assert str(ContainersMocker) == (
-        "<containers_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.containers'>>"
+        "<containers_v1_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.containers_v1'>>"
     )
 
-    assert "clusters" in model_mockers
-    ClustersMocker = model_mockers["clusters"]
+    assert "clusters_v1" in model_mockers
+    ClustersMocker = model_mockers["clusters_v1"]
     assert isinstance(ClustersMocker, FactoryMetaClass)
     assert str(ClustersMocker) == (
-        "<clusters_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.clusters'>>"
+        "<clusters_v1_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.clusters_v1'>>"
     )
 
 
@@ -155,7 +155,7 @@ def test_model_mocker_factory_fields(afval_dataset) -> None:
         "kortenaam",
     }
 
-    ContainersMocker = model_mockers["containers"]
+    ContainersMocker = model_mockers["containers_v1"]
     assert {f.name for f in ContainersMocker._meta.get_model_class()._meta.get_fields()} == fields
 
 
@@ -170,8 +170,8 @@ def test_model_mocker_factory_records_count(afval_dataset) -> None:
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    ContainersMocker = model_mockers["containers"]
-    Container = models["containers"]
+    ContainersMocker = model_mockers["containers_v1"]
+    Container = models["containers_v1"]
     # Create the tables for the dataset, to be able te add records to it.
     create_tables(afval_dataset)
     ContainersMocker.create()
@@ -192,8 +192,8 @@ def test_model_mocker_factory_field_types(afval_dataset) -> None:
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    ContainersMocker = model_mockers["containers"]
-    Container = models["containers"]
+    ContainersMocker = model_mockers["containers_v1"]
+    Container = models["containers_v1"]
     # Create the tables for the dataset, to be able te add records to it.
     create_tables(afval_dataset)
     ContainersMocker.create()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -22,7 +22,7 @@ def test_csv_export(here, engine, meetbouten_schema, dbsession, tmp_path):
     """Prove that csv export contains the correct content."""
     _load_meetbouten_content(here, engine, meetbouten_schema)
     export_csvs(engine, meetbouten_schema, str(tmp_path), [], [], 1)
-    with open(tmp_path / "meetbouten_meetbouten.csv") as out_file:
+    with open(tmp_path / "meetbouten_meetbouten_v1.csv") as out_file:
         assert out_file.read() == (
             "Identificatie,Ligtinbuurtid,Merkcode,Merkomschrijving,Geometrie\n"
             "1,10180001.1,12,De meetbout,SRID=28992;POINT(119434 487091.6)\n"
@@ -36,7 +36,7 @@ def test_csv_export_only_actual(here, engine, ggwgebieden_schema, dbsession, tmp
     importer.generate_db_objects("ggwgebieden", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
     export_csvs(engine, ggwgebieden_schema, str(tmp_path), [], [], 1)
-    with open(tmp_path / "ggwgebieden_ggwgebieden.csv") as out_file:
+    with open(tmp_path / "ggwgebieden_ggwgebieden_v1.csv") as out_file:
         lines = out_file.readlines()
         assert len(lines) == 2  # includes the headerline
         assert lines[1].split(",")[0] == "2"  # volgnummer == 2
@@ -46,7 +46,7 @@ def test_jsonlines_export(here, engine, meetbouten_schema, dbsession, tmp_path):
     """Prove that jsonlines export contains the correct content."""
     _load_meetbouten_content(here, engine, meetbouten_schema)
     export_jsonls(engine, meetbouten_schema, str(tmp_path), [], [], 1)
-    with open(tmp_path / "meetbouten_meetbouten.jsonl") as out_file:
+    with open(tmp_path / "meetbouten_meetbouten_v1.jsonl") as out_file:
         result = orjson.loads(out_file.read())
         result["geometrie"]["coordinates"][1] = round(result["geometrie"]["coordinates"][1], 5)
         result["geometrie"]["coordinates"][0] = round(result["geometrie"]["coordinates"][0], 5)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -55,7 +55,7 @@ def test_camelcased_names_during_import(here, engine, bouwblokken_schema, dbsess
         "schema": "irrelevant",
     }
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM bouwblokken_bouwblokken ORDER BY id")
+        dict(r) for r in engine.execute("SELECT * FROM bouwblokken_bouwblokken_v1 ORDER BY id")
     ]
     assert len(records) == 2
     assert set(records[0].keys()) == {
@@ -75,7 +75,7 @@ def test_skip_duplicate_keys_in_batch_during_import(here, engine, bouwblokken_sc
     importer.generate_db_objects("bouwblokken", truncate=True, ind_extra_index=False)
     last_record = importer.load_file(ndjson_path)
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM bouwblokken_bouwblokken ORDER BY id")
+        dict(r) for r in engine.execute("SELECT * FROM bouwblokken_bouwblokken_v1 ORDER BY id")
     ]
     assert records == [
         # Only one inserted, and no crash happened.
@@ -132,7 +132,7 @@ def test_numeric_datatype_scale(
             SELECT data_type, numeric_scale
                 FROM information_schema.columns
                 WHERE table_schema = 'public'
-                  AND table_name = 'woningbouwplannen_woningbouwplan'
+                  AND table_name = 'woningbouwplannen_woningbouwplan_v1'
                   AND column_name = 'avarage_sales_price';
             """
         )
@@ -155,7 +155,7 @@ def test_invalid_numeric_datatype_scale(
             SELECT data_type, numeric_scale
                 FROM information_schema.columns
                 WHERE table_schema = 'public'
-                    AND table_name = 'woningbouwplannen_woningbouwplan'
+                    AND table_name = 'woningbouwplannen_woningbouwplan_v1'
                     AND column_name = 'avarage_sales_price_incorrect'
                    OR column_name = 'avarage_sales_price_incorrect_zero'
             """
@@ -177,7 +177,7 @@ def test_biginteger_datatype(here, engine, woningbouwplannen_schema, gebieden_sc
         SELECT data_type, numeric_precision
             FROM information_schema.columns
             WHERE table_schema = 'public'
-              AND table_name = 'woningbouwplannen_woningbouwplan'
+              AND table_name = 'woningbouwplannen_woningbouwplan_v1'
               AND column_name = 'id';
         """
     )
@@ -197,7 +197,7 @@ def test_add_column_comment(here, engine, woningbouwplannen_schema, dbsession):
                      INNER JOIN pg_catalog.pg_description pgd ON (pgd.objoid = st.relid)
                      INNER JOIN information_schema.columns c ON (pgd.objsubid = c.ordinal_position
                 AND c.table_schema = st.schemaname AND c.table_name = st.relname)
-            WHERE table_name = 'woningbouwplannen_woningbouwplan'
+            WHERE table_name = 'woningbouwplannen_woningbouwplan_v1'
               AND column_name = 'projectnaam';
         """
     )
@@ -211,7 +211,7 @@ def test_add_table_comment(here, engine, woningbouwplannen_schema, dbsession):
     importer.generate_db_objects("woningbouwplan", ind_tables=True, ind_extra_index=False)
     results = engine.execute(
         """
-        SELECT OBJ_DESCRIPTION('public.woningbouwplannen_woningbouwplan'::REGCLASS) AS description;
+        SELECT OBJ_DESCRIPTION('public.woningbouwplannen_woningbouwplan_v1'::REGCLASS) AS description;
         """
     )
     record = results.fetchone()
@@ -234,7 +234,7 @@ def test_create_table_db_schema(here, engine, woningbouwplannen_schema, dbsessio
     )
     results = engine.execute(
         """
-        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan'
+        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan_v1'
         """
     )
     record = results.fetchone()
@@ -247,7 +247,7 @@ def test_create_table_no_db_schema(here, engine, woningbouwplannen_schema, dbses
     importer.generate_db_objects("woningbouwplan", None, ind_tables=True, ind_extra_index=False)
     results = engine.execute(
         """
-        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan'
+        SELECT schemaname FROM pg_tables WHERE tablename = 'woningbouwplannen_woningbouwplan_v1'
         """
     )
     record = results.fetchone()
@@ -266,15 +266,15 @@ def test_generate_db_objects_is_versioned_dataset(
     )
     assert engine.scalar(SCHEMA_EXISTS, schema_name="woningbouwplannen")
     for table_name in (
-        "woningbouwplan_1_0",
-        "woningbouwplan_buurten_1_0",
-        "woningbouwplan_buurten_as_scalar_1_0",
+        "woningbouwplan_v1",
+        "woningbouwplan_buurten_v1",
+        "woningbouwplan_buurten_as_scalar_v1",
     ):
         assert engine.scalar(TABLE_EXISTS, schema_name="woningbouwplannen", table_name=table_name)
     for view_name in (
-        "woningbouwplannen_woningbouwplan",
-        "woningbouwplannen_woningbouwplan_buurten",
-        "woningbouwplannen_woningbouwplan_buurten_as_scalar",
+        "woningbouwplannen_woningbouwplan_v1",
+        "woningbouwplannen_woningbouwplan_buurten_v1",
+        "woningbouwplannen_woningbouwplan_buurten_as_scalar_v1",
     ):
         assert engine.scalar(VIEW_EXISTS, schema_name="public", view_name=view_name)
 

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -59,13 +59,13 @@ def test_index_creation(engine, db_schema):
         meta_data = MetaData(bind=conn)
         meta_data.reflect()
         metadata_inspector = inspect(meta_data.bind)
-        table_db_name = f"{test_data['id']}_{table['id']}"  # test_test
+        table_db_name = f"{test_data['id']}_{table['id']}_v1"  # test_test
         indexes = metadata_inspector.get_indexes(table_db_name, schema=None)
         index_names.update(index["name"] for index in indexes)
 
     assert index_names == {
-        "test_test_identifier_idx",
-        "test_test_geometry_idx",
+        "test_test_v1_identifier_idx",
+        "test_test_v1_geometry_idx",
     }
 
 
@@ -186,10 +186,10 @@ def test_index_troughtables_creation(engine, db_schema):
                 indexes_names.update(index["name"] for index in indexes)
 
     assert indexes_names == {
-        "public.test_test_1_heeft_onderzoeken_heeft_onderzoeken_id_idx",
-        "public.test_test_1_heeft_onderzoeken_test_1_id_idx",
-        "public.test_test_1_some_random_name_some_random_name_id_idx",
-        "public.test_test_1_some_random_name_test_1_id_idx",
+        "6a5852e97fadf4a1a08cf016e1f6ef37d733a937_idx",
+        "public.test_test_1_heeft_onderzoeken_v1_test_1_id_idx",
+        "public.test_test_1_some_random_name_v1_some_random_name_id_idx",
+        "public.test_test_1_some_random_name_v1_test_1_id_idx",
     }
 
 
@@ -266,8 +266,8 @@ def test_fk_index_creation(engine, db_schema):
     indexes = metadata_inspector.get_indexes(table.db_name, schema=None)
     indexes_name = {index["name"] for index in indexes}
     assert indexes_name == {
-        "test_child_test_identifier_idx",
-        "test_child_test_fk_column_reference_id_idx",
+        "test_child_test_v1_identifier_idx",
+        "test_child_test_v1_fk_column_reference_id_idx",
     }
 
 
@@ -346,7 +346,7 @@ def test_size_of_index_name(engine, db_schema):
     meta_data = MetaData(bind=conn)
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
-    indexes = metadata_inspector.get_indexes(f"{data['id']}_{table['id']}", schema=None)
+    indexes = metadata_inspector.get_indexes(f"{data['id']}_{table['id']}_v1", schema=None)
     indexes_name = []
 
     for index in indexes:
@@ -367,7 +367,7 @@ def test_index_creation_db_schema2(engine, stadsdelen_schema):
     meta_data.reflect()
     metadata_inspector = inspect(meta_data.bind)
     indexes = metadata_inspector.get_indexes(
-        f"{stadsdelen_schema['id']}_stadsdelen", schema="schema_foo_bar"
+        f"{stadsdelen_schema['id']}_stadsdelen_v1", schema="schema_foo_bar"
     )
     index_names = {index["name"] for index in indexes}
-    assert index_names == {"stadsdelen_stadsdelen_identifier_idx"}
+    assert index_names == {"stadsdelen_stadsdelen_v1_identifier_idx"}

--- a/tests/test_ndjson.py
+++ b/tests/test_ndjson.py
@@ -11,7 +11,8 @@ def test_ndjson_import_nm(here, engine, meetbouten_schema, gebieden_schema, dbse
     importer.generate_db_objects("metingen", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
     records = [
-        dict(r) for r in engine.execute("SELECT * from meetbouten_metingen order by identificatie")
+        dict(r)
+        for r in engine.execute("SELECT * from meetbouten_metingen_v1 order by identificatie")
     ]
     assert len(records) == 4
     # A non-object relation, should just lead to _id field
@@ -21,7 +22,7 @@ def test_ndjson_import_nm(here, engine, meetbouten_schema, gebieden_schema, dbse
     records = [
         dict(r)
         for r in engine.execute(
-            "SELECT * from meetbouten_metingen_refereertaanreferentiepunten order by id"
+            "SELECT * from meetbouten_metingen_refereertaanreferentiepunten_v1 order by id"
         )
     ]
     # Should have a field 'id' in the n-m table
@@ -50,7 +51,7 @@ def test_ndjson_import_separate_relations_target_composite(
 
     importer.load_file(ndjson_path, is_through_table=True)
     records = [
-        dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_ligt_in_buurt")
+        dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_ligt_in_buurt_v1")
     ]
     assert records == [
         {
@@ -76,7 +77,8 @@ def test_ndjson_import_separate_relations_both_composite(
 
     importer.load_file(ndjson_path, is_through_table=True)
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten")
+        dict(r)
+        for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten_v1")
     ]
 
     assert records == [
@@ -97,7 +99,7 @@ def test_ndjson_import_no_embedded_relation_in_data(here, engine, meetbouten_sch
     importer = NDJSONImporter(meetbouten_schema, engine)
     importer.generate_db_objects("meetbouten", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten")]
+    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_v1")]
     assert records == [
         {
             "identificatie": 1,
@@ -119,13 +121,14 @@ def test_ndjson_import_no_embedded_nm_relation_in_data(
     importer.generate_db_objects("ggwgebieden", truncate=True, ind_extra_index=False)
 
     importer.load_file(ndjson_path, is_through_table=True)
-    records = [dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden")]
+    records = [dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_v1")]
     assert len(records) == 1
 
     # Through table is available, but has no content
     # (because there is no data  for it in the ndjson).
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten")
+        dict(r)
+        for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten_v1")
     ]
     assert len(records) == 0
 
@@ -135,7 +138,7 @@ def test_ndjson_import_jsonpath_provenance(here, engine, meetbouten_schema, dbse
     importer = NDJSONImporter(meetbouten_schema, engine)
     importer.generate_db_objects("meetbouten", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten")]
+    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_v1")]
     assert records == [
         {
             "identificatie": 1,
@@ -154,7 +157,7 @@ def test_ndjson_import_nm_composite_keys(here, engine, ggwgebieden_schema, dbses
     importer = NDJSONImporter(ggwgebieden_schema, engine)  # TODO: fix datetime tzinfo
     importer.generate_db_objects("ggwgebieden", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden")]
+    records = [dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_v1")]
 
     # An "id" should have been generated, concat of the composite key fields
     assert records == [
@@ -175,7 +178,8 @@ def test_ndjson_import_nm_composite_keys(here, engine, ggwgebieden_schema, dbses
     ]
 
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten")
+        dict(r)
+        for r in engine.execute("SELECT * FROM ggwgebieden_ggwgebieden_bestaatuitbuurten_v1")
     ]
     assert len(records) == 3
     # Also the temporal fields are present in the database
@@ -208,7 +212,7 @@ def test_ndjson_import_nm_composite_keys_with_geldigheid(here, engine, gebieden_
     importer = NDJSONImporter(gebieden_schema, engine)  # TODO: fix datetime tzinfo
     importer.generate_db_objects("ggwgebieden", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from gebieden_ggwgebieden")]
+    records = [dict(r) for r in engine.execute("SELECT * from gebieden_ggwgebieden_v1")]
     assert records == [
         {
             # An "id" should have been generated, concat of the composite key fields:
@@ -232,7 +236,7 @@ def test_ndjson_import_nm_composite_keys_with_geldigheid(here, engine, gebieden_
     records = [
         dict(r)
         for r in engine.execute(
-            "SELECT * from gebieden_ggwgebieden_bestaat_uit_buurten order by id"
+            "SELECT * from gebieden_ggwgebieden_bestaat_uit_buurten_v1 order by id"
         )
     ]
     assert len(records) == 3
@@ -259,7 +263,9 @@ def test_ndjson_import_nm_composite_selfreferencing_keys(
     importer.load_file(ndjson_path)
 
     # An "id" should have been generated, concat of the composite key fields
-    records = [dict(r) for r in engine.execute("SELECT * from brk_kadastraleobjecten order by id")]
+    records = [
+        dict(r) for r in engine.execute("SELECT * from brk_kadastraleobjecten_v1 order by id")
+    ]
     assert records == [
         {
             "begin_geldigheid": None,
@@ -292,7 +298,7 @@ def test_ndjson_import_nm_composite_selfreferencing_keys(
     records = [
         dict(r)
         for r in engine.execute(
-            "SELECT * from brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject"
+            "SELECT * from brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1"
         )
     ]
     assert records == [
@@ -317,7 +323,7 @@ def test_ndjson_import_nested_tables(here, engine, verblijfsobjecten_schema, dbs
         dict(r)
         for r in engine.execute(
             "SELECT code, omschrijving, parent_id"
-            " FROM verblijfsobjecten_verblijfsobjecten_gebruiksdoel"
+            " FROM verblijfsobjecten_verblijfsobjecten_gebruiksdoel_v1"
         )
     ]
     assert records == [
@@ -331,7 +337,7 @@ def test_ndjson_import_1n(here, engine, meetbouten_schema, dbsession):
     importer = NDJSONImporter(meetbouten_schema, engine)
     importer.generate_db_objects("meetbouten", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten")]
+    records = [dict(r) for r in engine.execute("SELECT * from meetbouten_meetbouten_v1")]
     # The foreign key, needed by Django, should be there
     # And should have the concatenated value
     # And Should have a field identificatie
@@ -354,7 +360,9 @@ def test_inactive_relation_that_are_commented_out(here, engine, stadsdelen_schem
     importer = NDJSONImporter(stadsdelen_schema, engine)
     importer.generate_db_objects("stadsdelen", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * FROM stadsdelen_stadsdelen ORDER BY id")]
+    records = [
+        dict(r) for r in engine.execute("SELECT * FROM stadsdelen_stadsdelen_v1 ORDER BY id")
+    ]
     # Field is stringified, because in schema the relation is 'disabled'
     assert records == [
         {"id": "1", "ligt_in_gemeente": '{"identificatie": "0363"}'},
@@ -369,7 +377,7 @@ def test_missing_fields_in_jsonpath_provenance(here, engine, woonplaatsen_schema
     importer.generate_db_objects("woonplaatsen", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM woonplaatsen_woonplaatsen ORDER BY id")
+        dict(r) for r in engine.execute("SELECT * FROM woonplaatsen_woonplaatsen_v1 ORDER BY id")
     ]
     assert records == [
         {
@@ -395,7 +403,7 @@ def test_ndjson_import_with_shortnames_missing_data(here, engine, hr_schema, dbs
         "maatschappelijkeactiviteiten", truncate=True, ind_extra_index=False
     )
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten")]
+    records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten_v1")]
 
     # shortname for heeftEenRelatieMetVerblijfsobject, not in hr_missing_nmrelation.ndjson
     assert records == [
@@ -416,7 +424,7 @@ def test_ndjson_import_with_shortnames_in_schema(here, engine, hr_schema, dbsess
         "maatschappelijkeactiviteiten", truncate=True, ind_extra_index=False
     )
     importer.load_file(ndjson_path)
-    records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten")]
+    records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten_v1")]
     assert records == [
         {
             "kvknummer": "90004213",
@@ -427,12 +435,12 @@ def test_ndjson_import_with_shortnames_in_schema(here, engine, hr_schema, dbsess
     ]
 
     records = [
-        dict(r) for r in engine.execute("SELECT * from hr_activiteiten_sbi_maatschappelijk")
+        dict(r) for r in engine.execute("SELECT * from hr_activiteiten_sbi_maatschappelijk_v1")
     ]
     assert records == [{"parent_id": "90004213", "bronwaarde": 1130, "id": 1}]
 
     records = [
-        dict(r) for r in engine.execute("SELECT * from hr_activiteiten_sbi_voor_activiteit")
+        dict(r) for r in engine.execute("SELECT * from hr_activiteiten_sbi_voor_activiteit_v1")
     ]
     # In this case, the through table does not have extra fields, because the
     # FK to the target is not a composite key.
@@ -444,7 +452,9 @@ def test_ndjson_import_with_shortnames_in_schema(here, engine, hr_schema, dbsess
         }
     ]
 
-    records = [dict(r) for r in engine.execute("SELECT * from hr_activiteiten_verblijfsobjecten")]
+    records = [
+        dict(r) for r in engine.execute("SELECT * from hr_activiteiten_verblijfsobjecten_v1")
+    ]
     assert records == [
         {
             "id": 1,
@@ -464,7 +474,7 @@ def test_ndjson_import_with_shortnames_in_identifier(here, engine, hr_schema, db
     importer.load_file(ndjson_path)
 
     records = [
-        dict(r) for r in engine.execute("SELECT * from hr_sbiactiviteiten ORDER BY sbi_act_nr")
+        dict(r) for r in engine.execute("SELECT * from hr_sbiactiviteiten_v1 ORDER BY sbi_act_nr")
     ]
     assert records == [{"sbi_act_nr": "12"}, {"sbi_act_nr": "16"}]
 
@@ -478,7 +488,7 @@ def test_ndjson_import_with_attributes_on_relation(
     importer.generate_db_objects("aantekeningenrechten", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
 
-    records = [dict(r) for r in engine.execute("SELECT * from brk_aantekeningenrechten")]
+    records = [dict(r) for r in engine.execute("SELECT * from brk_aantekeningenrechten_v1")]
     assert records == [
         {
             "aard_code": None,
@@ -504,7 +514,7 @@ def test_provenance_for_schema_field_ids_equal_to_ndjson_keys(
     importer.generate_db_objects("woonplaatsen", truncate=True, ind_extra_index=False)
     importer.load_file(ndjson_path)
     records = [
-        dict(r) for r in engine.execute("SELECT * FROM woonplaatsen_woonplaatsen ORDER BY id")
+        dict(r) for r in engine.execute("SELECT * FROM woonplaatsen_woonplaatsen_v1 ORDER BY id")
     ]
     assert records == [
         {

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -44,12 +44,12 @@ class TestReadPermissions:
         apply_schema_and_profile_permissions(
             engine, "public", ams_schema, profiles, "AUTO", "ALL", create_roles=True
         )
-        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten")
+        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten_v1")
         _check_select_permission_granted(
-            engine, "scope_level_b", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "scope_level_b", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "scope_level_c", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "scope_level_c", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
 
     def test_auto_permissions_with_scopes(self, here, engine, gebieden_schema_scopes, dbsession):
@@ -77,19 +77,19 @@ class TestReadPermissions:
         apply_schema_and_profile_permissions(
             engine, "public", ams_schema, profiles, "AUTO", "ALL", create_roles=True
         )
-        _check_select_permission_granted(engine, "scope_harry_one", "gebieden_buurten")
+        _check_select_permission_granted(engine, "scope_harry_one", "gebieden_buurten_v1")
         _check_select_permission_granted(
-            engine, "scope_harry_two", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "scope_harry_two", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "scope_harry_three", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "scope_harry_three", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
 
         # Check if auth strings in the same schema also work.
         _check_select_permission_granted(
             engine,
             "scope_level_d",
-            "gebieden_bouwblokken",
+            "gebieden_bouwblokken_v1",
             "ligt_in_buurt_id, ligt_in_buurt_loose_id",
         )
 
@@ -109,9 +109,9 @@ class TestReadPermissions:
 
         # Check if the roles exist, the tables exist,
         # and the roles have no read privilege on the tables.
-        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten")
-        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten")
-        _check_select_permission_denied(engine, "brk_ro", "brk_kadastraleobjecten")
+        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten_v1")
+        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten_v1")
+        _check_select_permission_denied(engine, "brk_ro", "brk_kadastraleobjecten_v1")
 
         # make sure role 'write_brk' exists with create_roles=True
         # The role exists now for all test following this statement
@@ -135,54 +135,54 @@ class TestReadPermissions:
 
         grants = _filter_grant_statements(caplog)
         assert grants == [
-            "GRANT SELECT (begin_geldigheid) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (eind_geldigheid) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (id) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (identificatie) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (koopsom) ON TABLE public.brk_kadastraleobjecten TO brk_ro",
-            "GRANT SELECT (neuron_id) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (registratiedatum) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (soort_cultuur_onbebouwd_code) ON TABLE public.brk_kadastraleobjecten TO brk_ro",
-            "GRANT SELECT (soort_cultuur_onbebouwd_omschrijving) ON TABLE public.brk_kadastraleobjecten TO brk_ro",
-            "GRANT SELECT (soort_grootte) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT (volgnummer) ON TABLE public.brk_kadastraleobjecten TO brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_id_seq TO brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject TO brk_rsn",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_id_seq TO write_brk",
+            "GRANT SELECT (begin_geldigheid) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (eind_geldigheid) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (id) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (identificatie) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (koopsom) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_ro",
+            "GRANT SELECT (neuron_id) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (registratiedatum) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (soort_cultuur_onbebouwd_code) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_ro",
+            "GRANT SELECT (soort_cultuur_onbebouwd_omschrijving) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_ro",
+            "GRANT SELECT (soort_grootte) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT (volgnummer) ON TABLE public.brk_kadastraleobjecten_v1 TO brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject__id_seq TO brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1 TO brk_rsn",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_v1 TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject__id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject__id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject__id_seq TO write_brk",
         ]
 
         # table denied
-        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten")
-        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten", "koopsom")
+        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten_v1")
+        _check_select_permission_denied(engine, "openbaar", "brk_kadastraleobjecten_v1", "koopsom")
 
         # table denied, column granted, auth level dataset
-        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten")
-        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten", "koopsom")
+        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten_v1")
+        _check_select_permission_denied(engine, "brk_rsn", "brk_kadastraleobjecten_v1", "koopsom")
         _check_select_permission_granted(
-            engine, "brk_rsn", "brk_kadastraleobjecten", "identificatie"
+            engine, "brk_rsn", "brk_kadastraleobjecten_v1", "identificatie"
         )
 
         # table denied, column granted, auth level field
-        _check_select_permission_denied(engine, "brk_ro", "brk_kadastraleobjecten")
-        _check_select_permission_granted(engine, "brk_ro", "brk_kadastraleobjecten", "koopsom")
+        _check_select_permission_denied(engine, "brk_ro", "brk_kadastraleobjecten_v1")
+        _check_select_permission_granted(engine, "brk_ro", "brk_kadastraleobjecten_v1", "koopsom")
 
         # nm relations table tests, should have dataset auth level: brk_rsn
         _check_select_permission_denied(
-            engine, "openbaar", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject"
+            engine, "openbaar", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1"
         )
         _check_select_permission_denied(
-            engine, "brk_ro", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject"
+            engine, "brk_ro", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1"
         )
         _check_select_permission_granted(
-            engine, "brk_rsn", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject"
+            engine, "brk_rsn", "brk_kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1"
         )
 
     def test_brk_permissions(
@@ -214,63 +214,63 @@ class TestReadPermissions:
         grants = _filter_grant_statements(caplog)
         assert grants == [
             "GRANT SELECT ON SEQUENCE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_pers_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_aantekeningenrechten_heeft_betrokken_persoon_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_aantekeningenrechten_is_gbsd_op_sdl_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_hft_rel_mt_vot_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_aantekeningenrechten_heeft_betrokken_persoon_v1_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_aantekeningenrechten_is_gbsd_op_sdl_v1_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_hft_rel_mt_vot_v1_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_v1_id_seq TO scope_brk_rsn",
             "GRANT SELECT ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_recht_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON SEQUENCE public.brk_stukdelen_is_bron_voor_zakelijk_recht_id_seq TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aantekeningenkadastraleobjecten TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_persoon TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten_heeft_betrokken_persoon TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten_is_gbsd_op_sdl TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_aardzakelijkerechten TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_gemeentes TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastralegemeentecodes TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastralegemeentes TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_hft_rel_mt_vot TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_soort_cultuur_bebouwd TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastralesecties TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_kadastralesubjecten TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_meta TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_stukdelen TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_recht TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_zakelijk_recht TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_tenaamstellingen TO scope_brk_rsn",
-            "GRANT SELECT ON TABLE public.brk_zakelijkerechten TO scope_brk_rsn",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenkadastraleobjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_persoon TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten_heeft_betrokken_persoon TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten_is_gbsd_op_sdl TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aardzakelijkerechten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_gemeentes TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralegemeentecodes TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralegemeentes TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_hft_rel_mt_vot TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_soort_cultuur_bebouwd TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralesecties TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralesubjecten TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_meta TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_recht TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_zakelijk_recht TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_tenaamstellingen TO write_brk",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_zakelijkerechten TO write_brk",
+            "GRANT SELECT ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_recht_v1_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON SEQUENCE public.brk_stukdelen_is_bron_voor_zakelijk_recht_v1_id_seq TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_persoon_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aantekeningenkadastraleobjecten_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten_heeft_betrokken_persoon_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten_is_gbsd_op_sdl_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aantekeningenrechten_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_aardzakelijkerechten_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_gemeentes_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastralegemeentecodes_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastralegemeentes_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_hft_rel_mt_vot_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastraleobjecten_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastralesecties_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_kadastralesubjecten_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_meta_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_recht_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_stukdelen_is_bron_voor_zakelijk_recht_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_stukdelen_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_tenaamstellingen_v1 TO scope_brk_rsn",
+            "GRANT SELECT ON TABLE public.brk_zakelijkerechten_v1 TO scope_brk_rsn",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_persoon_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenkadastraleobjecten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten_heeft_betrokken_persoon_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten_is_gbsd_op_sdl_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aantekeningenrechten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_aardzakelijkerechten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_gemeentes_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralegemeentecodes_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralegemeentes_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_hft_rel_mt_vot_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastraleobjecten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralesecties_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_kadastralesubjecten_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_meta_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_aantekening_recht_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_is_bron_voor_zakelijk_recht_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_stukdelen_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_tenaamstellingen_v1 TO write_brk",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.brk_zakelijkerechten_v1 TO write_brk",
             "GRANT USAGE ON SEQUENCE public.brk_aantekeningenkadastraleobjecten_heeft_betrokken_pers_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_aantekeningenrechten_heeft_betrokken_persoon_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_aantekeningenrechten_is_gbsd_op_sdl_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_hft_rel_mt_vot_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_aantekeningenrechten_heeft_betrokken_persoon_v1_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_aantekeningenrechten_is_gbsd_op_sdl_v1_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_hft_rel_mt_vot_v1_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_kadastraleobjecten_soort_cultuur_bebouwd_v1_id_seq TO write_brk",
             "GRANT USAGE ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_kadastraal_object_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_recht_id_seq TO write_brk",
-            "GRANT USAGE ON SEQUENCE public.brk_stukdelen_is_bron_voor_zakelijk_recht_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_stukdelen_is_bron_voor_aantekening_recht_v1_id_seq TO write_brk",
+            "GRANT USAGE ON SEQUENCE public.brk_stukdelen_is_bron_voor_zakelijk_recht_v1_id_seq TO write_brk",
         ]
 
     def test_openbaar_permissions(self, here, engine, afval_schema, dbsession, caplog):
@@ -294,8 +294,8 @@ class TestReadPermissions:
         _create_role(engine, "bag_r")
         # Check if the roles exist, the tables exist,
         # and the roles have no read privilige on the tables.
-        _check_select_permission_denied(engine, "openbaar", "afvalwegingen_containers")
-        _check_select_permission_denied(engine, "bag_r", "afvalwegingen_clusters")
+        _check_select_permission_denied(engine, "openbaar", "afvalwegingen_containers_v1")
+        _check_select_permission_denied(engine, "bag_r", "afvalwegingen_clusters_v1")
 
         with caplog.at_level(logging.INFO, logger="schematools.permissions.db"):
             apply_schema_and_profile_permissions(
@@ -320,15 +320,15 @@ class TestReadPermissions:
 
         grants = _filter_grant_statements(caplog)
         assert grants == [
-            "GRANT SELECT ON TABLE public.afvalwegingen_clusters TO bag_r",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.afvalwegingen_clusters TO write_afvalwegingen",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.afvalwegingen_containers TO write_afvalwegingen",
+            "GRANT SELECT ON TABLE public.afvalwegingen_clusters_v1 TO bag_r",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.afvalwegingen_clusters_v1 TO write_afvalwegingen",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.afvalwegingen_containers_v1 TO write_afvalwegingen",
         ]
 
-        _check_select_permission_granted(engine, "openbaar", "afvalwegingen_containers")
-        _check_select_permission_denied(engine, "openbaar", "afvalwegingen_clusters")
-        _check_select_permission_denied(engine, "bag_r", "afvalwegingen_containers")
-        _check_select_permission_granted(engine, "bag_r", "afvalwegingen_clusters")
+        _check_select_permission_granted(engine, "openbaar", "afvalwegingen_containers_v1")
+        _check_select_permission_denied(engine, "openbaar", "afvalwegingen_clusters_v1")
+        _check_select_permission_denied(engine, "bag_r", "afvalwegingen_containers_v1")
+        _check_select_permission_granted(engine, "bag_r", "afvalwegingen_clusters_v1")
 
     def test_interacting_permissions(self, here, engine, gebieden_schema_auth, dbsession):
         """
@@ -363,7 +363,7 @@ class TestReadPermissions:
         # Check if the roles exist, the tables exist,
         # and the roles have no read privilige on the tables.
         for test_role in test_roles:
-            for table in ["gebieden_bouwblokken", "gebieden_buurten"]:
+            for table in ["gebieden_bouwblokken_v1", "gebieden_buurten_v1"]:
                 _check_select_permission_denied(engine, test_role, table)
 
         # Apply the permissions from Schema and Profiles.
@@ -378,24 +378,24 @@ class TestReadPermissions:
         )
 
         # Check if the read priviliges are correct
-        _check_select_permission_denied(engine, "level_a", "gebieden_bouwblokken")
-        _check_select_permission_granted(engine, "level_a", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_a", "gebieden_bouwblokken_v1")
+        _check_select_permission_granted(engine, "level_a", "gebieden_buurten_v1")
 
         _check_select_permission_granted(
-            engine, "level_b", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_b", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_denied(
-            engine, "level_b", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_b", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_b", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_b", "gebieden_buurten_v1")
 
         _check_select_permission_denied(
-            engine, "level_c", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_c", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "level_c", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_c", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_c", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_c", "gebieden_buurten_v1")
 
     def test_auth_list_permissions(
         self, here, engine, gebieden_schema_auth_list, dbsession, caplog
@@ -440,7 +440,7 @@ class TestReadPermissions:
         # Check if the roles exist, the tables exist,
         # and the roles have no read privilige on the tables.
         for test_role in test_roles:
-            for table in ["gebieden_bouwblokken", "gebieden_buurten"]:
+            for table in ["gebieden_bouwblokken_v1", "gebieden_buurten_v1"]:
                 _check_select_permission_denied(engine, test_role, table)
 
         # Apply the permissions from Schema and Profiles.
@@ -450,15 +450,15 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO level_a1",
-                "GRANT SELECT ON TABLE public.gebieden_buurten TO level_a1",
-                "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk TO level_a1",
-                "GRANT SELECT ON TABLE public.gebieden_wijken TO level_a1",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO level_a1",
+                "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO level_a1",
+                "GRANT SELECT ON TABLE public.gebieden_buurten_v1 TO level_a1",
+                "GRANT SELECT ON TABLE public.gebieden_wijken_v1 TO level_a1",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
             apply_schema_and_profile_permissions(
@@ -466,14 +466,14 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken TO level_b1",
-                "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken TO level_b1",
-                "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken TO level_b1",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO level_b1",
+                "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken_v1 TO level_b1",
+                "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken_v1 TO level_b1",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
             apply_schema_and_profile_permissions(
@@ -481,12 +481,12 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken TO level_c1",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO level_c1",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
             apply_schema_and_profile_permissions(
@@ -494,15 +494,15 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO level_a2",
-                "GRANT SELECT ON TABLE public.gebieden_buurten TO level_a2",
-                "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk TO level_a2",
-                "GRANT SELECT ON TABLE public.gebieden_wijken TO level_a2",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO level_a2",
+                "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO level_a2",
+                "GRANT SELECT ON TABLE public.gebieden_buurten_v1 TO level_a2",
+                "GRANT SELECT ON TABLE public.gebieden_wijken_v1 TO level_a2",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
             apply_schema_and_profile_permissions(
@@ -510,14 +510,14 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken TO level_b2",
-                "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken TO level_b2",
-                "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken TO level_b2",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO level_b2",
+                "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken_v1 TO level_b2",
+                "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken_v1 TO level_b2",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
             apply_schema_and_profile_permissions(
@@ -525,58 +525,62 @@ class TestReadPermissions:
             )
             grants = _filter_grant_statements(caplog)
             assert grants == [
-                "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken TO level_c2",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
+                "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO level_c2",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+                "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
             ]
 
         # Check if the read priviliges are correct
-        _check_select_permission_denied(engine, "level_a1", "gebieden_bouwblokken")
-        _check_select_permission_granted(engine, "level_a1", "gebieden_buurten")
-        _check_select_permission_denied(engine, "level_a2", "gebieden_bouwblokken")
-        _check_select_permission_granted(engine, "level_a2", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_a1", "gebieden_bouwblokken_v1")
+        _check_select_permission_granted(engine, "level_a1", "gebieden_buurten_v1")
+        _check_select_permission_denied(engine, "level_a2", "gebieden_bouwblokken_v1")
+        _check_select_permission_granted(engine, "level_a2", "gebieden_buurten_v1")
 
         _check_select_permission_granted(
-            engine, "level_b1", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_b1", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_denied(
-            engine, "level_b1", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_b1", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_b1", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_b1", "gebieden_buurten_v1")
         _check_select_permission_granted(
-            engine, "level_b2", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_b2", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_denied(
-            engine, "level_b2", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_b2", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_b2", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_b2", "gebieden_buurten_v1")
 
         _check_select_permission_denied(
-            engine, "level_c1", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_c1", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "level_c1", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_c1", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_c1", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_c1", "gebieden_buurten_v1")
 
         _check_select_permission_denied(
-            engine, "level_c2", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "level_c2", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "level_c2", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "level_c2", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "level_c2", "gebieden_buurten")
+        _check_select_permission_denied(engine, "level_c2", "gebieden_buurten_v1")
 
         # Check that there are no INSERT, UPDATE, TRUNCATE, DELETE privileges
-        _check_insert_permission_denied(engine, "level_b1", "gebieden_bouwblokken", "id", "'abc'")
-        _check_update_permission_denied(
-            engine, "level_b1", "gebieden_bouwblokken", "id", "'def'", "id = 'abc'"
+        _check_insert_permission_denied(
+            engine, "level_b1", "gebieden_bouwblokken_v1", "id", "'abc'"
         )
-        _check_delete_permission_denied(engine, "level_b1", "gebieden_bouwblokken", "id = 'abc'")
-        _check_truncate_permission_denied(engine, "level_b1", "gebieden_bouwblokken")
+        _check_update_permission_denied(
+            engine, "level_b1", "gebieden_bouwblokken_v1", "id", "'def'", "id = 'abc'"
+        )
+        _check_delete_permission_denied(
+            engine, "level_b1", "gebieden_bouwblokken_v1", "id = 'abc'"
+        )
+        _check_truncate_permission_denied(engine, "level_b1", "gebieden_bouwblokken_v1")
 
     def test_auto_create_roles(self, here, engine, gebieden_schema_auth, dbsession, caplog):
         """
@@ -620,90 +624,90 @@ class TestReadPermissions:
 
         grants = _filter_grant_statements(caplog)
         assert grants == [
-            "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken TO scope_level_c",
-            "GRANT SELECT (begingeldigheid) ON TABLE public.gebieden_ggwgebieden TO scope_level_a",
-            "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken TO scope_level_b",
-            "GRANT SELECT (eindgeldigheid) ON TABLE public.gebieden_ggwgebieden TO scope_level_a",
-            "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken TO scope_level_b",
-            "GRANT SELECT (id) ON TABLE public.gebieden_ggwgebieden TO scope_level_a",
-            "GRANT SELECT (identificatie) ON TABLE public.gebieden_ggwgebieden TO scope_level_a",
-            "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken TO scope_level_d",
-            "GRANT SELECT (ligt_in_buurt_identificatie) ON TABLE public.gebieden_bouwblokken TO scope_level_d",
-            "GRANT SELECT (ligt_in_buurt_loose_id) ON TABLE public.gebieden_bouwblokken TO scope_level_d",
-            "GRANT SELECT (ligt_in_buurt_volgnummer) ON TABLE public.gebieden_bouwblokken TO scope_level_d",
-            "GRANT SELECT (volgnummer) ON TABLE public.gebieden_ggwgebieden TO scope_level_a",
-            "GRANT SELECT ON SEQUENCE public.gebieden_bouwblokken_ligt_in_buurt_id_seq TO scope_level_d",
-            "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO scope_level_a",
-            "GRANT SELECT ON SEQUENCE public.gebieden_ggwgebieden_bestaat_uit_buurten_id_seq TO scope_level_e",
-            "GRANT SELECT ON SEQUENCE public.gebieden_ggwgebieden_gebieds_grenzen_id_seq TO scope_level_f",
-            "GRANT SELECT ON TABLE public.gebieden_bouwblokken_ligt_in_buurt TO scope_level_d",
-            "GRANT SELECT ON TABLE public.gebieden_buurten TO scope_level_a",
-            "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk TO scope_level_a",
-            "GRANT SELECT ON TABLE public.gebieden_ggwgebieden_bestaat_uit_buurten TO scope_level_e",
-            "GRANT SELECT ON TABLE public.gebieden_ggwgebieden_gebieds_grenzen TO scope_level_f",
-            "GRANT SELECT ON TABLE public.gebieden_wijken TO scope_level_a",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_ligt_in_buurt TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden_bestaat_uit_buurten TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden_gebieds_grenzen TO write_gebieden",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken TO write_gebieden",
-            "GRANT USAGE ON SEQUENCE public.gebieden_bouwblokken_ligt_in_buurt_id_seq TO write_gebieden",
-            "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_id_seq TO write_gebieden",
-            "GRANT USAGE ON SEQUENCE public.gebieden_ggwgebieden_bestaat_uit_buurten_id_seq TO write_gebieden",
-            "GRANT USAGE ON SEQUENCE public.gebieden_ggwgebieden_gebieds_grenzen_id_seq TO write_gebieden",
+            "GRANT SELECT (begin_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_c",
+            "GRANT SELECT (begingeldigheid) ON TABLE public.gebieden_ggwgebieden_v1 TO scope_level_a",
+            "GRANT SELECT (eind_geldigheid) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_b",
+            "GRANT SELECT (eindgeldigheid) ON TABLE public.gebieden_ggwgebieden_v1 TO scope_level_a",
+            "GRANT SELECT (id) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_b",
+            "GRANT SELECT (id) ON TABLE public.gebieden_ggwgebieden_v1 TO scope_level_a",
+            "GRANT SELECT (identificatie) ON TABLE public.gebieden_ggwgebieden_v1 TO scope_level_a",
+            "GRANT SELECT (ligt_in_buurt_id) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_d",
+            "GRANT SELECT (ligt_in_buurt_identificatie) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_d",
+            "GRANT SELECT (ligt_in_buurt_loose_id) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_d",
+            "GRANT SELECT (ligt_in_buurt_volgnummer) ON TABLE public.gebieden_bouwblokken_v1 TO scope_level_d",
+            "GRANT SELECT (volgnummer) ON TABLE public.gebieden_ggwgebieden_v1 TO scope_level_a",
+            "GRANT SELECT ON SEQUENCE public.gebieden_bouwblokken_ligt_in_buurt_v1_id_seq TO scope_level_d",
+            "GRANT SELECT ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO scope_level_a",
+            "GRANT SELECT ON SEQUENCE public.gebieden_ggwgebieden_bestaat_uit_buurten_v1_id_seq TO scope_level_e",
+            "GRANT SELECT ON SEQUENCE public.gebieden_ggwgebieden_gebieds_grenzen_v1_id_seq TO scope_level_f",
+            "GRANT SELECT ON TABLE public.gebieden_bouwblokken_ligt_in_buurt_v1 TO scope_level_d",
+            "GRANT SELECT ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO scope_level_a",
+            "GRANT SELECT ON TABLE public.gebieden_buurten_v1 TO scope_level_a",
+            "GRANT SELECT ON TABLE public.gebieden_ggwgebieden_bestaat_uit_buurten_v1 TO scope_level_e",
+            "GRANT SELECT ON TABLE public.gebieden_ggwgebieden_gebieds_grenzen_v1 TO scope_level_f",
+            "GRANT SELECT ON TABLE public.gebieden_wijken_v1 TO scope_level_a",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_ligt_in_buurt_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_bouwblokken_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_ligt_in_wijk_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_buurten_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden_bestaat_uit_buurten_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden_gebieds_grenzen_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_ggwgebieden_v1 TO write_gebieden",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.gebieden_wijken_v1 TO write_gebieden",
+            "GRANT USAGE ON SEQUENCE public.gebieden_bouwblokken_ligt_in_buurt_v1_id_seq TO write_gebieden",
+            "GRANT USAGE ON SEQUENCE public.gebieden_buurten_ligt_in_wijk_v1_id_seq TO write_gebieden",
+            "GRANT USAGE ON SEQUENCE public.gebieden_ggwgebieden_bestaat_uit_buurten_v1_id_seq TO write_gebieden",
+            "GRANT USAGE ON SEQUENCE public.gebieden_ggwgebieden_gebieds_grenzen_v1_id_seq TO write_gebieden",
         ]
 
         # Check if roles exist and the read priviliges are correct
-        _check_select_permission_denied(engine, "scope_level_a", "gebieden_bouwblokken")
-        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten")
+        _check_select_permission_denied(engine, "scope_level_a", "gebieden_bouwblokken_v1")
+        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten_v1")
 
         _check_select_permission_granted(
-            engine, "scope_level_b", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "scope_level_b", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_denied(
-            engine, "scope_level_b", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "scope_level_b", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
-        _check_select_permission_denied(engine, "scope_level_b", "gebieden_buurten")
+        _check_select_permission_denied(engine, "scope_level_b", "gebieden_buurten_v1")
 
         _check_select_permission_denied(
-            engine, "scope_level_c", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "scope_level_c", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "scope_level_c", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "scope_level_c", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "scope_level_d", "gebieden_bouwblokken", "ligt_in_buurt_loose_id"
+            engine, "scope_level_d", "gebieden_bouwblokken_v1", "ligt_in_buurt_loose_id"
         )
         _check_select_permission_granted(
-            engine, "scope_level_d", "gebieden_bouwblokken", "ligt_in_buurt_id"
+            engine, "scope_level_d", "gebieden_bouwblokken_v1", "ligt_in_buurt_id"
         )
         _check_select_permission_granted(
-            engine, "scope_level_d", "gebieden_bouwblokken", "ligt_in_buurt_identificatie"
+            engine, "scope_level_d", "gebieden_bouwblokken_v1", "ligt_in_buurt_identificatie"
         )
         _check_select_permission_granted(
-            engine, "scope_level_d", "gebieden_bouwblokken", "ligt_in_buurt_volgnummer"
+            engine, "scope_level_d", "gebieden_bouwblokken_v1", "ligt_in_buurt_volgnummer"
         )
-        _check_select_permission_denied(engine, "scope_level_c", "gebieden_buurten")
-        _check_select_permission_denied(engine, "scope_level_d", "gebieden_buurten")
+        _check_select_permission_denied(engine, "scope_level_c", "gebieden_buurten_v1")
+        _check_select_permission_denied(engine, "scope_level_d", "gebieden_buurten_v1")
 
         # Check the through table, for all columns
         _check_select_permission_granted(
-            engine, "scope_level_e", "gebieden_ggwgebieden_bestaat_uit_buurten"
+            engine, "scope_level_e", "gebieden_ggwgebieden_bestaat_uit_buurten_v1"
         )
         # Check the nested table, for all columns
         _check_select_permission_granted(
-            engine, "scope_level_f", "gebieden_ggwgebieden_gebieds_grenzen"
+            engine, "scope_level_f", "gebieden_ggwgebieden_gebieds_grenzen_v1"
         )
         # Check the through table
         _check_select_permission_denied(
-            engine, "scope_level_a", "gebieden_ggwgebieden_bestaat_uit_buurten"
+            engine, "scope_level_a", "gebieden_ggwgebieden_bestaat_uit_buurten_v1"
         )
         # Check the nested table
         _check_select_permission_denied(
-            engine, "scope_level_a", "gebieden_ggwgebieden_gebieds_grenzen"
+            engine, "scope_level_a", "gebieden_ggwgebieden_gebieds_grenzen_v1"
         )
 
     def test_single_dataset_permissions(
@@ -732,12 +736,12 @@ class TestReadPermissions:
             engine, "public", gebieden_schema_auth, None, "AUTO", "ALL", create_roles=True
         )
         # Check perms on gebieden
-        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten")
+        _check_select_permission_granted(engine, "scope_level_a", "gebieden_buurten_v1")
         _check_select_permission_granted(
-            engine, "scope_level_b", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "scope_level_b", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
         _check_select_permission_granted(
-            engine, "scope_level_c", "gebieden_bouwblokken", "begin_geldigheid"
+            engine, "scope_level_c", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
 
         # Apply the permissions to meetbouten
@@ -745,7 +749,7 @@ class TestReadPermissions:
             engine, "public", meetbouten_schema, None, "AUTO", "ALL", create_roles=True
         )
         # Check perms on meetbouten
-        _check_select_permission_granted(engine, "scope_openbaar", "meetbouten_meetbouten")
+        _check_select_permission_granted(engine, "scope_openbaar", "meetbouten_meetbouten_v1")
 
         # Revoke permissions for dataset gebieden and set grant again
         apply_schema_and_profile_permissions(
@@ -759,7 +763,7 @@ class TestReadPermissions:
             revoke=True,
         )
         # Check perms again on meetbouten
-        _check_select_permission_granted(engine, "scope_openbaar", "meetbouten_meetbouten")
+        _check_select_permission_granted(engine, "scope_openbaar", "meetbouten_meetbouten_v1")
 
     def test_permissions_support_shortnames(self, here, engine, hr_schema_auth, dbsession, caplog):
         """
@@ -799,18 +803,18 @@ class TestReadPermissions:
 
         grants = _filter_grant_statements(caplog)
         assert grants == [
-            "GRANT SELECT (identifier) ON TABLE public.hr_sbi_ac TO level_b",
-            "GRANT SELECT (sbi_ac_naam) ON TABLE public.hr_sbi_ac TO level_b",
-            "GRANT SELECT (sbi_ac_no) ON TABLE public.hr_sbi_ac TO level_c",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.hr_sbi_ac TO write_hr",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.hr_sbi_ac TO write_hr",
+            "GRANT SELECT (identifier) ON TABLE public.hr_sbi_ac_v1 TO level_b",
+            "GRANT SELECT (sbi_ac_naam) ON TABLE public.hr_sbi_ac_v1 TO level_b",
+            "GRANT SELECT (sbi_ac_no) ON TABLE public.hr_sbi_ac_v1 TO level_c",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.hr_sbi_ac_v1 TO write_hr",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.hr_sbi_ac_v1 TO write_hr",
         ]
 
         # Check if the read priviliges are correct
-        _check_select_permission_granted(engine, "level_b", "hr_sbi_ac", "sbi_ac_naam")
-        _check_select_permission_denied(engine, "level_b", "hr_sbi_ac", "sbi_ac_no")
-        _check_select_permission_denied(engine, "level_c", "hr_sbi_ac", "sbi_ac_naam")
-        _check_select_permission_granted(engine, "level_c", "hr_sbi_ac", "sbi_ac_no")
+        _check_select_permission_granted(engine, "level_b", "hr_sbi_ac_v1", "sbi_ac_naam")
+        _check_select_permission_denied(engine, "level_b", "hr_sbi_ac_v1", "sbi_ac_no")
+        _check_select_permission_denied(engine, "level_c", "hr_sbi_ac_v1", "sbi_ac_naam")
+        _check_select_permission_granted(engine, "level_c", "hr_sbi_ac_v1", "sbi_ac_no")
 
 
 class TestWritePermissions:
@@ -832,7 +836,7 @@ class TestWritePermissions:
 
         # The write_ roles do not have SELECT permissions
         _check_insert_permission_denied(
-            engine, "write_gebieden", "gebieden_bouwblokken", "id", "'abc'"
+            engine, "write_gebieden", "gebieden_bouwblokken_v1", "id", "'abc'"
         )
 
         apply_schema_and_profile_permissions(
@@ -858,16 +862,20 @@ class TestWritePermissions:
             connection.execute("GRANT write_gebieden TO testuser")
 
         #  It is now possible to INSERT data into the dataset tables
-        _check_insert_permission_granted(engine, "testuser", "gebieden_bouwblokken", "id", "'abc'")
+        _check_insert_permission_granted(
+            engine, "testuser", "gebieden_bouwblokken_v1", "id", "'abc'"
+        )
 
         #  The write_ roles do have SELECT permissions, therefore testuser should not have it
-        _check_select_permission_granted(engine, "testuser", "gebieden_bouwblokken")
+        _check_select_permission_granted(engine, "testuser", "gebieden_bouwblokken_v1")
 
         #  With SELECT it is possible to UPDATE or DELETE on given condition
         _check_update_permission_granted(
-            engine, "testuser", "gebieden_bouwblokken", "id", "'def'", "id = 'abc'"
+            engine, "testuser", "gebieden_bouwblokken_v1", "id", "'def'", "id = 'abc'"
         )
-        _check_delete_permission_granted(engine, "testuser", "gebieden_bouwblokken", "id = 'abc'")
+        _check_delete_permission_granted(
+            engine, "testuser", "gebieden_bouwblokken_v1", "id = 'abc'"
+        )
 
         # Add SELECT permissions by granting the appropriate scope to the user
         with engine.begin() as connection:
@@ -875,18 +883,20 @@ class TestWritePermissions:
 
         # But now it's possible to SELECT the columns within scope level_b
         _check_select_permission_granted(
-            engine, "testuser", "gebieden_bouwblokken", "id, eind_geldigheid"
+            engine, "testuser", "gebieden_bouwblokken_v1", "id, eind_geldigheid"
         )
 
         # And it's also possible to UPDATE and DELETE,
         # if the column for the condition is within scope
         _check_update_permission_granted(
-            engine, "testuser", "gebieden_bouwblokken", "id", "'def'", "id = 'abc'"
+            engine, "testuser", "gebieden_bouwblokken_v1", "id", "'def'", "id = 'abc'"
         )
-        _check_delete_permission_granted(engine, "testuser", "gebieden_bouwblokken", "id = 'def'")
+        _check_delete_permission_granted(
+            engine, "testuser", "gebieden_bouwblokken_v1", "id = 'def'"
+        )
 
         # TRUNCATE is also allowed, even though the table is already empty by now
-        _check_truncate_permission_granted(engine, "testuser", "gebieden_bouwblokken")
+        _check_truncate_permission_granted(engine, "testuser", "gebieden_bouwblokken_v1")
 
     def test_multiple_datasets_write_roles(self, here, engine, parkeervakken_schema, afval_schema):
         """
@@ -930,19 +940,19 @@ class TestWritePermissions:
 
         #  parkeer_tester has INSERT permission on parkeervakken datasets
         _check_insert_permission_granted(
-            engine, "parkeer_tester", "parkeervakken_parkeervakken", "id", "'abc'"
+            engine, "parkeer_tester", "parkeervakken_parkeervakken_v1", "id", "'abc'"
         )
         #  afval_tester has INSERT permission on afvalwegingen datasets
         _check_insert_permission_granted(
-            engine, "afval_tester", "afvalwegingen_containers", "id", "3"
+            engine, "afval_tester", "afvalwegingen_containers_v1", "id", "3"
         )
         #  parkeer_tester has NO INSERT permission on afvalwegingen datasets
         _check_insert_permission_denied(
-            engine, "parkeer_tester", "afvalwegingen_containers", "id", "3"
+            engine, "parkeer_tester", "afvalwegingen_containers_v1", "id", "3"
         )
         #  afval_tester has NO INSERT permission on parkeervakken datasets
         _check_insert_permission_denied(
-            engine, "afval_tester", "parkeervakken_parkeervakken", "id", "'abc'"
+            engine, "afval_tester", "parkeervakken_parkeervakken_v1", "id", "'abc'"
         )
 
     def test_permissions_support_shortnames(self, here, engine, hr_schema_auth, dbsession):
@@ -967,7 +977,7 @@ class TestWritePermissions:
         _check_insert_permission_granted(
             engine,
             "write_hr",
-            "hr_sbi_ac",
+            "hr_sbi_ac_v1",
             "sbi_ac_naam,sbi_ac_no,identifier",
             "'berry','14641','15101051'",
         )
@@ -1002,21 +1012,21 @@ class TestWritePermissions:
 
         grants = _filter_grant_statements(caplog)
         assert grants == [
-            "GRANT SELECT ON SEQUENCE public.meetbouten_meetbouten_ligt_in_buurt_id_seq TO scope_openbaar",
-            "GRANT SELECT ON SEQUENCE public.meetbouten_metingen_refereertaanreferentiepunten_id_seq TO scope_openbaar",
+            "GRANT SELECT ON SEQUENCE public.meetbouten_meetbouten_ligt_in_buurt_v1_id_seq TO scope_openbaar",
+            "GRANT SELECT ON SEQUENCE public.meetbouten_metingen_refereertaanreferentiepunten_v1_id_seq TO scope_openbaar",
             "GRANT SELECT ON TABLE public.datasets_dataset TO scope_openbaar",
-            "GRANT SELECT ON TABLE public.meetbouten_meetbouten TO scope_openbaar",
-            "GRANT SELECT ON TABLE public.meetbouten_meetbouten_ligt_in_buurt TO scope_openbaar",
-            "GRANT SELECT ON TABLE public.meetbouten_metingen TO scope_openbaar",
-            "GRANT SELECT ON TABLE public.meetbouten_metingen_refereertaanreferentiepunten TO scope_openbaar",
-            "GRANT SELECT ON TABLE public.meetbouten_referentiepunten TO scope_openbaar",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_meetbouten TO write_meetbouten",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_meetbouten_ligt_in_buurt TO write_meetbouten",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_metingen TO write_meetbouten",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_metingen_refereertaanreferentiepunten TO write_meetbouten",
-            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_referentiepunten TO write_meetbouten",
-            "GRANT USAGE ON SEQUENCE public.meetbouten_meetbouten_ligt_in_buurt_id_seq TO write_meetbouten",
-            "GRANT USAGE ON SEQUENCE public.meetbouten_metingen_refereertaanreferentiepunten_id_seq TO write_meetbouten",
+            "GRANT SELECT ON TABLE public.meetbouten_meetbouten_ligt_in_buurt_v1 TO scope_openbaar",
+            "GRANT SELECT ON TABLE public.meetbouten_meetbouten_v1 TO scope_openbaar",
+            "GRANT SELECT ON TABLE public.meetbouten_metingen_refereertaanreferentiepunten_v1 TO scope_openbaar",
+            "GRANT SELECT ON TABLE public.meetbouten_metingen_v1 TO scope_openbaar",
+            "GRANT SELECT ON TABLE public.meetbouten_referentiepunten_v1 TO scope_openbaar",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_meetbouten_ligt_in_buurt_v1 TO write_meetbouten",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_meetbouten_v1 TO write_meetbouten",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_metingen_refereertaanreferentiepunten_v1 TO write_meetbouten",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_metingen_v1 TO write_meetbouten",
+            "GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLE public.meetbouten_referentiepunten_v1 TO write_meetbouten",
+            "GRANT USAGE ON SEQUENCE public.meetbouten_meetbouten_ligt_in_buurt_v1_id_seq TO write_meetbouten",
+            "GRANT USAGE ON SEQUENCE public.meetbouten_metingen_refereertaanreferentiepunten_v1_id_seq TO write_meetbouten",
         ]
 
         # Check perms on the datasets_dataset table


### PR DESCRIPTION
Major version is added to all table names to allow for multiple versions to co-exist. Django en sqlalchemy tests are fixed to reflect the new situation.