### PR TITLE
Error handling v3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-04-24 (7.5.6)
+
+* Ignore some errors in batch_validate due to existing db structure.
+
 # 2025-04-24 (7.5.5)
 
 * Fixed connection string issue in geopackage exporter

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.5.5
+version = 7.5.6
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)


### PR DESCRIPTION
Deze errors voorkomen dat we de datasets kunnen updaten naar v3. Voor nu deze negeren, aangezien de bestaande database tabellen uitgaan van de verkeerde gegevens. 