### PR TITLE
fix db name pt2

### DIFF
--- a/.github/workflows/deplic.yaml
+++ b/.github/workflows/deplic.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - 'schema-tools-v*'
 
 jobs:
   deplic:

--- a/.github/workflows/deplic.yaml
+++ b/.github/workflows/deplic.yaml
@@ -2,6 +2,9 @@
 # or incompatible with MPL.
 
 name: Check licenses of dependencies
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,7 @@
 name: pre-commit
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - main
     - master
+    - 'schema-tools-v*'
 
 jobs:
   pre-commit:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,7 @@
 name: Build and test
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 'schema-tools-v*'
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-05-08 (7.7.4)
+
+* Use unversioned filenames for exports (previously only '_v1' was removed).
+
 # 2025-05-08 (7.7.3)
 
 * Make import schemas atomic and fix empty migrations.
@@ -277,9 +281,9 @@
 * Change export to only use active records for csv and jsonlines,
   so, no historical records. Also brought the export more in line
   with the csv export of the DSO-API:
-  - headers using capitalize()
-  - date-time in iso notation
-  - foreign keys only with an `identificatie` (no `volgnummer`)
+  * headers using capitalize()
+  * date-time in iso notation
+  * foreign keys only with an `identificatie` (no `volgnummer`)
 
 # 2023-12-05 (5.19.1)
 
@@ -470,8 +474,8 @@
 # 2023-06-05 (5.11.6)
 
 * Two small fixes to make `sqlmigrate_schema` work:
-  - requires_system_checks needs to be a list (from Django 1.4)
-  - list of datsets need to be a set when calling Django schema migrate API
+  * requires_system_checks needs to be a list (from Django 1.4)
+  * list of datsets need to be a set when calling Django schema migrate API
 
 # 2023-05-24 (5.11.5)
 
@@ -701,7 +705,6 @@ SUPPORTED METASCHEMAS: 1 2
 * Cleanup SQLAlchemy column creation logic.
 * The schema validator now rejects tables with both an 'id' field and a composite primary key.
 
-
 # 2022-12-01 (5.1.3)
 
 * Fix `limit_tables_to` issue with crash in index creation for skipped tables.
@@ -711,19 +714,16 @@ SUPPORTED METASCHEMAS: 1 2
 * Improved 3D coordinate system detection, and added more common SRID values.
 * Improved naming of geometry column index to be consistent with other generated indices.
 
-
 # 2022-11-24 (5.1.2)
 
 * Fix `BaseImporter.generate_db_objects()` to handle properly snake-cased table identifiers values for table creation.
 * Improve the underlying `tables_factory()` logic to support snake-cased table identifiers for all remaining parameters.
-
 
 # 2022-11-22 (5.1.1)
 
 * Improve `limit_tables_to` to accept snake-cased table identifiers, which broke Airflow jobs.
   This addresses an inconsistency between parameters, where `BaseImporter.generate_db_objects()`
   allowed snake-cased identifiers for `table_id`, but needed exact-cased values for `limit_tables_to`.
-
 
 # 2022-11-21 (5.1)
 
@@ -742,20 +742,17 @@ as all datasets are only cached within the same loader instance now.
 * Removed ununsed functions in `schematools.utils`.
 * Deprecated loading functions in `schematools.utils`, use `schematools.loaders` instead.
 
-
 # 2022-11-15 (5.0.2)
 
 * Using `BigAutoField` for all identifier fields now by default.
 * Fixed Django system check warnings for `AutoField`/`BigAutoField` migration changes.
-* Fixed CKAN metadata upload to https://data.overheid.nl/ for datasets without a description or title.
-
+* Fixed CKAN metadata upload to <https://data.overheid.nl/> for datasets without a description or title.
 
 # 2022-11-02 (5.0.1)
 
 * Added validation check to prevent field names from being prefixed with their table or dataset name.
 * Fixed Django ``db_column`` for subfields that use a shortname (regression by 5.0).
 * Fixed dependency pinning of shapely to 1.8.0
-
 
 # 2022-10-31 (5.0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 7.7.3
+version = 7.7.4
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,8 @@ tests =
     pytest-cov
     pytest-django >= 4.7.0
     pytest-sqlalchemy
-    sqlalchemy-utils
+    sqlalchemy-utils == 0.41.2 # Breaking change was introduced in 0.42
+    # https://github.com/kvesteri/sqlalchemy-utils/issues/791
 django =
     django >= 4.2
     django-gisserver >= 1.2.7

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -133,7 +133,7 @@ class BaseExporter:
             if not columns:
                 continue
             with open(
-                self.base_dir / f"{table.db_name.replace('_v1', '')}.{self.extension}",
+                self.base_dir / f"{table.db_name_variant(with_version=False)}.{self.extension}",
                 "w",
                 encoding="utf8",
             ) as file_handle:

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -48,7 +48,8 @@ def export_geopackages(
     )
 
     for table in tables:
-        output_path = base_dir / f"{table.db_name.replace('_v1', '')}.gpkg"
+        # For now we only output the default version.
+        output_path = base_dir / f"{table.db_name_variant(with_version=False)}.gpkg"
         field_names = sql.SQL(",").join(
             sql.Identifier(field.db_name)
             for field in _get_fields(dataset_schema, table, scopes)


### PR DESCRIPTION
De fix op v8 brak omdat psycopg3 niet lekker gaat op de code in `export_geopackages` en ik niet zo snel een oplossing kon vinden. Dus nu ook op laatste versie van voor die transitie, zodat de exports in ieder geval kunnen draaien.