### PR TITLE
Create tables for all dataset versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
+# 2025-05-08 (7.7.0)
+
+* Create tables for all versions of a dataset.
+
 # 2025-05-08 (7.6.4)
+
 * Remove ALTER COLUMN statements from generated migrations, to prevent issues with our views.
 
 # 2025-04-30 (7.6.3)
+
 * Ensure all roles are created, not just the ones that have grants associated with them.
 
 # 2025-04-29 (7.6.2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.6.4
+version = 7.7.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -121,7 +121,7 @@ def schema_models_factory(
             base_app_name=base_app_name,
             base_model=base_model,
         )
-        for table in dataset.schema.get_tables(include_nested=True, include_through=True)
+        for table in dataset.schema.get_all_tables(include_nested=True, include_through=True)
         if tables is None or table.id in tables
     ]
 
@@ -134,7 +134,7 @@ def schema_model_mockers_factory(
     """Generate Django model mockers from the data of the schema."""
     return [
         model_mocker_factory(dataset=dataset, table_schema=table, base_app_name=base_app_name)
-        for table in dataset.schema.get_tables(include_nested=True, include_through=True)
+        for table in dataset.schema.get_all_tables(include_nested=True, include_through=True)
         if tables is None or table.id in tables
     ]
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -578,6 +578,19 @@ class DatasetSchema(SchemaType):
         publisher_id = raw_publisher["$ref"].split("/")[-1]
         return self.loader.get_publisher(publisher_id)
 
+    def get_all_tables(
+        self, include_nested: bool = False, include_through: bool = False
+    ) -> list[DatasetTableSchema]:
+        tables = {}
+        for _, version in self.versions.items():
+            version_tables = version.get_tables(
+                include_nested=include_nested, include_through=include_through
+            )
+            for table in version_tables:
+                if table.db_name not in tables:
+                    tables[table.db_name] = table
+        return tables.values()
+
     def get_tables(
         self,
         version: str | None = None,


### PR DESCRIPTION
Dit zou de tabellen moeten aanmaken voor alle versies, ook de experimentele.

- alleen handmatig getest op lokale db
- nog geen drop/replace