### PR TITLE
ignore schema prop in table validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-04-23 (7.5.2)
+
+* Ignore the table's `schema` property in table validation. This is a property that is not
+  persisted and therefore cannot introduce breaking changes.
+
 # 2025-04-23 (7.5.1)
 
 * Fixed bug in geojson exporter where decimals were not exported correctly.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.5.1
+version = 7.5.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -575,6 +575,7 @@ def _check_lifecycle_status(dataset: DatasetSchema) -> Iterator[str]:
 
 
 PROPERTIES_INTRODUCING_BREAKING_CHANGES = ["type", "$ref", "format", "relation", "enum"]
+IGNORED_FIELDS = ["schema"]  # This is not a database column.
 
 
 def validate_table(
@@ -597,6 +598,9 @@ def validate_table(
     table_errors = []
     current_object_path = object_path
     for previous_field_name, previous_field in previous_fields.items():
+        if previous_field_name in IGNORED_FIELDS:
+            continue
+
         column_name = parent_field or previous_field_name
 
         # check if field is deleted

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -389,6 +389,20 @@ def test_check_lifecycle_status(schema_loader) -> None:
         ({"name": {"type": "string"}}, {"name": {"type": "string"}}, []),
         # Deleted field
         ({"name": {"type": "string"}}, {}, ["Column name would be deleted."]),
+        # Changed schema ref
+        (
+            {
+                "schema": {
+                    "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+                }
+            },
+            {
+                "schema": {
+                    "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+                }
+            },
+            [],
+        ),
         # Changed array item type
         (
             {"list": {"type": "array", "items": {"type": "string"}}},


### PR DESCRIPTION
Tables hebben een schema $ref, die door het script van Jasper voor het omschrijven van de dataset + tabellen naar v3 omgezet worden naar de laatste versie. Dit moet kunnen, omdat deze prop niet in de db terechtkomt, dus we skippen checks op deze property. 

Validatie van de ref zelf gebeurt elders al. 