### PR TITLE
Autopatch database tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 2025-04-08 (7.5.0)
+
+* Update the import_schemas command so that it also patches the database, as we have added
+  CI-steps that ensure that no breaking changes are introduced before merging to main. A
+  --dry-run flag has been added as well, so that you can inspect the SQL that would be
+  executed before executing it.
+
 # 2025-04-15 (7.4.0)
 
 * Added support to export datasets to GeoJSON

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.4.0
+version = 7.5.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/management/commands/create_tables.py
+++ b/src/schematools/contrib/django/management/commands/create_tables.py
@@ -106,7 +106,7 @@ def create_tables(
                     if not re.search(r'relation "[^"]+" already exists', str(e)):
                         errors += 1
                 else:
-                    command.stdout.write(f"* Creating table {model._meta.db_table}")
+                    command.stdout.write(f"* Created table {model._meta.db_table}")
 
     if errors:
         raise CommandError("Not all tables could be created")

--- a/src/schematools/contrib/django/management/commands/create_views.py
+++ b/src/schematools/contrib/django/management/commands/create_views.py
@@ -100,6 +100,7 @@ def create_views(
     command: BaseCommand,
     datasets: Iterable[Dataset],
     base_app_name: str | None = None,
+    dry_run: bool = False,
 ) -> None:
     """Create views. This is a separate function to allow easy reuse."""
     errors = 0
@@ -139,6 +140,10 @@ def create_views(
                 )
 
                 if _check_required_permissions_exist(view_dataset_auth, required_permissions):
+                    if dry_run:
+                        command.stdout.write("  The following sql would be executed:")
+                        command.stdout.write(f"  {view_sql}")
+                        continue
                     try:
                         with connection.cursor() as cursor:
 

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from django.apps import apps
+from django.core.management import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.migrations import Migration
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.graph import MigrationGraph
+from django.db.migrations.questioner import InteractiveMigrationQuestioner
+from django.db.migrations.state import ModelState, ProjectState
+
+from schematools.contrib.django.factories import model_factory
+from schematools.contrib.django.models import Dataset
+from schematools.types import DatasetTableSchema
+
+
+def migrate(
+    command: BaseCommand,
+    current_dataset: Dataset,
+    updated_dataset: Dataset,
+    current_table: DatasetTableSchema,
+    updated_table: DatasetTableSchema,
+    real_apps: list[str],
+    dry_run: bool = True,
+    database: str = DEFAULT_DB_ALIAS,
+    project_state: ProjectState = None,
+):
+    """
+    Creates a project state for both the current dataset and the updated dataset.
+    """
+    # Generate a full project state that incorporates the table versions
+    # The used Django migration-API calls were inspired by reading
+    # the 'manage.py makemigrations' and 'manage.py sqlmigrate' command changes.
+    command.stdout.write(f"* Processing table {updated_table.id}")
+    base_state = get_base_project_state(command, current_dataset, current_table.id, real_apps)
+    current_state = project_state or get_versioned_project_state(
+        base_state, current_dataset, current_table
+    )
+    updated_state = get_versioned_project_state(base_state, updated_dataset, updated_table)
+
+    # Clear any models from the app cache to avoid confusion
+    del apps.all_models[current_dataset.schema.id]
+    del apps.app_configs[current_dataset.schema.id]
+    apps.clear_cache()
+
+    start_state = current_state
+
+    # Let the migration engine perform its magic, similar to `manage.py makemigrations`:
+    migrations = get_migrations(current_state, updated_state, app_name=current_dataset.schema.id)
+    if not migrations:
+        command.stdout.write(f"  No changes detected for table {current_table.id}")
+        return start_state
+
+    # Generate SQL per migration file, just like `manage.py sqlmigrate` does:
+    connection = connections[database]
+    for _app, app_migrations in migrations.items():
+        for migration in app_migrations:
+            start_state = execute_migration(
+                command, connection, start_state, migration, dry_run=dry_run
+            )
+    return start_state
+
+
+def get_base_project_state(
+    command: BaseCommand, dataset_model: Dataset, exclude_table: str, real_apps: list[str]
+) -> ProjectState:
+    """Generate the common/shared project state.
+
+    This includes all other models of the dataset, as those may be referenced by relations.
+    It excludes the versioned table, since that will differ.
+    """
+    if command.verbosity >= 2:
+        command.stdout.write(f"-- Building shared state for {dataset_model.name}")
+
+    project_state = ProjectState(real_apps=set(real_apps))
+
+    # Generate model states for all other tables in the dataset
+    for table in dataset_model.schema.get_tables(include_nested=True, include_through=True):
+        # Exclude the actual table that changes, including any nested/through tables.
+        if table.id == exclude_table or (
+            table.has_parent_table and table.parent_table.id == exclude_table
+        ):
+            continue
+
+        project_state.add_model(get_model_state(dataset_model, table))
+
+    return project_state
+
+
+def get_versioned_project_state(
+    base_state: ProjectState, dataset_model: Dataset, table: DatasetTableSchema
+) -> ProjectState:
+    """Generate the final project state.
+    This clones the base state, so other related models are only created once.
+    """
+    project_state = base_state.clone()
+    project_state.add_model(get_model_state(dataset_model, table))
+
+    # Add any nested tables and through tables,
+    # that are also part of this table schema.
+    for field in table.fields:
+        if (through_table := field.through_table) is not None:
+            project_state.add_model(get_model_state(dataset_model, through_table))
+        elif (nested_table := field.nested_table) is not None:
+            project_state.add_model(get_model_state(dataset_model, nested_table))
+
+    return project_state
+
+
+def get_model_state(dataset_model: Dataset, table: DatasetTableSchema, managed=True) -> ModelState:
+    """Generate the model state for a table."""
+    # The migration-engine will only consider models that have "managed=True".
+    # This is turned off by default for the model_factory() logic,
+    # and needs to be overwritten here (patching model._meta and its original_attrs is nasty).
+    model_class = model_factory(dataset_model, table, meta_options={"managed": managed})
+
+    # Generate the model. exclude_rels=True because M2M-through tables are generated manually.
+    return PatchedModelState.from_model(model_class, exclude_rels=True)
+
+
+def get_migrations(
+    state1: ProjectState, state2: ProjectState, app_name: str
+) -> dict[str, list[Migration]]:
+    """Generate a migration object for the given table versions."""
+    detector = MigrationAutodetector(
+        from_state=state1,
+        to_state=state2,
+        questioner=InteractiveMigrationQuestioner(specified_apps=[app_name]),
+    )
+    # The dependency graph remains empty here, as we assume all other models are still
+    # in place. We only compare the changes between 2 models of the same table.
+    dependency_graph = MigrationGraph()
+    return detector.changes(
+        dependency_graph,
+        trim_to_apps=[app_name],
+        migration_name=app_name,
+    )
+
+
+def execute_migration(
+    command: BaseCommand,
+    connection: BaseDatabaseWrapper,
+    start_state: ProjectState,
+    migration: Migration,
+    dry_run: bool = True,
+) -> ProjectState:
+    """Print the SQL statements for a migration"""
+    with connection.schema_editor(collect_sql=True, atomic=migration.atomic) as schema_editor:
+        command.stdout.write(f"-- Migration {migration.name} for dataset {migration.app_label}")
+        try:
+            start_state = migration.apply(start_state, schema_editor, collect_sql=True)
+        except Exception:
+            # On crashes, still show the generated statements so far
+            command.stdout.write("\n".join(schema_editor.collected_sql))
+            raise
+        if dry_run:
+            command.stdout.write("-- DRY RUN - the following would be executed:")
+            command.stdout.write("\n".join(schema_editor.collected_sql))
+        else:
+            schema_editor.collect_sql = False
+            schema_editor.execute("\n".join(schema_editor.collected_sql))
+    return start_state
+
+
+class PatchedModelState(ModelState):
+    """A workaround to avoid breaking migration rendering."""
+
+    def clone(self):
+        """Return an exact copy of this ModelState."""
+        # Workaround for Django issue. The fields get bound to a model during the first
+        # migration operation, which breaks reusing them in migrations.
+        # Quick fix is to deep-clone the fields too:
+        self.fields = {name: field.clone() for name, field in self.fields.items()}
+        return super().clone()

--- a/tests/django/test_schema_import.py
+++ b/tests/django/test_schema_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from django.core.management import call_command
+from django.db import connection
 
 from schematools.contrib.django import models
 
@@ -21,12 +22,96 @@ def test_import_schema(here):
 @pytest.mark.django_db
 def test_import_schema_twice(here):
     """Prove that importing a dataset schema twice does not fail"""
+    verblijfsobjecten = here / "files/datasets/verblijfsobjecten.json"
+    gebieden = here / "files/datasets/gebieden.json"
     hr_json_path = here / "files/datasets/hr.json"
-    args = [hr_json_path]
+    args = [hr_json_path, verblijfsobjecten, gebieden]
     call_command("import_schemas", *args)
     call_command("import_schemas", *args)
-    assert models.Dataset.objects.count() == 1
-    assert models.Dataset.objects.first().name == "hr"
+    assert models.Dataset.objects.count() == 3
+    assert models.Dataset.objects.get(name="hr") is not None
+
+
+@pytest.mark.django_db()
+def test_import_schema_update_runs_migrations(here):
+    """Prove that importing a dataset schema twice does not fail"""
+    verblijfsobjecten = here / "files/datasets/verblijfsobjecten.json"
+    gebieden = here / "files/datasets/gebieden.json"
+    hr_json_path = here / "files/datasets/hr.json"
+    call_command(
+        "import_schemas",
+        gebieden,
+        verblijfsobjecten,
+        hr_json_path,
+        create_tables=1,
+        create_views=1,
+    )
+    activiteiten_table = models.DatasetTable.objects.get(name="maatschappelijkeactiviteiten")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""SELECT
+                column_name
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = '{activiteiten_table.db_table}'
+            """
+        )
+        columns = [col for row in cursor.fetchall() for col in row]
+        assert "activiteit_type" not in columns
+
+    updated_hr_json_path = here / "files/datasets/hr_updated.json"
+    call_command("import_schemas", updated_hr_json_path, gebieden, verblijfsobjecten, verbosity=3)
+    activiteiten_table = models.DatasetTable.objects.get(name="maatschappelijkeactiviteiten")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""SELECT
+                column_name
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = '{activiteiten_table.db_table}'
+            """
+        )
+        columns = [col for row in cursor.fetchall() for col in row]
+        assert "activiteit_type" in columns
+
+
+@pytest.mark.django_db()
+def test_import_schema_update_has_dry_run(here, capsys):
+    """Prove that importing a dataset schema twice does not fail"""
+    verblijfsobjecten = here / "files/datasets/verblijfsobjecten.json"
+    gebieden = here / "files/datasets/gebieden.json"
+    hr_json_path = here / "files/datasets/hr.json"
+    call_command(
+        "import_schemas",
+        gebieden,
+        verblijfsobjecten,
+        hr_json_path,
+        create_tables=1,
+        create_views=1,
+    )
+    updated_hr_json_path = here / "files/datasets/hr_updated.json"
+    call_command("import_schemas", updated_hr_json_path, gebieden, verblijfsobjecten, "--dry-run")
+    activiteiten_table = models.DatasetTable.objects.get(name="maatschappelijkeactiviteiten")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""SELECT
+                column_name
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = '{activiteiten_table.db_table}'
+            """
+        )
+        columns = [col for row in cursor.fetchall() for col in row]
+        assert "activiteit_type" not in columns
+    captured = capsys.readouterr()
+    assert "DRY RUN" in captured.out
+    assert (
+        """ALTER TABLE "hr_activiteiten_v1" ADD COLUMN "activiteit_type" varchar NULL;"""
+        in captured.out
+    )
 
 
 @pytest.mark.django_db

--- a/tests/files/datasets/hr_updated.json
+++ b/tests/files/datasets/hr_updated.json
@@ -1,0 +1,117 @@
+{
+  "type": "dataset",
+  "id": "hr",
+  "title": "hr",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "auth": "HR/R",
+  "tables": [
+    {
+      "id": "maatschappelijkeactiviteiten",
+      "shortname": "activiteiten",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/hr/maatschappelijke_activiteiten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "kvknummer",
+        "required": ["schema", "kvknummer"],
+        "display": "kvknummer",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "kvknummer": {
+            "type": "string",
+            "description": "Betreft het identificerende gegeven voor de Maatschappelijke Activiteit, het KvK-nummer."
+          },
+          "heeftSbiActiviteitenVoorMaatschappelijkeActiviteit": {
+            "type": "array",
+            "shortname": "sbiMaatschappelijk",
+            "items": {
+              "type": "object",
+              "properties": { "bronwaarde": { "type": "integer" } }
+            },
+            "description": "De omschrijving van de activiteiten die de maatschappelijke activiteit uitoefent."
+          },
+          "heeftSbiActiviteitenVoorOnderneming": {
+            "shortname": "sbiVoorActiviteit",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": { "sbiActiviteitNummer": { "type": "integer" } }
+            },
+            "relation": "hr:sbiactiviteiten",
+            "description": "De omschrijving van de activiteiten die de onderneming uitoefent."
+          },
+          "wordtUitgeoefendInCommercieleVestiging": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": { "bronwaarde": { "type": "integer" } }
+            },
+            "$comment": "relation hr:vestigingen",
+            "description": "Een vestiging is gebouw of een complex van gebouwen waar duurzame uitoefening van activiteiten van een Onderneming of Rechtspersoon plaatsvindt."
+          },
+          "heeftEenRelatieMetVerblijfsobject": {
+            "type": "array",
+            "shortname": "verblijfsobjecten",
+            "items": {
+              "type": "object",
+              "properties": {
+                "identificatie": { "type": "string" },
+                "volgnummer": { "type": "integer" }
+              }
+            },
+            "relation": "verblijfsobjecten:verblijfsobjecten",
+            "description": "Relatie naar verblijfsobject",
+            "$comment": "This is a fictional relation, added for testing purposes"
+          },
+          "isGevestigdInVerblijfsobject": {
+            "type": "object",
+            "shortname": "gevestigdIn",
+            "properties": {
+              "identificatie": { "type": "string" },
+              "volgnummer": { "type": "integer" },
+              "beginGeldigheid": { "type": "string", "format": "date-time" }
+            },
+            "relation": "verblijfsobjecten:verblijfsobjecten",
+            "description": "Relatie naar verblijfsobject",
+            "$comment": "This is a fictional relation, added for testing purposes"
+          },
+          "activiteitType": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "sbiactiviteiten",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/hr/sbiactiviteiten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "sbiActiviteitNummer",
+        "required": ["schema", "sbiActiviteitNummer"],
+        "display": "sbiActiviteitNummer",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "sbiActiviteitNummer": {
+            "type": "string",
+            "shortname": "sbiActNr",
+            "description": "Samenstelling van KvK-nummer en/of Vestigingsnummer of {BSN- of RSIN-nummer}"
+          }
+        }
+      }
+    }
+  ],
+  "publisher": "unknown"
+}


### PR DESCRIPTION
Dit loopt over alle datasets heen en past de database tabellen aan indien nodig. Een eerdere validatiestap zorgt ervoor dat alleen branches gemerged worden die zorgen dat de alters backwards compatible zijn (i.e. alleen kolommen toevoegen). 
 * --dry-run flag toegevoegd op het import_schemas commando
 * logica van sqlmigrate_schema commando herbruikt => staat nu in migration_helpers.py
 * een test voor --dry-run en voor de alters toegevoegd
 * versie naar 7.5
 * schoont de output/logs op: fixt 81710

NB: dit doet nog geen drop&replace voor de tabellen die op experimental staan.
