### PR TITLE
Make factory version aware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2025-06-05 (8.0.0-rc5)
+
+* Create a DjangoModelFactory class that keeps track of the version, so relations are resolved
+  correctly for each version.
+
 # 2025-05-28 (8.0.0-rc4)
 
 * Inline all tables in a migration, so that when DSO starts up, the versioned

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 8.0.0-rc4
+version = 8.0.0-rc5
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -17,7 +17,7 @@ from schematools import SRID_3D
 from schematools.contrib.django import app_config, signals
 from schematools.contrib.django.fields import UnlimitedCharField
 from schematools.naming import to_snake_case
-from schematools.types import DatasetFieldSchema, DatasetTableSchema
+from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema
 
 from .mockers import DynamicModelMocker
 from .models import (
@@ -105,6 +105,353 @@ def remove_dynamic_models() -> None:
 def is_dangling_model(model: type[DynamicModel]) -> bool:
     """Tell whether the model should have been removed, as everything reloaded."""
     return model.CREATION_COUNTER < MODEL_CREATION_COUNTER
+
+
+class DjangoModelFactory:
+    """Thic class builds the Django models while continuously being aware of the dataset versions
+
+    Encapsulates the logic of the legacy factory functions below. # TODO: REMOVE
+    Since relations need to be aware of which version of the dataset it relates to, we must keep
+    track of the version and walk over the tree of tables in each version.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        base_app_name: str = "dso_api.dynamic_api",
+        base_model: type[M] = DynamicModel,
+    ):
+        self.dataset = dataset
+        self.schema: DatasetSchema = dataset.schema
+        self.base_model = base_model
+        self.base_app_name = base_app_name
+        self.models = []
+        self._current_version: str | None = None
+
+    def build_models(self) -> list[type[M]]:
+        """Main entrypoint, creates a list of django models for a dataset.
+
+        Ensures relations are built properly between versions.
+        """
+        for vmajor, version in self.schema.versions.items():
+            self._current_version = vmajor
+            for table in version.get_tables(include_nested=True, include_through=True):
+                self.models.append(self.build_model(table))
+
+        return self.models
+
+    def build_model(
+        self, table_schema: DatasetTableSchema, meta_options: dict[str, Any] | None = None
+    ) -> type[M]:
+        """Generate a Django model class from a JSON Schema definition."""
+        app_label = self.schema.id
+        module_name = f"{self.base_app_name}.{app_label}.models"
+        is_temporal = table_schema.is_temporal
+        display_field = table_schema.display_field
+
+        # Generate fields
+        fields = {}
+        constraints = []
+
+        for field in table_schema.get_fields(include_subfields=True):
+            # skip schema field for now
+            # skip nested tables and fields that are only added for temporality
+            if (
+                field.type.endswith("definitions/schema")
+                or field.is_nested_table
+                or field.is_temporal_range
+            ):
+                continue
+
+            model_field = self._model_field_factory(field)
+
+            model_field.name = field.python_name  # Generate name, fix if needed.
+            model_field.field_schema = field  # avoid extra lookups.
+            fields[model_field.name] = model_field
+
+            # Non-composite string identifiers may not contain forwardslashes, since this
+            # breaks URL matching when they are used in URL paths.
+            if field.is_primary and field.type == "string":
+                # To make sure OneToOneField relations also support the '__contains' lookup,
+                # that lookup type is registered with this field class in apps.py.
+                constraints.append(
+                    CheckConstraint(
+                        check=~Q(**{f"{model_field.name}__contains": "/"}),
+                        name=f"{table_schema.db_name}_{self._current_version}_{field.db_name}_not_contains_slash",
+                    )
+                )
+
+        # Generate Meta part
+        meta_cls = type(
+            "Meta",
+            (),
+            {
+                "managed": False,
+                "db_table": table_schema.db_name,
+                "app_label": app_label,
+                "verbose_name": (table_schema.title or table_schema.id).capitalize(),
+                "ordering": [idf.python_name for idf in table_schema.identifier_fields],
+                "constraints": constraints,
+                **(meta_options or {}),
+            },
+        )
+        dataset_versions = (
+            [self._current_version]
+            if table_schema.is_through_table
+            else [v.version for v in self.schema.versions.values() if table_schema in v.tables]
+        )
+        model_class = ModelBase(
+            self.get_model_name(table_schema),
+            (self.base_model,),
+            {
+                **fields,
+                "__doc__": table_schema.description or "",
+                "_dataset": self.dataset,
+                "_dataset_versions": dataset_versions,
+                "_table_schema": table_schema,
+                "_dataset_schema": self.schema,
+                "_display_field": (
+                    display_field.python_name if display_field is not None else None
+                ),
+                "_is_temporal": is_temporal,
+                "CREATION_COUNTER": MODEL_CREATION_COUNTER,  # for debugging recreation
+                "__module__": module_name,
+                "Meta": meta_cls,
+            },
+        )
+
+        app_config.register_model(app_label, model_class)
+        return model_class
+
+    def get_model_name(self, table_schema: DatasetTableSchema) -> str:
+        """Returns model name for this table.
+
+        In case of relations, this will use the _current_version if the dataset matches,
+        otherwise we use the default version of the target dataset.
+
+        NB: The version suffix is the dataset version, not the table version. This is
+        currently this way, because using it as a prefix prevents OpenAPI from detecting
+        the paths in a dataset.
+        """
+        # Using table_schema.python_name gives UpperCamelCased names, the old format is kept here.
+        # This also keeps model names more readable and recognizable/linkable with db table names.
+        model_name = to_snake_case(table_schema.id)
+        if table_schema.schema.id == self.schema.id:
+            return f"{model_name}_{self._current_version}"
+        else:
+            return f"{model_name}_{table_schema.schema.default_version}"
+
+    def _model_field_factory(self, field: DatasetFieldSchema) -> models.Field:
+        """Construct the Django model field for a schema field."""
+        if field.relation:
+            return self._fk_field_factory(field)
+        elif field.nm_relation:
+            return self._nm_field_factory(field)
+        else:
+            return self._basic_field_factory(field)
+
+    def _get_model_field_class(self, field: DatasetFieldSchema) -> type[models.Field]:
+        type_ = field.type
+        # reduce amsterdam schema refs to their fragment
+        # only relevant for `/definitions/id` types atm.
+        if type_.startswith(settings.SCHEMA_DEFS_URL):
+            type_ = urlparse(type_).fragment
+
+        try:
+            return JSON_TYPE_TO_DJANGO[field.format or type_]
+        except KeyError as e:
+            raise RuntimeError(
+                f"Field '{field.qualified_id}' has unsupported type: {type_}."
+            ) from e
+
+    def _get_basic_kwargs(self, field: DatasetFieldSchema) -> dict:
+        """Common model field kwargs for all field types."""
+        kwargs = {
+            "primary_key": field.is_primary,
+            "verbose_name": field.title,
+            "help_text": field.description or "",  # also used by OpenAPI spec
+            "db_column": field.db_name if field.db_name != field.python_name else None,
+            "db_comment": field.description or None,
+        }
+
+        if not field.is_primary and field.nm_relation is None:
+            # Primary can not be Null
+            kwargs["null"] = not field.required
+
+        return kwargs
+
+    def _basic_field_factory(self, field: DatasetFieldSchema) -> models.Field:
+        """Construct a Django model field for a basic field type."""
+        field_cls = self._get_model_field_class(field)
+        kwargs = self._get_basic_kwargs(field)
+
+        if issubclass(field_cls, ArrayField):
+            # Array field
+            item_type = field.get("entity", {}).get("type", "string")
+            kwargs["base_field"] = JSON_TYPE_TO_DJANGO[item_type]()
+
+        if issubclass(field_cls, gis_models.GeometryField):
+            # Geometry field specials
+            kwargs.update(
+                {
+                    "srid": field.srid,
+                    "dim": (3 if field.srid in SRID_3D else 2),
+                    "geography": False,
+                    "db_index": True,
+                }
+            )
+
+        return field_cls(**kwargs)
+
+    def _fk_field_factory(self, field: DatasetFieldSchema) -> models.ForeignKey:
+        """Generate a Django ForeignKey field for a schema 1N relation field.
+
+        This also takes composite-key relations into account,
+        and "loose relations" where the field only references
+        one part of the composite relation
+        """
+        to_field = self._get_fk_to_field(field)
+        kwargs = {
+            "to": f"{field.related_table.dataset.id}.{self.get_model_name(field.related_table)}",
+            **self._get_basic_kwargs(field),
+            "on_delete": models.CASCADE if field.required else models.SET_NULL,
+            "db_column": field.db_name,
+            "db_constraint": False,  # don't enforce on database, not feasible for many datasets.
+            "related_name": self._get_fk_related_name(field),
+        }
+
+        if field.is_composite_key:
+            # Make it easier to recognize the keys, e.g. in ``manage.py dump_models``.
+            # For the most part, this is a tagging interface class.
+            field_cls = CompositeForeignKeyField
+            kwargs["to_fields"] = [field.python_name for field in field.related_fields]
+        elif field.is_primary:
+            # A primary key with a relation is typically a OneToOneField.
+            # For a field named "id", using db_column="id" will work to retrieve the field there.
+            # Internally, Django will still add an "id_id" field to the model to access the
+            # raw value.
+            field_cls = models.OneToOneField
+            kwargs["primary_key"] = (
+                True  # Note Django will use an INNER JOIN to retrieve the model.
+            )
+            # Not using 'kwargs["parent_link"] = True', as model inheritance is not used here.
+        elif field.is_loose_relation or to_field:
+            # Points to the first part of a composite key (e.g. "identificatie").
+            field_cls = LooseRelationField
+            kwargs["to_field"] = to_field.python_name
+        else:
+            field_cls = models.ForeignKey
+
+        return field_cls(**kwargs)
+
+    def _get_fk_related_name(self, field: DatasetFieldSchema) -> str:
+        """Determine the name of the backwards relationship.
+
+        If the linked table describes the other end of the relationship,
+        this field will also be included in the model.
+        """
+        parent_table = field.table
+        if parent_table.is_nested_table:
+            # Won't ever show related name for internal tables
+            return to_snake_case(parent_table["originalID"])
+        elif parent_table.is_through_table:
+            dataset_name = parent_table.dataset.db_name
+            # This provides a reverse-link from each FK in the M2M table to the linked tables,
+            # allowing to walk *inside* the M2M table instead of over it.
+            # For debugging purposes these names are clarified depending on what direction
+            # the key takes.
+            m2m_field = parent_table.parent_table_field
+            through_fields = parent_table["throughFields"]
+            if field.name == through_fields[0]:
+                # First model, can resemble the original field name,
+                return f"{dataset_name}_rev_m2m_{to_snake_case(m2m_field.name)}"
+            elif field.name == through_fields[1]:
+                # Second model, can resemble the reverse name if it exists.
+                m2m_reverse_name = m2m_field.reverse_relation
+                if m2m_reverse_name is not None:
+                    # As the field exists on the second model,
+                    # let the reverse relation also reflect that.
+                    return f"{dataset_name}_rev_m2m_{to_snake_case(m2m_reverse_name.id)}"
+
+            # By default, create something unique and recognizable.
+            # The "m2m" would be snake_cased as m_2_m, so it's added afterwards.
+            # The parent table ID already has the main field name included, but for tables
+            # with a self-reference, the field is still added to guarantee uniqueness.
+            return f"{dataset_name}_rev_m2m_" + to_snake_case(f"{parent_table.id}_via_{field.id}")
+        elif (additional_relation := field.reverse_relation) is not None:
+            # The relation is described by the other table, return it
+            return additional_relation.id
+        else:
+            # Hide it as relation.
+            # Note that for M2M relations, Django will replace this with "_tablename_fieldname_+",
+            # as Django still uses the backwards relation internally.
+            return "+"
+
+    def _get_fk_to_field(self, field: DatasetFieldSchema) -> DatasetFieldSchema | None:
+        """Determine the "to_field" for the foreign key.
+
+        This returns a value when the relation doesn't point to the targets's primary key,
+        hence the "to_field" parameter is needed.
+
+        The current implementation only works for the right-side of N-M relations at the moment,
+        other relation types are still created as a loose relation field.
+        """
+        if (
+            # HACK: This complicated logic is needed because self.field.is_loose_relation
+            # has very mixed-up logic that handles things which the callers should have handled.
+            # This makes it impossible to determine whether a through-table has loose relations.
+            # Solving that turns out to be really complex and bring up more issues. However,
+            # reading the NM-field does work, so at least one side of the relation can be fixed.
+            (nm_field := field.table.parent_table_field) is not None
+            and nm_field.is_loose_relation
+            and field.id == field.table["throughFields"][1]
+        ):
+            # A FK in the through table might actually be a partial composite key.
+            # When this is the case, make sure the to_field points to the right field.
+            target_fields = nm_field.related_fields
+
+            if target_fields[0].id != "id" and not target_fields[0].is_primary:
+                return target_fields[0]
+        elif field.is_loose_relation:
+            # Loose relation points to the first field of a composite foreign key
+            return field.related_table.identifier_fields[0]
+
+        return None
+
+    def _nm_field_factory(self, field: DatasetFieldSchema) -> models.ManyToManyField:
+        """Generate a Django ManyToManyField for the NM-relation.
+
+        NOTE: this still generates a regular M2M relation for "loose m2m relations".
+        """
+        # TODO: this doesn't really take loose relations into account.
+        # In practice, the schematools still has 2 regular foreignkey pairs,
+        # # but also includes subfields for the composite key field.
+        field_cls = (
+            LooseRelationManyToManyField if field.is_loose_relation else models.ManyToManyField
+        )
+        through_table = field.through_table
+        through_fields = [f.python_name for f in through_table.through_fields]
+
+        if (additional_relation := field.reverse_relation) is not None:
+            # The relation is described by the other table, return it
+            related_name = additional_relation.id
+        else:
+            # Default: give it a name, but hide it as relation.
+            # This becomes the models.ManyToManyRel field on the target model.
+            related_name = f"rev_{field.table.python_name}_{field.python_name}+"
+
+        kwargs = {
+            "to": f"{field.related_table.dataset.id}.{self.get_model_name(field.related_table)}",
+            **self._get_basic_kwargs(field),
+            "related_name": related_name,
+            "through": f"{through_table.dataset.id}.{self.get_model_name(through_table)}",
+            "through_fields": through_fields,
+        }
+
+        return field_cls(**kwargs)
+
+
+# Legacy factory functions below
 
 
 def schema_models_factory(

--- a/src/schematools/contrib/django/models.py
+++ b/src/schematools/contrib/django/models.py
@@ -354,17 +354,18 @@ class Dataset(models.Model):
         include_versioned_tables: bool = False,
     ) -> list[type[M]]:
         """Extract the models found in the schema"""
-        from schematools.contrib.django.factories import schema_models_factory
-
         if not self.enable_db:
             return []
         else:
-            return schema_models_factory(
+            # Prevent circular import
+            from schematools.contrib.django.factories import DjangoModelFactory
+
+            factory = DjangoModelFactory(
                 self,
                 base_app_name=base_app_name,
                 base_model=base_model,
-                include_versioned_tables=include_versioned_tables,
             )
+            return factory.build_models()
 
 
 class DatasetVersion(models.Model):

--- a/tests/django/test_models.py
+++ b/tests/django/test_models.py
@@ -7,7 +7,11 @@ from django.db import IntegrityError, connection
 from django.db.models.base import ModelBase
 from django.db.models.fields import DateTimeField
 
-from schematools.contrib.django.factories import model_factory, schema_models_factory
+from schematools.contrib.django.factories import (
+    DjangoModelFactory,
+    model_factory,
+    schema_models_factory,
+)
 from schematools.contrib.django.fields import UnlimitedCharField
 from schematools.contrib.django.models import (
     Dataset,
@@ -15,6 +19,363 @@ from schematools.contrib.django.models import (
     LooseRelationField,
     LooseRelationManyToManyField,
 )
+
+
+class TestDjangoModelFactory:
+    @pytest.mark.django_db
+    def test_model_factory_fields(self, afval_dataset) -> None:
+        """Prove that the fields from the schema will be generated"""
+        table = afval_dataset.schema.tables[0]
+        factory = DjangoModelFactory(afval_dataset)
+        model_cls = factory.build_model(table)
+        meta = model_cls._meta
+        assert meta.verbose_name == "Containers title"
+        assert {f.name for f in meta.get_fields()} == {
+            "id",
+            "cluster",
+            "serienummer",
+            "eigenaar_naam",
+            "datum_creatie",
+            "datum_leegmaken",
+            "geometry",
+            "kortenaam",
+        }
+        assert meta.get_field("id").primary_key
+
+        assert isinstance(meta.get_field("cluster_id"), models.ForeignKey)
+        assert isinstance(meta.get_field("eigenaar_naam"), UnlimitedCharField)
+        assert isinstance(meta.get_field("datum_creatie"), models.DateField)
+        assert isinstance(meta.get_field("datum_leegmaken"), models.DateTimeField)
+        geo_field = meta.get_field("geometry")
+        assert geo_field.srid == 28992
+        assert geo_field.db_index
+        assert meta.app_label == afval_dataset.schema.id
+
+        assert meta.get_field("eigenaar_naam").verbose_name == "Naam eigenaar"
+
+        table_with_id_as_string = afval_dataset.schema.tables[1]
+        model_cls = factory.build_model(table_with_id_as_string)
+        meta = model_cls._meta
+        assert meta.get_field("id").primary_key
+        assert isinstance(meta.get_field("id"), UnlimitedCharField)
+
+    @pytest.mark.django_db
+    def test_model_factory_table_name_no_versions(self, afval_dataset):
+        """Prove that relations between models can be resolved"""
+        factory = DjangoModelFactory(afval_dataset)
+        models = {cls._meta.model_name: cls for cls in factory.build_models()}
+        Containers = models["containers_v1"]
+        assert Containers._meta.db_table == "afvalwegingen_containers_v1"
+
+    @pytest.mark.django_db
+    def test_model_factory_table_name_default_version(self, afval_schema):
+        """Prove that default dataset gets no version in table name"""
+        afval_schema.data["default_version"] = "1.0.1"
+        afval_schema.data["version"] = "1.0.1"
+        afval_dataset = Dataset.create_for_schema(afval_schema)
+        factory = DjangoModelFactory(afval_dataset)
+        models = {cls._meta.model_name: cls for cls in factory.build_models()}
+        assert "containers_v1" in models
+        assert "containers_1_0_1" not in models
+        Containers = models["containers_v1"]
+        assert Containers._meta.db_table == "afvalwegingen_containers_v1"
+
+    @pytest.mark.django_db
+    def test_model_factory_versioned_tables(self, metaschemav3_dataset):
+        """Prove that versioned tables can be created"""
+        factory = DjangoModelFactory(metaschemav3_dataset)
+        table_names = [cls._meta.db_table for cls in factory.build_models()]
+        assert table_names == ["metaschema_3_table_v0", "metaschema_3_table_v1"]
+
+    @pytest.mark.django_db
+    def test_model_factory_relations(self, afval_dataset):
+        """Prove that relations between models can be resolved"""
+        factory = DjangoModelFactory(afval_dataset)
+        models = {cls._meta.model_name: cls for cls in factory.build_models()}
+        cluster_fk = models["containers_v1"]._meta.get_field("cluster")
+        # Cannot compare using identity for dynamically generated classes
+        assert cluster_fk.related_model._table_schema.id == models["clusters_v1"]._table_schema.id
+
+    @pytest.mark.django_db
+    def test_model_factory_n_m_relations(self, gebieden_dataset, meetbouten_dataset):
+        """Prove that n-m relations between models can be resolved"""
+        factory = DjangoModelFactory(meetbouten_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        nm_ref = model_dict["metingen_v1"]._meta.get_field("refereertaanreferentiepunten")
+        assert isinstance(nm_ref, models.ManyToManyField)
+
+    @pytest.mark.django_db
+    def test_model_factory_pk_with_relation(self, here, aardgasverbruik_dataset):
+        """Prove that primary keys with relations are supported."""
+        call_command(
+            "import_schemas",
+            here / "files/datasets/aardgasverbruik.json",
+            create_tables=True,
+            dry_run=False,
+        )
+        factory = DjangoModelFactory(aardgasverbruik_dataset)
+        MraLiander, PostcodeRangeModel = factory.build_models()
+        pk_field = PostcodeRangeModel._meta.pk
+        assert isinstance(pk_field, models.OneToOneField)
+        assert pk_field.db_column == "id"
+
+        PostcodeRangeModel.objects.create(
+            id_id="foobar",  # needs raw instance, must be mraLiander model otherwise.
+            gemiddeld_verbruik=200,
+        )
+        # Prove that the actual database does use the "id" column:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT * FROM aardgasverbruik_mra_statistieken_pcranges_v1")
+            rows = dictfetchall(cursor)
+        assert rows == [{"id": "foobar", "gemiddeld_verbruik": 200}]
+
+        instance = PostcodeRangeModel.objects.get(
+            id="foobar"
+        )  # new instance, no refresh_from_db()!
+        assert (
+            instance.id_id == "foobar"
+        )  # read Django added "attname" attribute for raw data access
+        with pytest.raises(MraLiander.DoesNotExist):
+            assert instance.id  # Read OneToOneField descriptor that accesses the model value.
+
+    @pytest.mark.django_db
+    def test_model_factory_sub_objects(self, parkeervakken_dataset):
+        """Prove that subobjects between models lead to extra child model"""
+        factory = DjangoModelFactory(parkeervakken_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        assert "parkeervakken_regimes_v1" in model_dict
+
+        fields_dict = {f.name: f for f in model_dict["parkeervakken_regimes_v1"]._meta.fields}
+        assert "parent" in fields_dict
+        assert isinstance(fields_dict["parent"], models.ForeignKey)
+
+    @pytest.mark.django_db
+    def test_model_factory_sub_objects_for_shortened_names(
+        self, verblijfsobjecten_dataset, hr_dataset
+    ):
+        """Prove that subobjects also work for shortened names in the schema"""
+        factory = DjangoModelFactory(hr_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+
+        # XXX Change: one field is now nested, the other is changed to a relation
+        # Check a relation where the fieldname is intact and one where fieldname is shortened
+        model = model_dict[
+            "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_maatschappelijke_activiteit_v1"
+        ]
+        fields_dict = {f.name: f for f in model._meta.fields}
+
+        # Field is nested, should have a parent field
+        assert isinstance(fields_dict["parent"], models.ForeignKey)
+
+        model = model_dict[
+            "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming_v1"
+        ]
+        fields_dict = {f.name: f for f in model._meta.fields}
+
+        # Field is a related, should have 2 FKs to both sides of the relation
+        assert isinstance(fields_dict["maatschappelijkeactiviteiten"], models.ForeignKey)
+        assert fields_dict["maatschappelijkeactiviteiten"].db_column == "activiteiten_id"
+
+        heeft_sbi_voor_activiteit_voor_onder = fields_dict[
+            "heeft_sbi_activiteiten_voor_onderneming"
+        ]
+        assert isinstance(heeft_sbi_voor_activiteit_voor_onder, models.ForeignKey)
+        assert heeft_sbi_voor_activiteit_voor_onder.db_column == "sbi_voor_activiteit_id"
+
+    @pytest.mark.django_db
+    def test_model_factory_temporary_1_n_relation(self, ggwgebieden_dataset):
+        """Prove that extra relation fields are added to temporary relation"""
+        factory = DjangoModelFactory(ggwgebieden_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        related_temporary_fields = {
+            "ligtinstadsdeel_identificatie",
+            "ligtinstadsdeel_volgnummer",
+        }
+        model_fields = {f.name for f in model_dict["ggwgebieden_v1"]._meta.fields}
+        assert model_fields > related_temporary_fields
+
+    @pytest.mark.django_db
+    def test_model_factory_temporary_n_m_relation(self, ggwgebieden_dataset):
+        """Prove that through table is created for n_m relation"""
+        factory = DjangoModelFactory(ggwgebieden_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        # The through table is created
+        through_table_name = "ggwgebieden_bestaatuitbuurten_v1"
+        assert through_table_name in model_dict
+
+        # Through table has refs to both 'sides' and extra fields for the relation
+        through_table_field_names = {
+            "ggwgebieden",
+            "bestaatuitbuurten",
+            "bestaatuitbuurten_identificatie",
+            "bestaatuitbuurten_volgnummer",
+        }
+        fields_dict = {f.name: f for f in model_dict[through_table_name]._meta.fields}
+
+        assert set(fields_dict.keys()) > through_table_field_names
+        for field_name in ("ggwgebieden", "bestaatuitbuurten"):
+            assert isinstance(fields_dict[field_name], models.ForeignKey)
+
+    @pytest.mark.django_db
+    def test_model_factory_loose_relations(self, meldingen_dataset, gebieden_dataset):
+        """Prove that a loose relation is created when column
+        is part of relation definition (<dataset>:<table>:column)
+        """
+        factory = DjangoModelFactory(meldingen_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        model_cls = model_dict["statistieken_v1"]
+        meta = model_cls._meta
+        assert isinstance(meta.get_field("buurt"), LooseRelationField)
+
+    @pytest.mark.django_db
+    def test_model_factory_loose_relations_n_m_temporeel(
+        self, woningbouwplannen_dataset, gebieden_dataset
+    ):
+        """Prove that a loose relation is created when column
+        is part of relation definition (<dataset>:<table>:column)
+        and that the intermediate model contains the correct references to both
+        associated tables.
+
+        Loose m2m relations defined with an array of scalars or an array of
+        single-property-objects generate the same output.
+        """
+        factory = DjangoModelFactory(woningbouwplannen_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        model_cls = model_dict["woningbouwplan_v1"]
+        meta = model_cls._meta
+        buurten_field = meta.get_field("buurten")
+        intermediate_table = buurten_field.remote_field.through
+        assert isinstance(buurten_field, LooseRelationManyToManyField)
+        assert isinstance(intermediate_table, ModelBase)
+
+        assert {x.name for x in intermediate_table._meta.get_fields()} == {
+            "buurten",
+            "id",
+            "woningbouwplan",
+        }
+
+        buurten_as_scalar_field = meta.get_field("buurten_as_scalar")
+        intermediate_table = buurten_as_scalar_field.remote_field.through
+        assert isinstance(buurten_as_scalar_field, LooseRelationManyToManyField)
+        assert isinstance(buurten_as_scalar_field.remote_field.through, ModelBase)
+
+        assert {x.name for x in intermediate_table._meta.get_fields()} == {
+            "buurten_as_scalar",
+            "id",
+            "woningbouwplan",
+        }
+
+    @pytest.mark.django_db
+    def test_table_shortname(self, verblijfsobjecten_dataset, hr_dataset):
+        """Prove that the shortnames definition for tables
+        are showing up in the Django db_table definitions.
+        We changed the table name to 'activiteiten'.
+        And used a shortname for a nested and for a relation field.
+        """
+        factory = DjangoModelFactory(hr_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        db_table_names = {
+            "hr_activiteiten_v1",
+            "hr_sbiactiviteiten_v1",
+            "hr_activiteiten_sbi_maatschappelijk_v1",
+            "hr_activiteiten_sbi_voor_activiteit_v1",
+            "hr_activiteiten_verblijfsobjecten_v1",
+            "hr_activiteiten_gevestigd_in_v1",
+            "hr_activiteiten_wordt_uitgeoefend_in_commerciele_vestiging_v1",
+        }
+
+        assert db_table_names == {m._meta.db_table for m in model_dict.values()}
+
+    @pytest.mark.django_db
+    def test_column_shortnames_in_nm_throughtables(self, verblijfsobjecten_dataset, hr_dataset):
+        """Prove that the shortnames definition for fields
+        are showing up in the Django db_table definitions.
+        We changed the table name to 'activiteiten'.
+        And used a shortname for a nested and for a relation field.
+        """
+        factory = DjangoModelFactory(hr_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+
+        db_colnames = {"activiteiten_id", "sbi_voor_activiteit_id"}
+        model = model_dict[
+            "maatschappelijkeactiviteiten_heeft_sbi_activiteiten_voor_onderneming_v1"
+        ]
+        assert db_colnames == {f.db_column for f in model._meta.fields if f.db_column is not None}
+
+    @pytest.mark.django_db
+    def test_nested_objects_should_never_be_temporal(self, verblijfsobjecten_dataset):
+        """Prove that a nested object is not marked as temporal."""
+        factory = DjangoModelFactory(verblijfsobjecten_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+
+        assert not model_dict["verblijfsobjecten_gebruiksdoel_v1"].is_temporal()
+
+    @pytest.mark.django_db
+    def test_temporal_subfields_are_skipped(self, verblijfsobjecten_dataset):
+        """Prove that relation subfields are skipped when they are temporal.
+
+        Verblijfsobjecten has as `beginGeldigheid` that is a `date-time`.
+        The `ligtInBuurt` FK also has a `beginGeldigheid` but field that is a `date`.
+        This `ligtInBuurt.beginGeldigheid` should not be used for model creation.
+        If it does, is will "mask" the original `beginGeldigheid` field, this
+        leads to a wrong Django field model type.
+        """
+        factory = DjangoModelFactory(verblijfsobjecten_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+
+        begin_geldigheid_field = model_dict["verblijfsobjecten_v1"]._meta.get_field(
+            "begin_geldigheid"
+        )
+        assert isinstance(begin_geldigheid_field, DateTimeField)
+
+    @pytest.mark.django_db
+    def test_non_composite_string_identifiers_use_slash_constraints(
+        self, parkeervakken_dataset, here
+    ):
+        call_command(
+            "import_schemas",
+            here / "files/datasets/parkeervakken.json",
+            create_tables=True,
+            dry_run=False,
+        )
+        factory = DjangoModelFactory(parkeervakken_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+
+        model = model_dict["parkeervakken_v1"]
+
+        with pytest.raises(
+            IntegrityError,
+            match=(
+                r'^new row for relation "parkeervakken_parkeervakken_v1" violates'
+                r' check constraint "parkeervakken_parkeervakken_v1_id_not_contains_slash".*'
+            ),
+        ):
+            model.objects.create(id="forbidden/slash")
+
+    @pytest.mark.django_db
+    def test_model_factory_sub_object_is_flattened(self, kadastraleobjecten_dataset):
+        """Prove that object type fields are 'flattened' in the model.
+
+        The field `soortCultuurOnbebouwd` is an object field with subfields `code` and `omschrijving`.
+
+        So, fields `soort_cultuur_onbebouwd_code`
+            and `soort_cultuur_onbebouwd_omschrijving` should be generated.
+        """
+        factory = DjangoModelFactory(kadastraleobjecten_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        model_field_names = {f.name for f in model_dict["kadastraleobjecten_v1"]._meta.fields}
+        assert {
+            "soort_cultuur_onbebouwd_code",
+            "soort_cultuur_onbebouwd_omschrijving",
+        } < model_field_names
+
+    @pytest.mark.django_db
+    def test_model_factory_sub_object_is_json(self, kadastraleobjecten_dataset):
+        """Prove that object type fields are JSONField when `"format" = "json"`."""
+        factory = DjangoModelFactory(kadastraleobjecten_dataset)
+        model_dict = {cls._meta.model_name: cls for cls in factory.build_models()}
+        model_fields = {f.name: f for f in model_dict["kadastraleobjecten_v1"]._meta.fields}
+        assert isinstance(model_fields["soort_grootte"], models.JSONField)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Dit zorgt ervoor dat de relaties op de juiste manier worden resolved. 

Tests zijn gerepliceerd van andere model tests met juiste version suffixes erbij. 

TODO (later): schema_models_factory / model_factory uitfaseren.