### PR TITLE
Add zoom props to DatasetTableSchema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-04-08 (7.3.0)
+
+* Add min_zoom and max_zoom properties to the DatasetTableSchema.
+  This is used to determine when to show which fields in the MVT view.
+
 # 2025-04-07 (7.2.2)
 
 * Fix bug in read_json_path.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.2.2
+version = 7.3.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1107,6 +1107,14 @@ class DatasetTableSchema(SchemaType):
             self.get_field_by_id(field_ids[1]),
         )
 
+    @cached_property
+    def max_zoom(self) -> int:
+        return self.get("zoom", {"max": 30})["max"]
+
+    @cached_property
+    def min_zoom(self) -> int:
+        return self.get("zoom", {"min": 15})["min"]
+
     @property
     def description(self) -> str | None:
         """The description of the table as stated in the schema."""

--- a/tests/files/datasets/gebieden.json
+++ b/tests/files/datasets/gebieden.json
@@ -15,6 +15,10 @@
         "identifier": "volgnummer",
         "dimensions": { "geldigOp": ["beginGeldigheid", "eindGeldigheid"] }
       },
+      "zoom": {
+        "min": 20,
+        "max": 28
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -480,6 +480,18 @@ def test_extra_properties_of_relation_field_are_also_in_through_table(gebieden_s
     ].json_data()["properties"].keys()
 
 
+def test_table_zoom(gebieden_schema: DatasetSchema):
+    bouwblokken = gebieden_schema.get_table_by_id("bouwblokken")
+    buurten = gebieden_schema.get_table_by_id("buurten")
+
+    # bouwblokken has a zoom min and max set
+    assert bouwblokken.min_zoom == 20
+    assert bouwblokken.max_zoom == 28
+    # buurten has no zoom set, and therefore uses the defaults
+    assert buurten.min_zoom == 15
+    assert buurten.max_zoom == 30
+
+
 def test_datasetversions(schema_loader):
     """
     Test dataset versioning results in multiple versions on the dataset and


### PR DESCRIPTION
Zodat we dit gemakkelijk kunnen uitlezen in DSO-API en de velden kunnen bepalen die in de MVT view worden meegegeven bij elk zoomniveau.