### PR TITLE
Add method to filter table fields based on scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2025-09-24 (8.3.6)
+
+* DatasetSchema method to filter table fields based on scope
+
 # 2025-09-17 (8.3.5)
 
 * Use unversioned filenames for exports (previously only '_v1' was removed).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 8.3.5
+version = 8.3.6
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/tests/files/datasets/scope_filtering.json
+++ b/tests/files/datasets/scope_filtering.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
-  "id": "experimental",
-  "title": "Schema experimental scope filtering",
+  "id": "scope_filtering",
+  "title": "Schema scope filtering",
   "description": "Schema for unit testing that DatasetSchemas can be filtered on scope",
   "defaultVersion": "v1",
   "versions": {
@@ -11,8 +11,8 @@
       "lifecycleStatus": "stable",
       "tables": [
         {
-          "id": "scoped_table",
-          "title": "Table to test experimental tables in a stable version",
+          "id": "unscoped_table",
+          "title": "Unscoped table to test if it can be accessed when scopes are provided",
           "type": "table",
           "version": "1.0.0",
           "lifecycleStatus": "stable",
@@ -35,7 +35,43 @@
                 "type": "string",
                 "description": "Unieke identificatie"
               },
-              "test_filter_field": {
+              "scoped_field": {
+                "title": "scoped_field",
+                "type": "string",
+                "description": "Scope filtering",
+                 "auth": [
+                    "FIELD/AUTH"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "scoped_table",
+          "title": "Scoped table to test if it can be accessed when (correct) scopes are provided",
+          "type": "table",
+          "version": "1.0.0",
+          "lifecycleStatus": "stable",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "identifier": "id",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "schema"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3#/definitions/schema"
+              },
+              "id": {
+                "title": "id",
+                "type": "string",
+                "description": "Unieke identificatie"
+              },
+              "scoped_field": {
                 "title": "scoped_field",
                 "type": "string",
                 "description": "Scope filtering",
@@ -56,8 +92,8 @@
     "auth": [
         {
             "type": "scope",
-            "id": "DB/AUTH",
-            "name": "DB/AUTH",
+            "id": "DS/AUTH",
+            "name": "DS/AUTH",
             "accessPackages": {
                 "nonProduction": "EM4W-DATA-schemascope-ot-scope_hr_r",
                 "production": "EM4W-DATA-schemascope-p-scope_hr_r"

--- a/tests/files/datasets/scope_filtering.json
+++ b/tests/files/datasets/scope_filtering.json
@@ -1,0 +1,70 @@
+{
+  "type": "dataset",
+  "id": "experimental",
+  "title": "Schema experimental scope filtering",
+  "description": "Schema for unit testing that DatasetSchemas can be filtered on scope",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "status": "beschikbaar",
+      "version": "1.0.0",
+      "lifecycleStatus": "stable",
+      "tables": [
+        {
+          "id": "scoped_table",
+          "title": "Table to test experimental tables in a stable version",
+          "type": "table",
+          "version": "1.0.0",
+          "lifecycleStatus": "stable",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "identifier": "id",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "schema"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3#/definitions/schema"
+              },
+              "id": {
+                "title": "id",
+                "type": "string",
+                "description": "Unieke identificatie"
+              },
+              "test_filter_field": {
+                "title": "scoped_field",
+                "type": "string",
+                "description": "Scope filtering",
+                 "auth": [
+                    "FIELD/AUTH"
+                ]
+              }
+            }
+          },
+          "auth": [
+            "TABLE/AUTH"
+          ]
+        }
+      ]
+    }
+  },
+  "publisher": "unknown",
+    "auth": [
+        {
+            "type": "scope",
+            "id": "DB/AUTH",
+            "name": "DB/AUTH",
+            "accessPackages": {
+                "nonProduction": "EM4W-DATA-schemascope-ot-scope_hr_r",
+                "production": "EM4W-DATA-schemascope-p-scope_hr_r"
+            },
+            "owner": {
+                "$ref": "publishers/BENK"
+            }
+        }
+    ]
+}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -331,6 +331,40 @@ def test_load_scope_object_from_field(schema_loader):
     assert field.auth == frozenset({"HARRY/THREE"})
 
 
+def test_scope_filtering(schema_loader):
+    """Test that supplying a scope only returns fields within that scope"""
+    schema = schema_loader.get_dataset_from_file("scope_filtering.json")
+    all_fields = {field.id for field in schema.tables[0].fields}
+
+    # Request has all scopes -> access to all fields
+    scopes = ["DB/AUTH", "TABLE/AUTH", "FIELD/AUTH"]
+    filtered_schema = schema.filter_on_scopes(scopes)
+    filtered_fields = {field.id for field in filtered_schema.tables[0].fields}
+
+    assert filtered_fields == all_fields
+
+    # Request misses field scope
+    scopes = ["DB/AUTH", "TABLE/AUTH"]
+    filtered_schema = schema.filter_on_scopes(scopes)
+    filtered_fields = {field.id for field in filtered_schema.tables[0].fields}
+
+    assert filtered_fields == {"schema", "id"}
+
+    # Request misses table scope
+    scopes = ["DB/AUTH", "FIELD/AUTH"]
+    filtered_schema = schema.filter_on_scopes(scopes)
+    filtered_fields = {field.id for field in filtered_schema.tables[0].fields}
+
+    assert filtered_fields == set()
+
+    # Request misses db scope
+    scopes = ["TABLE/AUTH", "FIELD/AUTH"]
+    filtered_schema = schema.filter_on_scopes(scopes)
+    filtered_fields = {field.id for field in filtered_schema.tables[0].fields}
+
+    assert filtered_fields == set()
+
+
 def test_load_multiple_scope_objects(schema_loader):
     """Test that we can retrieve a scope object from a DatasetSchema
     as defined by metaschema 2.0"""


### PR DESCRIPTION
Nieuwe class method voor `DatasetSchema` om velden uit de tabellen te filteren op basis van een lijst met scopes.

Het werkt zo:
- Je geeft een lijst met scopes mee aan `DatasetSchema.filter_on_scopes(scopes)`
-  Deze wordt doorgegeven aan de `DatasetSchema.json_data()` van en daarin aan `DatasetTableSchema.json_data()`.
- `inline_tables` wordt op `True` gezet, want daardoor gaan we daadwerkelijk door alle velden van alle tabellen. _Is dit wel een goede methode?_
- Tijdens het inlinen wordt met de `DatasetTableSchema.filter_on_scopes`-method de scopes-array omgezet in een UserScopes object _(ik kan UserScopes niet globaal importeren door een circular import)_, en daarmee wordt er bij elk veld gecheckt of gegeven scope toegang heeft tot het veld. Zo ja, dan wordt het opgeslagen en uiteindelijk overschrijven we de `properties` key van `DatasetTableSchema.json_data()` met de gefilterde fields

Ik zou de scopes-array meteen in `DatasetSchema.filter_on_scopes` al om kunnen zetten in een `UserScopes` object en dat steeds mee geven, maar zou ik de type 'UserScopes' niet kunnen definieren in elke method waar ik die aan meegeef omdat ik die niet globaal kan importeren. Of misschien is er wel een manier om die import te kunnen doen. Of misschien is er nog een andere oplossing?

Laat het vooral weten als iets anders/beter/netter kan! :) 