### PR TITLE
add version_option decorator

### DIFF
--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -136,6 +136,7 @@ def main() -> None:
         exit(1)
 
 
+@click.version_option(package_name="amsterdam-schema-tools")
 @click.group()
 def schema() -> None:
     """Command line utility to work with Amsterdam Schema files."""


### PR DESCRIPTION
Dan kunnen we `schema --version` doen. Handig nu we twee versies onderhouden (6 en 7). 

Commit ook gepusht op `schema-tools-v6` branch