### PR TITLE
Allow strings as path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-04-07 (7.2.2)
+
+* Fix bug in read_json_path.
+
 # 2025-04-03 (7.2.1)
 
 * Add validate-table command to CLI. This will be used in the amsterdam-schema repo to check

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.2.1
+version = 7.2.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/loaders.py
+++ b/src/schematools/loaders.py
@@ -495,8 +495,9 @@ class FileSystemSchemaLoader(_FileBasedSchemaLoader):
         return _read_sql_path(self.root / dataset_path / "dataset.sql")
 
 
-def read_json_path(dataset_file: Path) -> Json:
+def read_json_path(dataset_file: Path | str) -> Json:
     """Load JSON from a path."""
+    dataset_file = Path(dataset_file)  # Path can take both string and Path
     try:
         with dataset_file.open() as stream:
             try:


### PR DESCRIPTION
Dit was erdoorheen geglipt. 

Heb deze versie getest en de github [workflow](https://github.com/Amsterdam/amsterdam-schema/actions/runs/14303082119/job/40080941661) in amsterdam-schema pikt dit wel goed op. 

