### PR TITLE
Validate relation suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2026-04-09 (9.4.2)
+
+* Add validation for fields with a relation: these should NOT end with "Id".
+
 # 2026-04-08 (9.4.1)
 
 * Add deprecated state to DatasetVersion Django model.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.4.1
+version = 9.4.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -808,6 +808,19 @@ def _check_export_scopes(dataset: DatasetSchema) -> Iterator[str]:
                             )
 
 
+@_register_validator("relation suffix")
+def _check_relation_suffix(dataset: DatasetSchema) -> Iterator[str]:
+    """Check that fields with a 'relation' property does not end with 'Id'. This is added by us
+    in the database column."""
+    for table in dataset.tables:
+        for field in table.fields:
+            if "relation" in field and field.id.endswith("Id"):
+                yield (
+                    f"Field {field.id!r} on table {table.id!r} has a 'relation' property but "
+                    "ends with 'Id'. Fields with a 'relation' property should not end with 'Id'."
+                )
+
+
 def validate_dataset(
     previous_tables: list[dict[str, str]],
     current_tables: list[dict[str, str]],
@@ -994,8 +1007,7 @@ def validate_table_version(previous: dict, current: dict) -> list[str]:
         expected_version.patch = 0
         if current_version != expected_version:
             return [
-                f"Table '{table_id}' added fields, expecting new version "
-                f"to be {expected_version}."
+                f"Table '{table_id}' added fields, expecting new version to be {expected_version}."
             ]
         else:
             # If there is a minor version bump, we don't need to check for metadata changes

--- a/tests/files/datasets/relation_suffix.json
+++ b/tests/files/datasets/relation_suffix.json
@@ -1,0 +1,491 @@
+{
+  "type": "dataset",
+  "id": "gebieden",
+  "title": "gebieden",
+  "identifier": "identificatie",
+  "crs": "EPSG:28992",
+  "publisher": "unknown",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "0.0.1",
+      "tables": [
+        {
+          "id": "bouwblokken",
+          "type": "table",
+          "version": "1.0.0",
+          "temporal": {
+            "identifier": "volgnummer",
+            "dimensions": {
+              "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+            }
+          },
+          "zoom": {
+            "min": 20,
+            "max": 28
+          },
+          "schema": {
+            "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": ["identificatie", "volgnummer"],
+            "required": ["schema", "identificatie", "volgnummer"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "identificatie": {
+                "type": "string",
+                "description": "Unieke identificatie van het object."
+              },
+              "volgnummer": {
+                "type": "integer",
+                "description": "Uniek volgnummer van de toestand van het object."
+              },
+              "registratiedatum": {
+                "type": "string",
+                "format": "date-time",
+                "description": "De datum waarop de toestand is geregistreerd."
+              },
+              "code": {
+                "type": "string",
+                "description": "Offici\u00eble code van het object."
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is gecre\u00eberd."
+              },
+              "eindGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is komen te vervallen."
+              },
+              "buurtId": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "integer"
+                  },
+                  "beginGeldigheid": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "eindGeldigheid": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "relation": "gebieden:buurten",
+                "description": "De buurt waar het bouwblok in ligt."
+              },
+              "ligtInBuurtMetTeLangeNaam": {
+                "shortname": "lgtInBrt",
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "integer"
+                  }
+                },
+                "relation": "gebieden:buurten",
+                "description": "De buurt waar het bouwblok in ligt."
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrische beschrijving van een object."
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "buurten",
+          "type": "table",
+          "version": "1.0.0",
+          "temporal": {
+            "identifier": "volgnummer",
+            "dimensions": {
+              "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+            }
+          },
+          "schema": {
+            "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": ["identificatie", "volgnummer"],
+            "required": ["schema", "identificatie", "volgnummer"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "volgnummer": {
+                "type": "integer",
+                "description": "Uniek volgnummer van de toestand van het object."
+              },
+              "registratiedatum": {
+                "type": "string",
+                "format": "date-time",
+                "description": "De datum waarop de toestand is geregistreerd."
+              },
+              "identificatie": {
+                "type": "string",
+                "description": "Unieke identificatie van het object."
+              },
+              "naam": {
+                "type": "string",
+                "description": "De naam van het object."
+              },
+              "code": {
+                "type": "string",
+                "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is gecre\u00eberd."
+              },
+              "eindGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is komen te vervallen."
+              },
+              "documentdatum": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "documentnummer": {
+                "type": "string",
+                "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "cbsCode": {
+                "type": "string",
+                "description": "De CBS-code van het object."
+              },
+              "ligtInWijk": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "integer"
+                  }
+                },
+                "relation": "gebieden:wijken",
+                "description": "De wijk waar de buurt in ligt."
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrische beschrijving van een object."
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "wijken",
+          "type": "table",
+          "version": "1.0.0",
+          "temporal": {
+            "identifier": "volgnummer",
+            "dimensions": {
+              "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+            }
+          },
+          "schema": {
+            "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": ["identificatie", "volgnummer"],
+            "required": ["schema", "identificatie", "volgnummer"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "identificatie": {
+                "type": "string",
+                "description": "Unieke identificatie van het object."
+              },
+              "volgnummer": {
+                "type": "integer",
+                "description": "Uniek volgnummer van de toestand van het object."
+              },
+              "registratiedatum": {
+                "type": "string",
+                "format": "date-time",
+                "description": "De datum waarop de toestand is geregistreerd."
+              },
+              "naam": {
+                "type": "string",
+                "description": "De naam van het object."
+              },
+              "code": {
+                "type": "string",
+                "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is gecre\u00eberd."
+              },
+              "eindGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is komen te vervallen."
+              },
+              "documentdatum": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "documentnummer": {
+                "type": "string",
+                "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "cbsCode": {
+                "type": "string",
+                "description": "De CBS-code van het object."
+              },
+              "ligtInStadsdeel": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "integer"
+                  },
+                  "beginGeldigheid": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "eindGeldigheid": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "relation": "gebieden:stadsdelen",
+                "description": "Het stadsdeel waar de wijk in ligt."
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrische beschrijving van een object."
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "stadsdelen",
+          "type": "table",
+          "version": "1.0.0",
+          "temporal": {
+            "identifier": "volgnummer",
+            "dimensions": {
+              "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+            }
+          },
+          "schema": {
+            "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": ["identificatie", "volgnummer"],
+            "required": ["schema", "identificatie", "volgnummer"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "identificatie": {
+                "type": "string",
+                "description": "Unieke identificatie van het object."
+              },
+              "volgnummer": {
+                "type": "integer",
+                "description": "Uniek volgnummer van de toestand van het object."
+              },
+              "registratiedatum": {
+                "type": "string",
+                "format": "date-time",
+                "description": "De datum waarop de toestand is geregistreerd."
+              },
+              "naam": {
+                "type": "string",
+                "description": "De naam van het object."
+              },
+              "code": {
+                "type": "string",
+                "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is gecre\u00eberd."
+              },
+              "eindGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is komen te vervallen."
+              },
+              "documentdatum": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "documentnummer": {
+                "type": "string",
+                "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "ligtInGemeente": {
+                "type": "string",
+                "$comment": "relation brk:gemeentes *stringify*",
+                "description": "De gemeente waar het stadsdeel in ligt."
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrische beschrijving van een object."
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "ggwgebieden",
+          "type": "table",
+          "version": "1.0.0",
+          "temporal": {
+            "identifier": "volgnummer",
+            "dimensions": {
+              "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+            }
+          },
+          "schema": {
+            "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": ["identificatie", "volgnummer"],
+            "required": ["schema", "identificatie", "volgnummer"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "identificatie": {
+                "type": "string",
+                "description": "Unieke identificatie van het object."
+              },
+              "volgnummer": {
+                "type": "integer",
+                "description": "Uniek volgnummer van de toestand van het object."
+              },
+              "registratiedatum": {
+                "type": "string",
+                "format": "date-time",
+                "description": "De datum waarop de toestand is geregistreerd."
+              },
+              "naam": {
+                "type": "string",
+                "description": "De naam van het object."
+              },
+              "code": {
+                "type": "string",
+                "description": "De code van het object."
+              },
+              "beginGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is gecre\u00eberd."
+              },
+              "eindGeldigheid": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het object is komen te vervallen."
+              },
+              "documentdatum": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "documentnummer": {
+                "type": "string",
+                "description": "Unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+              },
+              "stadsdeelId": {
+                "type": "object",
+                "properties": {
+                  "identificatie": {
+                    "type": "string"
+                  },
+                  "volgnummer": {
+                    "type": "integer"
+                  },
+                  "beginGeldigheid": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "eindGeldigheid": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "relation": "gebieden:stadsdelen",
+                "description": "Het stadsdeel waar het ggwgebied in ligt."
+              },
+              "bestaatUitBuurten": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "identificatie": {
+                      "type": "string"
+                    },
+                    "volgnummer": {
+                      "type": "integer"
+                    },
+                    "beginGeldigheid": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "eindGeldigheid": {
+                      "type": "string",
+                      "format": "date"
+                    }
+                  }
+                },
+                "relation": "gebieden:buurten",
+                "description": "De buurten waaruit het object bestaat."
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrische beschrijving van een object."
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,6 +15,7 @@ from schematools.validation import (
     _check_export_scopes,
     _check_exports,
     _check_maingeometry,
+    _check_relation_suffix,
     _check_scopes_exist,
     _identifier_properties,
     validate_dataset,
@@ -558,6 +559,18 @@ def test_check_superseded_version(schema_loader) -> None:
         "Dataset version (v1) cannot have a status of 'superseded' without an endSupportDate."
         in errors[0].message
     )
+
+
+def test_relation_suffix(schema_loader) -> None:
+    dataset = schema_loader.get_dataset_from_file("relation_suffix.json")
+    errors = list(_check_relation_suffix(dataset))
+    assert len(errors) == 2
+    assert errors == [
+        "Field 'buurtId' on table 'bouwblokken' has a 'relation' property but ends with 'Id'. "
+        "Fields with a 'relation' property should not end with 'Id'.",
+        "Field 'stadsdeelId' on table 'ggwgebieden' has a 'relation' property but ends with 'Id'. "
+        "Fields with a 'relation' property should not end with 'Id'.",
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
de "id" voegen we zelf toe aan de naam van de db kolom, dus dit voorkomt dat we "_id_id" hebben en het elders misgaat.   