### PR TITLE
Remove version number from model name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-03-31 (7.1.2)
+
+* Removed the version name from Django model names to prevent issues in DSO-API. We will need
+  this when we'll implement versioning in the DSO-API, but for now it causes issues.
+
 # 2025-03-27 (7.1.1)
 
 * Removed the .json extension from index files, as this has been changed in amsterdam-schema

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.1.1
+version = 7.1.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -144,7 +144,7 @@ def get_model_name(table_schema: DatasetTableSchema) -> str:
     # Using table_schema.python_name gives UpperCamelCased names, the old format is kept here.
     # This also keeps model names more readable and recognizable/linkable with db table names.
     model_name = to_snake_case(table_schema.id)
-    return f"{model_name}_{table_schema.version.vmajor}"
+    return f"{model_name}"
 
 
 def model_factory(

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -140,7 +140,7 @@ def schema_model_mockers_factory(
 
 
 def get_model_name(table_schema: DatasetTableSchema) -> str:
-    """Returns model name for this table including the version number."""
+    """Returns model name for this table."""
     # Using table_schema.python_name gives UpperCamelCased names, the old format is kept here.
     # This also keeps model names more readable and recognizable/linkable with db table names.
     model_name = to_snake_case(table_schema.id)

--- a/src/schematools/contrib/django/faker/relate.py
+++ b/src/schematools/contrib/django/faker/relate.py
@@ -59,7 +59,7 @@ def relate_datasets(*datasets: Dataset) -> None:
         dataset_schema = dataset.schema
         for table in dataset_schema.tables:
             model = models[dataset_schema.db_name][
-                table.db_name_variant(with_dataset_prefix=False)
+                table.db_name_variant(with_dataset_prefix=False, with_version=False)
             ]
             for f in table.fields:
                 field_name = f.python_name

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -896,7 +896,7 @@ class DatasetVersionSchema(SchemaType):
         available = "', '".join([table["id"] for table in tables])
         raise DatasetTableNotFound(
             f"Table '{table_id}' does not exist "
-            f"in schema '{self.id}', available are: '{available}'"
+            f"in schema '{self._parent_schema.id}', available are: '{available}'"
         )
 
     def _get_tables(self, include_nested: bool = False, include_through: bool = False):

--- a/tests/django/test_mocking.py
+++ b/tests/django/test_mocking.py
@@ -51,7 +51,7 @@ def test_mocking_take_min_max_into_account(
     for cls in schema_models_factory(afvalwegingen_dataset, base_app_name="dso_api.dynamic_api"):
         models[cls._meta.model_name] = cls
 
-    assert models["containertypes_v1"].objects.filter(volume__gt=12, volume__lt=5).count() == 0
+    assert models["containertypes"].objects.filter(volume__gt=12, volume__lt=5).count() == 0
 
 
 @pytest.mark.django_db
@@ -80,9 +80,9 @@ def test_mocking_add_ids_for_relations(
 
     # The relations should be filled with None values
     for dataset_id, table_id, relation_ids in (
-        ("afvalwegingen", "containers_v1", ("cluster", "containertype")),
-        ("afvalwegingen", "clusters_v1", (to_snake_case("bagHoofdadresVerblijfsobject"),)),
-        ("afvalwegingen", "wegingen_v1", ("cluster",)),
+        ("afvalwegingen", "containers", ("cluster", "containertype")),
+        ("afvalwegingen", "clusters", (to_snake_case("bagHoofdadresVerblijfsobject"),)),
+        ("afvalwegingen", "wegingen", ("cluster",)),
     ):
 
         for relation_id in relation_ids:
@@ -96,9 +96,9 @@ def test_mocking_add_ids_for_relations(
 
     # Check if relations are added.
     for dataset_id, table_id, relation_ids in (
-        ("afvalwegingen", "containers_v1", ("cluster", "containertype")),
-        ("afvalwegingen", "clusters_v1", (to_snake_case("bagHoofdadresVerblijfsobject"),)),
-        ("afvalwegingen", "wegingen_v1", ("cluster",)),
+        ("afvalwegingen", "containers", ("cluster", "containertype")),
+        ("afvalwegingen", "clusters", (to_snake_case("bagHoofdadresVerblijfsobject"),)),
+        ("afvalwegingen", "wegingen", ("cluster",)),
     ):
 
         for relation_id in relation_ids:
@@ -132,7 +132,7 @@ def test_mocking_uses_enum(
             afvalwegingen_dataset, base_app_name="dso_api.dynamic_api"
         )
     }
-    mocked_fractie_codes = {o.afvalfractie for o in models["containers_v1"].objects.all()}
+    mocked_fractie_codes = {o.afvalfractie for o in models["containers"].objects.all()}
     all_fractie_codes = {"Rest", "Glas", "Papier", "Plastic", "Textiel"}
     assert all_fractie_codes >= mocked_fractie_codes and mocked_fractie_codes
 
@@ -152,7 +152,7 @@ def test_mocking_add_temporal_fields_for_1n_relations(
 
     relate_datasets(gebieden_dataset)
 
-    for bb in models["bouwblokken_v1"].objects.all():
+    for bb in models["bouwblokken"].objects.all():
         bb.ligt_in_buurt_id = ".".join(
             [
                 bb.ligt_in_buurt_identificatie,
@@ -183,8 +183,8 @@ def test_mocking_adds_nm_relations(
 
     relate_datasets(kadastraleobjecten_dataset)
 
-    source_model = models["kadastraleobjecten_v1"]
-    through_model = models["kadastraleobjecten_is_ontstaan_uit_kadastraalobject_v1"]
+    source_model = models["kadastraleobjecten"]
+    through_model = models["kadastraleobjecten_is_ontstaan_uit_kadastraalobject"]
     through_model_objects = through_model.objects.all()
     source_ids = {o.id for o in source_model.objects.all()}
     through_source_ids = {o.kadastraleobjecten_id for o in through_model_objects}
@@ -220,7 +220,7 @@ def test_mocking_with_shortname_on_relation(gebieden_dataset, gebieden_schema):
     for cls in schema_models_factory(gebieden_dataset, base_app_name="dso_api.dynamic_api"):
         models[cls._meta.model_name] = cls
 
-    fields = {f.name: f for f in models["bouwblokken_v1"]._meta.get_fields()}
+    fields = {f.name: f for f in models["bouwblokken"]._meta.get_fields()}
     # proves both the existence of the (long) fieldname + correct (short) db_column
     assert fields["ligt_in_buurt_met_te_lange_naam"].db_column == "lgt_in_brt_id"
 
@@ -284,7 +284,7 @@ def test_mocking_fills_nested_objects(
         )
     }
 
-    kad_obj = models["kadastraleobjecten_v1"].objects.first()
+    kad_obj = models["kadastraleobjecten"].objects.first()
     # Random value in `soort_grootte` should be a valid json string.
     json.loads(kad_obj.soort_grootte)
 

--- a/tests/django/test_model_mockers.py
+++ b/tests/django/test_model_mockers.py
@@ -30,7 +30,7 @@ def test_model_mocker_factory_registers_a_dynamic_model_in_the_app_config(afval_
     # So we assert that the DynamicModel is indeed registered.
     model_mocker_factory(afval_dataset, table_schema, base_app_name="dso_api.dynamic_api")
     registered_models = [f"{m._meta.app_label}.{m._meta.model_name}" for m in apps.get_models()]
-    assert "afvalwegingen.containers_v1" in registered_models
+    assert "afvalwegingen.containers" in registered_models
 
     # The afval_dataset has two tables (containers, clusters),
     # so we check the second table (i.e. second model) too.
@@ -44,7 +44,7 @@ def test_model_mocker_factory_registers_a_dynamic_model_in_the_app_config(afval_
     registered_models_updated = [
         f"{m._meta.app_label}.{m._meta.model_name}" for m in apps.get_models()
     ]
-    assert "afvalwegingen.clusters_v1" in registered_models_updated
+    assert "afvalwegingen.clusters" in registered_models_updated
 
 
 @pytest.mark.skip(
@@ -121,18 +121,18 @@ def test_schema_model_mockers_factory(afval_dataset):
         cls._meta.get_model_class()._meta.model_name: cls
         for cls in schema_model_mockers_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    assert "containers_v1" in model_mockers
-    ContainersMocker = model_mockers["containers_v1"]
+    assert "containers" in model_mockers
+    ContainersMocker = model_mockers["containers"]
     assert isinstance(ContainersMocker, FactoryMetaClass)
     assert str(ContainersMocker) == (
-        "<containers_v1_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.containers_v1'>>"
+        "<containers_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.containers'>>"
     )
 
-    assert "clusters_v1" in model_mockers
-    ClustersMocker = model_mockers["clusters_v1"]
+    assert "clusters" in model_mockers
+    ClustersMocker = model_mockers["clusters"]
     assert isinstance(ClustersMocker, FactoryMetaClass)
     assert str(ClustersMocker) == (
-        "<clusters_v1_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.clusters_v1'>>"
+        "<clusters_factory for <class 'dso_api.dynamic_api.afvalwegingen.models.clusters'>>"
     )
 
 
@@ -155,7 +155,7 @@ def test_model_mocker_factory_fields(afval_dataset) -> None:
         "kortenaam",
     }
 
-    ContainersMocker = model_mockers["containers_v1"]
+    ContainersMocker = model_mockers["containers"]
     assert {f.name for f in ContainersMocker._meta.get_model_class()._meta.get_fields()} == fields
 
 
@@ -170,8 +170,8 @@ def test_model_mocker_factory_records_count(afval_dataset) -> None:
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    ContainersMocker = model_mockers["containers_v1"]
-    Container = models["containers_v1"]
+    ContainersMocker = model_mockers["containers"]
+    Container = models["containers"]
     # Create the tables for the dataset, to be able te add records to it.
     create_tables(afval_dataset)
     ContainersMocker.create()
@@ -192,8 +192,8 @@ def test_model_mocker_factory_field_types(afval_dataset) -> None:
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    ContainersMocker = model_mockers["containers_v1"]
-    Container = models["containers_v1"]
+    ContainersMocker = model_mockers["containers"]
+    Container = models["containers"]
     # Create the tables for the dataset, to be able te add records to it.
     create_tables(afval_dataset)
     ContainersMocker.create()

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -65,7 +65,7 @@ def test_model_factory_table_name_no_versions(afval_dataset):
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    Containers = models["containers_v1"]
+    Containers = models["containers"]
     assert Containers._meta.db_table == "afvalwegingen_containers_v1"
 
 
@@ -80,9 +80,9 @@ def test_model_factory_table_name_default_version(afval_schema):
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    assert "containers_v1" in models
+    assert "containers" in models
     assert "containers_1_0_1" not in models
-    Containers = models["containers_v1"]
+    Containers = models["containers"]
     assert Containers._meta.db_table == "afvalwegingen_containers_v1"
 
 
@@ -93,9 +93,9 @@ def test_model_factory_relations(afval_dataset):
         cls._meta.model_name: cls
         for cls in schema_models_factory(afval_dataset, base_app_name="dso_api.dynamic_api")
     }
-    cluster_fk = models["containers_v1"]._meta.get_field("cluster")
+    cluster_fk = models["containers"]._meta.get_field("cluster")
     # Cannot compare using identity for dynamically generated classes
-    assert cluster_fk.related_model._table_schema.id == models["clusters_v1"]._table_schema.id
+    assert cluster_fk.related_model._table_schema.id == models["clusters"]._table_schema.id
 
 
 @pytest.mark.django_db
@@ -105,7 +105,7 @@ def test_model_factory_n_m_relations(gebieden_dataset, meetbouten_dataset):
         cls._meta.model_name: cls
         for cls in schema_models_factory(meetbouten_dataset, base_app_name="dso_api.dynamic_api")
     }
-    nm_ref = model_dict["metingen_v1"]._meta.get_field("refereertaanreferentiepunten")
+    nm_ref = model_dict["metingen"]._meta.get_field("refereertaanreferentiepunten")
     assert isinstance(nm_ref, models.ManyToManyField)
 
 
@@ -155,9 +155,9 @@ def test_model_factory_sub_objects(parkeervakken_dataset):
             parkeervakken_dataset, base_app_name="dso_api.dynamic_api"
         )
     }
-    assert "parkeervakken_regimes_v1" in model_dict
+    assert "parkeervakken_regimes" in model_dict
 
-    fields_dict = {f.name: f for f in model_dict["parkeervakken_regimes_v1"]._meta.fields}
+    fields_dict = {f.name: f for f in model_dict["parkeervakken_regimes"]._meta.fields}
     assert "parent" in fields_dict
     assert isinstance(fields_dict["parent"], models.ForeignKey)
 
@@ -173,14 +173,14 @@ def test_model_factory_sub_objects_for_shortened_names(verblijfsobjecten_dataset
     # XXX Change: one field is now nested, the other is changed to a relation
     # Check a relation where the fieldname is intact and one where fieldname is shortened
     model = model_dict[
-        "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_maatschappelijke_activiteit_v1"
+        "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_maatschappelijke_activiteit"
     ]
     fields_dict = {f.name: f for f in model._meta.fields}
 
     # Field is nested, should have a parent field
     assert isinstance(fields_dict["parent"], models.ForeignKey)
 
-    model = model_dict["maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming_v1"]
+    model = model_dict["maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming"]
     fields_dict = {f.name: f for f in model._meta.fields}
 
     # Field is a related, should have 2 FKs to both sides of the relation
@@ -203,7 +203,7 @@ def test_model_factory_temporary_1_n_relation(ggwgebieden_dataset):
         "ligtinstadsdeel_identificatie",
         "ligtinstadsdeel_volgnummer",
     }
-    model_fields = {f.name for f in model_dict["ggwgebieden_v1"]._meta.fields}
+    model_fields = {f.name for f in model_dict["ggwgebieden"]._meta.fields}
     assert model_fields > related_temporary_fields
 
 
@@ -215,7 +215,7 @@ def test_model_factory_temporary_n_m_relation(ggwgebieden_dataset):
         for cls in schema_models_factory(ggwgebieden_dataset, base_app_name="dso_api.dynamic_api")
     }
     # The through table is created
-    through_table_name = "ggwgebieden_bestaatuitbuurten_v1"
+    through_table_name = "ggwgebieden_bestaatuitbuurten"
     assert through_table_name in model_dict
 
     # Through table has refs to both 'sides' and extra fields for the relation
@@ -241,7 +241,7 @@ def test_model_factory_loose_relations(meldingen_dataset, gebieden_dataset):
         cls._meta.model_name: cls
         for cls in schema_models_factory(meldingen_dataset, base_app_name="dso_api.dynamic_api")
     }
-    model_cls = model_dict["statistieken_v1"]
+    model_cls = model_dict["statistieken"]
     meta = model_cls._meta
     assert isinstance(meta.get_field("buurt"), LooseRelationField)
 
@@ -262,7 +262,7 @@ def test_model_factory_loose_relations_n_m_temporeel(woningbouwplannen_dataset, 
             woningbouwplannen_dataset, base_app_name="dso_api.dynamic_api"
         )
     }
-    model_cls = model_dict["woningbouwplan_v1"]
+    model_cls = model_dict["woningbouwplan"]
     meta = model_cls._meta
     buurten_field = meta.get_field("buurten")
     intermediate_table = buurten_field.remote_field.through
@@ -334,7 +334,7 @@ def test_column_shortnames_in_nm_throughtables(verblijfsobjecten_dataset, hr_dat
     }
 
     db_colnames = {"activiteiten_id", "sbi_voor_activiteit_id"}
-    model = model_dict["maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming_v1"]
+    model = model_dict["maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming"]
     assert db_colnames == {f.db_column for f in model._meta.fields if f.db_column is not None}
 
 
@@ -348,7 +348,7 @@ def test_nested_objects_should_never_be_temporal(verblijfsobjecten_dataset):
         )
     }
 
-    assert not model_dict["verblijfsobjecten_gebruiksdoel_v1"].is_temporal()
+    assert not model_dict["verblijfsobjecten_gebruiksdoel"].is_temporal()
 
 
 @pytest.mark.django_db
@@ -368,7 +368,7 @@ def test_temporal_subfields_are_skipped(verblijfsobjecten_dataset):
         )
     }
 
-    begin_geldigheid_field = model_dict["verblijfsobjecten_v1"]._meta.get_field("begin_geldigheid")
+    begin_geldigheid_field = model_dict["verblijfsobjecten"]._meta.get_field("begin_geldigheid")
     assert isinstance(begin_geldigheid_field, DateTimeField)
 
 
@@ -382,7 +382,7 @@ def test_non_composite_string_identifiers_use_slash_constraints(parkeervakken_da
         )
     }
 
-    model = model_dict["parkeervakken_v1"]
+    model = model_dict["parkeervakken"]
 
     with pytest.raises(
         IntegrityError,
@@ -409,7 +409,7 @@ def test_model_factory_sub_object_is_flattened(kadastraleobjecten_dataset):
             kadastraleobjecten_dataset, base_app_name="dso_api.dynamic_api"
         )
     }
-    model_field_names = {f.name for f in model_dict["kadastraleobjecten_v1"]._meta.fields}
+    model_field_names = {f.name for f in model_dict["kadastraleobjecten"]._meta.fields}
     assert {
         "soort_cultuur_onbebouwd_code",
         "soort_cultuur_onbebouwd_omschrijving",
@@ -425,7 +425,7 @@ def test_model_factory_sub_object_is_json(kadastraleobjecten_dataset):
             kadastraleobjecten_dataset, base_app_name="dso_api.dynamic_api"
         )
     }
-    model_fields = {f.name: f for f in model_dict["kadastraleobjecten_v1"]._meta.fields}
+    model_fields = {f.name: f for f in model_dict["kadastraleobjecten"]._meta.fields}
     assert isinstance(model_fields["soort_grootte"], models.JSONField)
 
 


### PR DESCRIPTION
Removed major version number from version name as it causes issues in the DSO-API for now. We will need this once we'll start to support multiple versions of a model, but for now this causes to much required changes in DSO-API.