### PR TITLE
Migrate schema data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-05-28 (8.0.0-rc4)
+
+* Inline all tables in a migration, so that when DSO starts up, the versioned
+  datasets have all necessary data in the database.
+
 # 2025-05-08 (8.0.0-rc3)
 
 * Make import schemas atomic and fix empty migrations.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 8.0.0-rc3
+version = 8.0.0-rc4
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/migrations/0022_inline_tables_for_all_versions_in_schema_data.py
+++ b/src/schematools/contrib/django/migrations/0022_inline_tables_for_all_versions_in_schema_data.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+
+from django.db import migrations
+
+from schematools import DEFAULT_SCHEMA_URL
+from schematools.loaders import get_schema_loader
+from schematools.types import DatasetSchema
+
+
+def fill_schema_data(apps, schema_editor):
+    Dataset = apps.get_model("datasets", "Dataset")
+    loader = get_schema_loader(DEFAULT_SCHEMA_URL)
+    for dataset in Dataset.objects.all():
+        schema = DatasetSchema.from_dict(
+            json.loads(dataset.schema_data),
+            loader=loader,
+        )
+        dataset.schema_data = schema.json(
+            inline_tables=True, inline_publishers=True, inline_scopes=True
+        )
+        dataset.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("datasets", "0021_remove_dataset_is_default_version_and_more"),
+    ]
+
+    operations = [migrations.RunPython(fill_schema_data, reverse_code=migrations.RunPython.noop)]


### PR DESCRIPTION
Dit voorkomt dat we ontbrekende schema_data hebben als we DSO opstarten met schematools v8