### PR TITLE
Fix db-comments, use native Django 4.2 logic for that

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,10 +82,9 @@ tests =
     pytest-django >= 4.7.0
     pytest-sqlalchemy
 django =
-    django >= 3.2
+    django >= 4.2
     django-gisserver >= 1.2.7
     django-environ
-    django-db-comments
     factory_boy
 dev =
     build  # PEP5127 package builder (recommended by PYPA)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -260,6 +260,7 @@ def _get_basic_kwargs(field: DatasetFieldSchema) -> dict:
         "verbose_name": field.title,
         "help_text": field.description or "",  # also used by OpenAPI spec
         "db_column": field.db_name if field.db_name != field.python_name else None,
+        "db_comment": field.description or None,
     }
 
     if not field.is_primary and field.nm_relation is None:

--- a/tests/django/conftest.py
+++ b/tests/django/conftest.py
@@ -26,7 +26,6 @@ def pytest_configure(config):
             "django.contrib.staticfiles",
             "django.contrib.gis",
             "django.contrib.postgres",
-            "django_db_comments",
             "schematools.contrib.django",
         ],
         DATABASES=databases,


### PR DESCRIPTION
Also django-db-comments requires psycopg2, which would block the upgrade.