### PR TITLE
Add flag to schema_model_factory to create versioned tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-05-08 (7.7.2)
+
+* Add flag to schema_model_factory to create all tables. This way we can use it in create_tables, but
+  not break the DSO-API.
+
 # 2025-05-08 (7.7.1)
 
 * Fix datasets path in validate schemas

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.7.1
+version = 7.7.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -112,8 +112,14 @@ def schema_models_factory(
     tables: Collection[str] | None = None,
     base_app_name: str | None = None,
     base_model: type[M] = DynamicModel,
+    include_versioned_tables: bool = False,
 ) -> list[type[M]]:
     """Generate Django models from the data of the schema."""
+    # Return versioned tables when specifically requested. Used for now so we can
+    # create experimental tables as well
+    get_table_function = (
+        dataset.schema.get_all_tables if include_versioned_tables else dataset.schema.get_tables
+    )
     return [
         model_factory(
             dataset=dataset,
@@ -121,7 +127,7 @@ def schema_models_factory(
             base_app_name=base_app_name,
             base_model=base_model,
         )
-        for table in dataset.schema.get_all_tables(include_nested=True, include_through=True)
+        for table in get_table_function(include_nested=True, include_through=True)
         if tables is None or table.id in tables
     ]
 
@@ -134,7 +140,7 @@ def schema_model_mockers_factory(
     """Generate Django model mockers from the data of the schema."""
     return [
         model_mocker_factory(dataset=dataset, table_schema=table, base_app_name=base_app_name)
-        for table in dataset.schema.get_all_tables(include_nested=True, include_through=True)
+        for table in dataset.schema.get_tables(include_nested=True, include_through=True)
         if tables is None or table.id in tables
     ]
 

--- a/src/schematools/contrib/django/management/commands/create_tables.py
+++ b/src/schematools/contrib/django/management/commands/create_tables.py
@@ -56,7 +56,11 @@ def create_tables(
         if not dataset.enable_db or dataset.name in to_be_skipped:
             continue  # in case create_tables() is called by import_schemas
 
-        models.extend(schema_models_factory(dataset, base_app_name=base_app_name))
+        models.extend(
+            schema_models_factory(
+                dataset, base_app_name=base_app_name, include_versioned_tables=True
+            )
+        )
 
     # Grouping multiple versions of same model by table name
     models_by_table = defaultdict(list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,6 +404,11 @@ def woningbouwplannen_schema(schema_loader, gebieden_schema) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("woningbouwplannen.json")
 
 
+@pytest.fixture
+def metaschemav3_schema(schema_loader, gebieden_schema) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("metaschemav3/dataset.json")
+
+
 @pytest.fixture()
 def profile_loader(here) -> FileSystemProfileLoader:
     return FileSystemProfileLoader(here / "files/profiles")

--- a/tests/django/fixtures.py
+++ b/tests/django/fixtures.py
@@ -134,3 +134,9 @@ def verblijfsobjecten_dataset(verblijfsobjecten_schema: DatasetSchema) -> Datase
 def woningbouwplannen_dataset(woningbouwplannen_schema: DatasetSchema) -> Dataset:
     """Create Woning Bouw Plannen dataset."""
     return Dataset.create_for_schema(woningbouwplannen_schema)
+
+
+@pytest.fixture
+def metaschemav3_dataset(metaschemav3_schema: DatasetSchema) -> Dataset:
+    """Create Metaschema v3 dataset."""
+    return Dataset.create_for_schema(metaschemav3_schema)

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -87,6 +87,20 @@ def test_model_factory_table_name_default_version(afval_schema):
 
 
 @pytest.mark.django_db
+def test_model_factory_versioned_tables(metaschemav3_dataset):
+    """Prove that versioned tables can be created"""
+    table_names = [
+        cls._meta.db_table
+        for cls in schema_models_factory(
+            metaschemav3_dataset,
+            base_app_name="dso_api.dynamic_api",
+            include_versioned_tables=True,
+        )
+    ]
+    assert table_names == ["metaschema_3_table_v0", "metaschema_3_table_v1"]
+
+
+@pytest.mark.django_db
 def test_model_factory_relations(afval_dataset):
     """Prove that relations between models can be resolved"""
     models = {

--- a/tests/files/datasets/metaschemav3/dataset.json
+++ b/tests/files/datasets/metaschemav3/dataset.json
@@ -2,6 +2,7 @@
   "id": "metaschema3",
   "type": "dataset",
   "status": "beschikbaar",
+  "publisher": "unknown",
   "defaultVersion": "v1",
   "versions": {
     "v0": {


### PR DESCRIPTION
The new gat_all_tables functions introduced to be able to create multiple versions of a table caused issues in DSO API. I've added a flag to specifically request versioned tables used in create_tables only for now.