### PR TITLE
DX upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ version := $(shell awk '/^version = / {print $$3}' setup.cfg)
 .PHONY: upload
 upload: build
 	[ "$$(head -n 1 CHANGES.md)" = "# $$(date +%Y-%m-%d) (${version})" ]
-	python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+	python -m twine upload dist/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   database:
     image: postgis/postgis:14-3.2
     ports:
-      - "5415:5432"
+      - "5417:5432"
     environment:
       POSTGRES_DB: dataservices
       POSTGRES_USER: dataservices

--- a/tests/django/conftest.py
+++ b/tests/django/conftest.py
@@ -13,7 +13,7 @@ def pytest_configure(config):
     databases = {
         "default": env.db_url(
             "DATABASE_URL",
-            default="postgresql://dataservices:insecure@localhost:5415/dataservices",
+            default="postgresql://dataservices:insecure@localhost:5417/dataservices",
             engine="django.contrib.gis.db.backends.postgis",
         ),
     }


### PR DESCRIPTION
fixed some things:
- postgres port conflicted with the one in dso-api, which was a PITA when switching between the two
- twine arg in the make upload command caused a prompt for API token, while this should be available in the .pypirc file. The repository arg was identical to its default value.