### PR TITLE
Pieter/validate default version enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-09-10 (8.3.3)
+
+* Validate that the default version is enabled instead of the only enabled version.
+
 # 2025-09-09 (8.3.2)
 
 * Only create dynamic models for available dataset versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 8.3.2
+version = 8.3.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -527,17 +527,12 @@ def _check_schema_ref(dataset: DatasetSchema) -> Iterator[str]:
 
 
 @_register_validator("defaultVersion")
-def _check_default_version(dataset: DatasetSchema) -> Iterator[str]:
-    """Check that defaultVersion field for a dataset matches the only 'beschikbaar' version."""
-    enabled_versions = []
-    for version_number, version in dataset.versions.items():
-        if version.status == DatasetSchema.Status.beschikbaar:
-            enabled_versions.append(version_number)
-            if version_number != dataset.default_version:
-                yield (
-                    f"Default version {dataset.default_version} does not match enabled "
-                    f"version {version_number}"
-                )
+def _check_default_version_is_enabled(dataset: DatasetSchema) -> Iterator[str]:
+    """Check that defaultVersion of a dataset is enabled if there is more than one version."""
+    if len(dataset.versions) > 1:
+        default_version = dataset.get_version(dataset.default_version)
+        if default_version.status != DatasetSchema.Status.beschikbaar:
+            yield (f"Default version {dataset.default_version} is not enabled.")
 
 
 @_register_validator("production version tables")

--- a/tests/files/datasets/schema_default_version_experimental.json
+++ b/tests/files/datasets/schema_default_version_experimental.json
@@ -1,0 +1,16 @@
+{
+  "type": "dataset",
+  "id": "schemadefaultversion",
+  "title": "Schema defaultVersion Validation Test",
+  "description": "Schema for unit testing defaultVersion with experimental version",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "status": "niet_beschikbaar",
+      "lifecycleStatus": "experimental",
+      "version": "1.0.0",
+      "tables": []
+    }
+  },
+  "publisher": "unknown"
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -355,11 +355,12 @@ def test_check_default_version(schema_loader) -> None:
     errors = list(validation.run(dataset))
     assert len(errors) == 0
 
-    # Prove that wrong default version gives an error
+    # Prove that disabled default version gives an error (when there are multiple versions)
     dataset["defaultVersion"] = "v2"
+    dataset["versions"]["v2"]["status"] = "niet_beschikbaar"
     errors = list(validation.run(dataset))
     assert len(errors) == 1
-    assert "Default version v2 does not match enabled version v1" in errors[0].message
+    assert "Default version v2 is not enabled." in errors[0].message
 
 
 def test_production_version_tables(schema_loader) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -363,6 +363,15 @@ def test_check_default_version(schema_loader) -> None:
     assert "Default version v2 is not enabled." in errors[0].message
 
 
+def test_check_default_version_is_experimental(schema_loader) -> None:
+    """Ensure that if there is only one version and it is experimental, it does not matter that
+    the default version is unavailable."""
+    dataset = schema_loader.get_dataset_from_file("schema_default_version_experimental.json")
+
+    errors = list(validation.run(dataset))
+    assert len(errors) == 0
+
+
 def test_production_version_tables(schema_loader) -> None:
     dataset = schema_loader.get_dataset("production_version")
 


### PR DESCRIPTION
Loosen validation of the enabled versions. 

With this change, you can have multiple enabled versions, but we ensure that in that case, at least the default version is enabled. 

It is still possible to only have an experimental version which is not available - for when a new dataset is being developed.