### PR TITLE
[Bugfix] migrations bij verandering in default version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2026-04-22 (9.4.3)
+
+* Bugfix: Do not migrate any table that doesn't change its version.
+
 # 2026-04-09 (9.4.2)
 
 * Add validation for fields with a relation: these should NOT end with "Id".

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.4.2
+version = 9.4.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -196,6 +196,9 @@ class Command(BaseCommand):
                 updated_table = updated_dataset.schema.get_table_by_id(
                     current_table.id, include_nested=False, include_through=False
                 )
+                if current_table.version == updated_table.version:
+                    # No migration necessary, as any change would have resulted in a version bump.
+                    continue
                 if current_table.version.vmajor == updated_table.version.vmajor:
                     # If the table is under_development and there are breaking changes to
                     # the table, drop the table

--- a/tests/django/test_schema_import.py
+++ b/tests/django/test_schema_import.py
@@ -34,6 +34,24 @@ def test_import_schema_twice(here):
 
 
 @pytest.mark.django_db()
+def test_import_schema_update_default_version(here):
+    gebieden = here / "files/datasets/gebieden.json"
+    bag = here / "files/datasets/bag_verblijfsobjecten.json"
+    afval = here / "files/datasets/huishoudelijkafval/dataset.json"
+    args = [gebieden, bag, afval]
+    call_command("import_schemas", *args, create_tables=1, create_views=1, dry_run=False)
+    assert models.Dataset.objects.count() == 3
+    assert models.Dataset.objects.get(name="huishoudelijkafval").schema.default_version == "v1"
+
+    afval_v2 = here / "files/datasets/huishoudelijkafval/dataset_v2.json"
+    args = [gebieden, bag, afval_v2]
+    # Changing the default version should not fail
+    call_command("import_schemas", *args, create_tables=1, create_views=1, dry_run=False)
+    assert models.Dataset.objects.count() == 3
+    assert models.Dataset.objects.get(name="huishoudelijkafval").schema.default_version == "v2"
+
+
+@pytest.mark.django_db()
 def test_import_schema_update_runs_migrations(here):
     """Prove that importing a dataset schema twice does not fail"""
     verblijfsobjecten = here / "files/datasets/verblijfsobjecten.json"

--- a/tests/files/datasets/experimental/new_field.json
+++ b/tests/files/datasets/experimental/new_field.json
@@ -14,17 +14,14 @@
           "id": "experimentaltable",
           "title": "Table to test experimental tables in a stable version",
           "type": "table",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "status": "under_development",
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {

--- a/tests/files/datasets/experimental/removed_field.json
+++ b/tests/files/datasets/experimental/removed_field.json
@@ -14,17 +14,14 @@
           "id": "experimentaltable",
           "title": "Table to test experimental tables in a stable version",
           "type": "table",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "status": "under_development",
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {

--- a/tests/files/datasets/experimental/removed_field_m2m.json
+++ b/tests/files/datasets/experimental/removed_field_m2m.json
@@ -14,17 +14,14 @@
           "id": "experimentaltable",
           "title": "Table to test experimental tables with m2m relations in a stable version",
           "type": "table",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "status": "under_development",
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {
@@ -53,10 +50,7 @@
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {

--- a/tests/files/datasets/hr_updated.json
+++ b/tests/files/datasets/hr_updated.json
@@ -16,17 +16,14 @@
           "id": "maatschappelijkeactiviteiten",
           "shortname": "activiteiten",
           "type": "table",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "schema": {
             "$id": "https://github.com/Amsterdam/schemas/hr/maatschappelijke_activiteiten.json",
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "additionalProperties": false,
             "identifier": "kvknummer",
-            "required": [
-              "schema",
-              "kvknummer"
-            ],
+            "required": ["schema", "kvknummer"],
             "display": "kvknummer",
             "properties": {
               "schema": {
@@ -130,10 +127,7 @@
             "type": "object",
             "additionalProperties": false,
             "identifier": "sbiActiviteitNummer",
-            "required": [
-              "schema",
-              "sbiActiviteitNummer"
-            ],
+            "required": ["schema", "sbiActiviteitNummer"],
             "display": "sbiActiviteitNummer",
             "properties": {
               "schema": {

--- a/tests/files/datasets/huishoudelijkafval/dataset.json
+++ b/tests/files/datasets/huishoudelijkafval/dataset.json
@@ -1,0 +1,434 @@
+{
+  "id": "huishoudelijkafval",
+  "type": "dataset",
+  "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
+  "auth": "OPENBAAR",
+  "theme": ["duurzaamheid en milieu"],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Directie Afval en Grondstoffen, Gemeente Amsterdam",
+  "spatialDescription": "Gemeente Amsterdam",
+  "title": "Afvalcontainers, putten en weeggegevens",
+  "language": "nl",
+  "dateCreated": "2020-01-13T00:00:00+01:00",
+  "license": "openbaar, tenzij anders aangegeven / behoudens uitzonderingen",
+  "creator": "Datateam Beeldschoon/BOR",
+  "publisher": {
+    "$ref": "/publishers/GLEBZ"
+  },
+  "description": "Alle locaties van afvalcontainers (ondergrondse afvalcontainers, bovengrondse afvalcontainers en rolcontainers) en  betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas en Textiel. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
+  "keywords": [
+    "Afval",
+    "Afvalcontainers",
+    "Containers",
+    "Glas",
+    "Glasbak",
+    "Oud papier",
+    "Textiel",
+    "Restafval",
+    "rolcontainer",
+    "loopafstanden",
+    "servicegebieden"
+  ],
+  "crs": "EPSG:28992",
+  "objective": "Deze dataset bevat data over huishoudelijk afval. Het gaat hierbij om de infrastructuur van  ondergrondse- en rolcontainers. Naast de objecteigenschappen, van bijvoorbeeld locatie tot containervolume, bevat de set ook gegevens over het onderhoud, de vulling, de hoeveelheid afval, bijplaatsingen enz. De dataset wordt gevuld vanuit veel verschillende bronsystemen. VConsyst voor containers, clusters, fracties en tickets(meldingen over containers). Inovim voor de rolcontainers. Kilogram voor weeggegevens afkomstig van de wagens. In afvoermomenten de hoeveelheden afval aangeboden aan afvalverwerkers. Container vulgraden en vulsnelheden is  sensordata uit containers. Het doel van deze dataset is het beschikbaar stellen van gegevens voor het ondersteunen van plaatsingsbeleid betreffende ondergrondse afvalcontainers en het ondersteunen van routeoptimalisatie voor afvalinzameling.",
+  "temporalUnit": "uren",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "version": "2.5.0",
+      "tables": [
+        {
+          "id": "container",
+          "version": "2.2.0",
+          "status": "stable",
+          "type": "table",
+          "title": "Onder- en bovengronds afvalcontainers",
+          "description": "Bevat een overzicht van alle onder- en bovengronds afvalcontainers in Gemeente Amsterdam",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": "id",
+            "required": ["id", "schema"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "string",
+                "description": "Unieke aanduiding objecttype",
+                "title": "Object ID"
+              },
+              "idNummer": {
+                "type": "string",
+                "description": "Identificatie dat door de fabrikant aan het object is gegeven",
+                "title": "Object externe ID"
+              },
+              "serienummer": {
+                "type": "string",
+                "description": "serienummer uitgegeven door de fabrikant",
+                "title": "Serienummer"
+              },
+              "eigenaarId": {
+                "type": "string",
+                "description": "Identificerend kenmerk eigenaar",
+                "title": "Eigenaar ID"
+              },
+              "eigenaarNaam": {
+                "type": "string",
+                "description": "Naam eigenaar",
+                "title": "Eigenaar naam"
+              },
+              "status": {
+                "type": "integer",
+                "enum": [0, 1, 2],
+                "description": "Status van de container,0 - inactief, 1 - actief, 2 - gepland",
+                "title": "Container status code"
+              },
+              "fractieCode": {
+                "type": "string",
+                "enum": ["1", "2", "3", "4", "5", "6", "9"],
+                "description": "Type afvalfractie code waarvoor de container is bedoeld: 1 - Rest, 2 - Glas, 3 - Papier, 4 - Plastic, 5 - Textiel, 6 - GFT, 9 - Brood",
+                "title": "Afvalfractie soort code"
+              },
+              "fractieOmschrijving": {
+                "type": "string",
+                "description": "Container fractieomschrijving zoals door leverancier is geleverd.",
+                "title": "Afvalfractie soort naam"
+              },
+              "datumCreatie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is gecreëerd in container management systeem",
+                "title": "Datum registratie startdatum"
+              },
+              "datumPlaatsing": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object op de locatie is geplaatst",
+                "title": "Datum plaatsing"
+              },
+              "datumOperationeel": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum dat de container operationeel is voor het aanbieden van afval",
+                "title": "Datum operationeel"
+              },
+              "datumAflopenGarantie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop de garantie verloopt",
+                "title": "Einde garantieperiode"
+              },
+              "datumOplevering": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is geleverd",
+                "title": "Datum oplevering"
+              },
+              "wijzigingsdatumDp": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop het object is gewijzigd",
+                "title": "Datumtijd aanmaak wijziging"
+              },
+              "verwijderdDp": {
+                "type": "boolean",
+                "description": "Indicatie of het object verwijderd is bij de bronhouder",
+                "title": "Geldigheid einddatumtijd"
+              },
+              "geadopteerdInd": {
+                "type": "boolean",
+                "description": "indicatie of het object door een bewoner geadopteerd is",
+                "title": "Object geadopteerd indicatie"
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Point.json",
+                "description": "Geometrie van het type POINT van de container RD (epsg:28992)",
+                "title": "Geometrie"
+              },
+              "bagHoofdadresVerblijfsobject": {
+                "type": "string",
+                "relation": "bag:verblijfsobjecten",
+                "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+                "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject.",
+                "title": "BAG hoofdadres verblijfsobject"
+              },
+              "containerRalKleurNaam": {
+                "type": "string",
+                "description": "De naam van de ralkleur",
+                "title": "Container RAL kleur naam"
+              },
+              "containerRalKleurCode": {
+                "type": "string",
+                "description": "De internationale ralkleurcode.",
+                "title": "Container RAL kleur code"
+              },
+              "containerRalKleurHexcode": {
+                "type": "string",
+                "description": "De hexcode van de ralkleur.",
+                "title": "Container RAL hex kleur code"
+              },
+              "containerChipNummber": {
+                "type": "string",
+                "description": "Het identificatienummer van de chip die registreert wanneer de container wordt geleegd.",
+                "title": "Container chip nummer"
+              },
+              "containerUnitCardLezerId": {
+                "type": "string",
+                "description": "Het identificatienummer van de kaartlezer.",
+                "title": "Container unit card lezer id"
+              },
+              "containerKleur": {
+                "type": "string",
+                "description": "De naam van de kleur",
+                "title": "Container kleur"
+              },
+              "containerMark": {
+                "type": "integer",
+                "description": "Definitie volgt nog",
+                "title": "Container mark"
+              },
+              "containerDatumVervanging": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop de container wordt vervangen.",
+                "title": "Container datum vervanging"
+              },
+              "containerDatumWijziging": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop de container is gewijzigd.",
+                "title": "Container datum wijziging"
+              },
+              "containerEndOfLife": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object het einde van zijn levenscyclus heeft bereikt.",
+                "title": "Container levenscyclus einddatum"
+              },
+              "containerEigenaarschap": {
+                "type": "string",
+                "description": "De soort eigenaarschap van het object.",
+                "title": "Container eigenaarschap type"
+              },
+              "containerEigenaarschapOpmerking": {
+                "type": "string",
+                "description": "Beschrijving van  het type eigenaarschap.",
+                "title": "Container eigenaarschap opmerking"
+              },
+              "containerOpmerking": {
+                "type": "string",
+                "description": "Opmerking over het object door de betrokken medewerker.",
+                "title": "Opmerking"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "v2": {
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "version": "1.0.0",
+      "tables": [
+        {
+          "id": "container",
+          "version": "2.2.0",
+          "status": "stable",
+          "type": "table",
+          "title": "Onder- en bovengronds afvalcontainers",
+          "description": "Bevat een overzicht van alle onder- en bovengronds afvalcontainers in Gemeente Amsterdam",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": "id",
+            "required": ["id", "schema"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "string",
+                "description": "Unieke aanduiding objecttype",
+                "title": "Object ID"
+              },
+              "idNummer": {
+                "type": "string",
+                "description": "Identificatie dat door de fabrikant aan het object is gegeven",
+                "title": "Object externe ID"
+              },
+              "serienummer": {
+                "type": "string",
+                "description": "serienummer uitgegeven door de fabrikant",
+                "title": "Serienummer"
+              },
+              "eigenaarId": {
+                "type": "string",
+                "description": "Identificerend kenmerk eigenaar",
+                "title": "Eigenaar ID"
+              },
+              "eigenaarNaam": {
+                "type": "string",
+                "description": "Naam eigenaar",
+                "title": "Eigenaar naam"
+              },
+              "status": {
+                "type": "integer",
+                "enum": [0, 1, 2],
+                "description": "Status van de container,0 - inactief, 1 - actief, 2 - gepland",
+                "title": "Container status code"
+              },
+              "fractieCode": {
+                "type": "string",
+                "enum": ["1", "2", "3", "4", "5", "6", "9"],
+                "description": "Type afvalfractie code waarvoor de container is bedoeld: 1 - Rest, 2 - Glas, 3 - Papier, 4 - Plastic, 5 - Textiel, 6 - GFT, 9 - Brood",
+                "title": "Afvalfractie soort code"
+              },
+              "fractieOmschrijving": {
+                "type": "string",
+                "description": "Container fractieomschrijving zoals door leverancier is geleverd.",
+                "title": "Afvalfractie soort naam"
+              },
+              "datumCreatie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is gecreëerd in container management systeem",
+                "title": "Datum registratie startdatum"
+              },
+              "datumPlaatsing": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object op de locatie is geplaatst",
+                "title": "Datum plaatsing"
+              },
+              "datumOperationeel": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum dat de container operationeel is voor het aanbieden van afval",
+                "title": "Datum operationeel"
+              },
+              "datumAflopenGarantie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop de garantie verloopt",
+                "title": "Einde garantieperiode"
+              },
+              "datumOplevering": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is geleverd",
+                "title": "Datum oplevering"
+              },
+              "wijzigingsdatumDp": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop het object is gewijzigd",
+                "title": "Datumtijd aanmaak wijziging"
+              },
+              "verwijderdDp": {
+                "type": "boolean",
+                "description": "Indicatie of het object verwijderd is bij de bronhouder",
+                "title": "Geldigheid einddatumtijd"
+              },
+              "geadopteerdInd": {
+                "type": "boolean",
+                "description": "indicatie of het object door een bewoner geadopteerd is",
+                "title": "Object geadopteerd indicatie"
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Point.json",
+                "description": "Geometrie van het type POINT van de container RD (epsg:28992)",
+                "title": "Geometrie"
+              },
+              "bagHoofdadresVerblijfsobject": {
+                "type": "string",
+                "relation": "bag:verblijfsobjecten",
+                "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+                "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject.",
+                "title": "BAG hoofdadres verblijfsobject"
+              },
+              "containerRalKleurNaam": {
+                "type": "string",
+                "description": "De naam van de ralkleur",
+                "title": "Container RAL kleur naam"
+              },
+              "containerRalKleurCode": {
+                "type": "string",
+                "description": "De internationale ralkleurcode.",
+                "title": "Container RAL kleur code"
+              },
+              "containerRalKleurHexcode": {
+                "type": "string",
+                "description": "De hexcode van de ralkleur.",
+                "title": "Container RAL hex kleur code"
+              },
+              "containerChipNummber": {
+                "type": "string",
+                "description": "Het identificatienummer van de chip die registreert wanneer de container wordt geleegd.",
+                "title": "Container chip nummer"
+              },
+              "containerUnitCardLezerId": {
+                "type": "string",
+                "description": "Het identificatienummer van de kaartlezer.",
+                "title": "Container unit card lezer id"
+              },
+              "containerKleur": {
+                "type": "string",
+                "description": "De naam van de kleur",
+                "title": "Container kleur"
+              },
+              "containerMark": {
+                "type": "integer",
+                "description": "Definitie volgt nog",
+                "title": "Container mark"
+              },
+              "containerDatumVervanging": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop de container wordt vervangen.",
+                "title": "Container datum vervanging"
+              },
+              "containerDatumWijziging": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop de container is gewijzigd.",
+                "title": "Container datum wijziging"
+              },
+              "containerEndOfLife": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object het einde van zijn levenscyclus heeft bereikt.",
+                "title": "Container levenscyclus einddatum"
+              },
+              "containerEigenaarschap": {
+                "type": "string",
+                "description": "De soort eigenaarschap van het object.",
+                "title": "Container eigenaarschap type"
+              },
+              "containerEigenaarschapOpmerking": {
+                "type": "string",
+                "description": "Beschrijving van  het type eigenaarschap.",
+                "title": "Container eigenaarschap opmerking"
+              },
+              "containerOpmerking": {
+                "type": "string",
+                "description": "Opmerking over het object door de betrokken medewerker.",
+                "title": "Opmerking"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/files/datasets/huishoudelijkafval/dataset_v2.json
+++ b/tests/files/datasets/huishoudelijkafval/dataset_v2.json
@@ -1,0 +1,434 @@
+{
+  "id": "huishoudelijkafval",
+  "type": "dataset",
+  "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
+  "auth": "OPENBAAR",
+  "theme": ["duurzaamheid en milieu"],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Directie Afval en Grondstoffen, Gemeente Amsterdam",
+  "spatialDescription": "Gemeente Amsterdam",
+  "title": "Afvalcontainers, putten en weeggegevens",
+  "language": "nl",
+  "dateCreated": "2020-01-13T00:00:00+01:00",
+  "license": "openbaar, tenzij anders aangegeven / behoudens uitzonderingen",
+  "creator": "Datateam Beeldschoon/BOR",
+  "publisher": {
+    "$ref": "/publishers/GLEBZ"
+  },
+  "description": "Alle locaties van afvalcontainers (ondergrondse afvalcontainers, bovengrondse afvalcontainers en rolcontainers) en  betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas en Textiel. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
+  "keywords": [
+    "Afval",
+    "Afvalcontainers",
+    "Containers",
+    "Glas",
+    "Glasbak",
+    "Oud papier",
+    "Textiel",
+    "Restafval",
+    "rolcontainer",
+    "loopafstanden",
+    "servicegebieden"
+  ],
+  "crs": "EPSG:28992",
+  "objective": "Deze dataset bevat data over huishoudelijk afval. Het gaat hierbij om de infrastructuur van  ondergrondse- en rolcontainers. Naast de objecteigenschappen, van bijvoorbeeld locatie tot containervolume, bevat de set ook gegevens over het onderhoud, de vulling, de hoeveelheid afval, bijplaatsingen enz. De dataset wordt gevuld vanuit veel verschillende bronsystemen. VConsyst voor containers, clusters, fracties en tickets(meldingen over containers). Inovim voor de rolcontainers. Kilogram voor weeggegevens afkomstig van de wagens. In afvoermomenten de hoeveelheden afval aangeboden aan afvalverwerkers. Container vulgraden en vulsnelheden is  sensordata uit containers. Het doel van deze dataset is het beschikbaar stellen van gegevens voor het ondersteunen van plaatsingsbeleid betreffende ondergrondse afvalcontainers en het ondersteunen van routeoptimalisatie voor afvalinzameling.",
+  "temporalUnit": "uren",
+  "defaultVersion": "v2",
+  "versions": {
+    "v1": {
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "version": "2.5.0",
+      "tables": [
+        {
+          "id": "container",
+          "version": "2.2.0",
+          "status": "stable",
+          "type": "table",
+          "title": "Onder- en bovengronds afvalcontainers",
+          "description": "Bevat een overzicht van alle onder- en bovengronds afvalcontainers in Gemeente Amsterdam",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": "id",
+            "required": ["id", "schema"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "string",
+                "description": "Unieke aanduiding objecttype",
+                "title": "Object ID"
+              },
+              "idNummer": {
+                "type": "string",
+                "description": "Identificatie dat door de fabrikant aan het object is gegeven",
+                "title": "Object externe ID"
+              },
+              "serienummer": {
+                "type": "string",
+                "description": "serienummer uitgegeven door de fabrikant",
+                "title": "Serienummer"
+              },
+              "eigenaarId": {
+                "type": "string",
+                "description": "Identificerend kenmerk eigenaar",
+                "title": "Eigenaar ID"
+              },
+              "eigenaarNaam": {
+                "type": "string",
+                "description": "Naam eigenaar",
+                "title": "Eigenaar naam"
+              },
+              "status": {
+                "type": "integer",
+                "enum": [0, 1, 2],
+                "description": "Status van de container,0 - inactief, 1 - actief, 2 - gepland",
+                "title": "Container status code"
+              },
+              "fractieCode": {
+                "type": "string",
+                "enum": ["1", "2", "3", "4", "5", "6", "9"],
+                "description": "Type afvalfractie code waarvoor de container is bedoeld: 1 - Rest, 2 - Glas, 3 - Papier, 4 - Plastic, 5 - Textiel, 6 - GFT, 9 - Brood",
+                "title": "Afvalfractie soort code"
+              },
+              "fractieOmschrijving": {
+                "type": "string",
+                "description": "Container fractieomschrijving zoals door leverancier is geleverd.",
+                "title": "Afvalfractie soort naam"
+              },
+              "datumCreatie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is gecreëerd in container management systeem",
+                "title": "Datum registratie startdatum"
+              },
+              "datumPlaatsing": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object op de locatie is geplaatst",
+                "title": "Datum plaatsing"
+              },
+              "datumOperationeel": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum dat de container operationeel is voor het aanbieden van afval",
+                "title": "Datum operationeel"
+              },
+              "datumAflopenGarantie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop de garantie verloopt",
+                "title": "Einde garantieperiode"
+              },
+              "datumOplevering": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is geleverd",
+                "title": "Datum oplevering"
+              },
+              "wijzigingsdatumDp": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop het object is gewijzigd",
+                "title": "Datumtijd aanmaak wijziging"
+              },
+              "verwijderdDp": {
+                "type": "boolean",
+                "description": "Indicatie of het object verwijderd is bij de bronhouder",
+                "title": "Geldigheid einddatumtijd"
+              },
+              "geadopteerdInd": {
+                "type": "boolean",
+                "description": "indicatie of het object door een bewoner geadopteerd is",
+                "title": "Object geadopteerd indicatie"
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Point.json",
+                "description": "Geometrie van het type POINT van de container RD (epsg:28992)",
+                "title": "Geometrie"
+              },
+              "bagHoofdadresVerblijfsobject": {
+                "type": "string",
+                "relation": "bag:verblijfsobjecten",
+                "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+                "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject.",
+                "title": "BAG hoofdadres verblijfsobject"
+              },
+              "containerRalKleurNaam": {
+                "type": "string",
+                "description": "De naam van de ralkleur",
+                "title": "Container RAL kleur naam"
+              },
+              "containerRalKleurCode": {
+                "type": "string",
+                "description": "De internationale ralkleurcode.",
+                "title": "Container RAL kleur code"
+              },
+              "containerRalKleurHexcode": {
+                "type": "string",
+                "description": "De hexcode van de ralkleur.",
+                "title": "Container RAL hex kleur code"
+              },
+              "containerChipNummber": {
+                "type": "string",
+                "description": "Het identificatienummer van de chip die registreert wanneer de container wordt geleegd.",
+                "title": "Container chip nummer"
+              },
+              "containerUnitCardLezerId": {
+                "type": "string",
+                "description": "Het identificatienummer van de kaartlezer.",
+                "title": "Container unit card lezer id"
+              },
+              "containerKleur": {
+                "type": "string",
+                "description": "De naam van de kleur",
+                "title": "Container kleur"
+              },
+              "containerMark": {
+                "type": "integer",
+                "description": "Definitie volgt nog",
+                "title": "Container mark"
+              },
+              "containerDatumVervanging": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop de container wordt vervangen.",
+                "title": "Container datum vervanging"
+              },
+              "containerDatumWijziging": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop de container is gewijzigd.",
+                "title": "Container datum wijziging"
+              },
+              "containerEndOfLife": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object het einde van zijn levenscyclus heeft bereikt.",
+                "title": "Container levenscyclus einddatum"
+              },
+              "containerEigenaarschap": {
+                "type": "string",
+                "description": "De soort eigenaarschap van het object.",
+                "title": "Container eigenaarschap type"
+              },
+              "containerEigenaarschapOpmerking": {
+                "type": "string",
+                "description": "Beschrijving van  het type eigenaarschap.",
+                "title": "Container eigenaarschap opmerking"
+              },
+              "containerOpmerking": {
+                "type": "string",
+                "description": "Opmerking over het object door de betrokken medewerker.",
+                "title": "Opmerking"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "v2": {
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "version": "1.0.0",
+      "tables": [
+        {
+          "id": "container",
+          "version": "2.2.0",
+          "status": "stable",
+          "type": "table",
+          "title": "Onder- en bovengronds afvalcontainers",
+          "description": "Bevat een overzicht van alle onder- en bovengronds afvalcontainers in Gemeente Amsterdam",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "mainGeometry": "geometrie",
+            "identifier": "id",
+            "required": ["id", "schema"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "string",
+                "description": "Unieke aanduiding objecttype",
+                "title": "Object ID"
+              },
+              "idNummer": {
+                "type": "string",
+                "description": "Identificatie dat door de fabrikant aan het object is gegeven",
+                "title": "Object externe ID"
+              },
+              "serienummer": {
+                "type": "string",
+                "description": "serienummer uitgegeven door de fabrikant",
+                "title": "Serienummer"
+              },
+              "eigenaarId": {
+                "type": "string",
+                "description": "Identificerend kenmerk eigenaar",
+                "title": "Eigenaar ID"
+              },
+              "eigenaarNaam": {
+                "type": "string",
+                "description": "Naam eigenaar",
+                "title": "Eigenaar naam"
+              },
+              "status": {
+                "type": "integer",
+                "enum": [0, 1, 2],
+                "description": "Status van de container,0 - inactief, 1 - actief, 2 - gepland",
+                "title": "Container status code"
+              },
+              "fractieCode": {
+                "type": "string",
+                "enum": ["1", "2", "3", "4", "5", "6", "9"],
+                "description": "Type afvalfractie code waarvoor de container is bedoeld: 1 - Rest, 2 - Glas, 3 - Papier, 4 - Plastic, 5 - Textiel, 6 - GFT, 9 - Brood",
+                "title": "Afvalfractie soort code"
+              },
+              "fractieOmschrijving": {
+                "type": "string",
+                "description": "Container fractieomschrijving zoals door leverancier is geleverd.",
+                "title": "Afvalfractie soort naam"
+              },
+              "datumCreatie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is gecreëerd in container management systeem",
+                "title": "Datum registratie startdatum"
+              },
+              "datumPlaatsing": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object op de locatie is geplaatst",
+                "title": "Datum plaatsing"
+              },
+              "datumOperationeel": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum dat de container operationeel is voor het aanbieden van afval",
+                "title": "Datum operationeel"
+              },
+              "datumAflopenGarantie": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop de garantie verloopt",
+                "title": "Einde garantieperiode"
+              },
+              "datumOplevering": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object is geleverd",
+                "title": "Datum oplevering"
+              },
+              "wijzigingsdatumDp": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop het object is gewijzigd",
+                "title": "Datumtijd aanmaak wijziging"
+              },
+              "verwijderdDp": {
+                "type": "boolean",
+                "description": "Indicatie of het object verwijderd is bij de bronhouder",
+                "title": "Geldigheid einddatumtijd"
+              },
+              "geadopteerdInd": {
+                "type": "boolean",
+                "description": "indicatie of het object door een bewoner geadopteerd is",
+                "title": "Object geadopteerd indicatie"
+              },
+              "geometrie": {
+                "$ref": "https://geojson.org/schema/Point.json",
+                "description": "Geometrie van het type POINT van de container RD (epsg:28992)",
+                "title": "Geometrie"
+              },
+              "bagHoofdadresVerblijfsobject": {
+                "type": "string",
+                "relation": "bag:verblijfsobjecten",
+                "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+                "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject.",
+                "title": "BAG hoofdadres verblijfsobject"
+              },
+              "containerRalKleurNaam": {
+                "type": "string",
+                "description": "De naam van de ralkleur",
+                "title": "Container RAL kleur naam"
+              },
+              "containerRalKleurCode": {
+                "type": "string",
+                "description": "De internationale ralkleurcode.",
+                "title": "Container RAL kleur code"
+              },
+              "containerRalKleurHexcode": {
+                "type": "string",
+                "description": "De hexcode van de ralkleur.",
+                "title": "Container RAL hex kleur code"
+              },
+              "containerChipNummber": {
+                "type": "string",
+                "description": "Het identificatienummer van de chip die registreert wanneer de container wordt geleegd.",
+                "title": "Container chip nummer"
+              },
+              "containerUnitCardLezerId": {
+                "type": "string",
+                "description": "Het identificatienummer van de kaartlezer.",
+                "title": "Container unit card lezer id"
+              },
+              "containerKleur": {
+                "type": "string",
+                "description": "De naam van de kleur",
+                "title": "Container kleur"
+              },
+              "containerMark": {
+                "type": "integer",
+                "description": "Definitie volgt nog",
+                "title": "Container mark"
+              },
+              "containerDatumVervanging": {
+                "type": "string",
+                "format": "date",
+                "description": "De datum waarop de container wordt vervangen.",
+                "title": "Container datum vervanging"
+              },
+              "containerDatumWijziging": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Datum waarop de container is gewijzigd.",
+                "title": "Container datum wijziging"
+              },
+              "containerEndOfLife": {
+                "type": "string",
+                "format": "date",
+                "description": "Datum waarop het object het einde van zijn levenscyclus heeft bereikt.",
+                "title": "Container levenscyclus einddatum"
+              },
+              "containerEigenaarschap": {
+                "type": "string",
+                "description": "De soort eigenaarschap van het object.",
+                "title": "Container eigenaarschap type"
+              },
+              "containerEigenaarschapOpmerking": {
+                "type": "string",
+                "description": "Beschrijving van  het type eigenaarschap.",
+                "title": "Container eigenaarschap opmerking"
+              },
+              "containerOpmerking": {
+                "type": "string",
+                "description": "Opmerking over het object door de betrokken medewerker.",
+                "title": "Opmerking"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
NB: dit omzeilt het onderliggende probleem. 

Het onderliggende probleem is dat bij een defaultVersion wijziging, de tabellen van de oude versie zouden worden verwijderd (en gelukkig faalde dat), omdat de states die vergeleken werden twee niet-overlappende sets aan modellen hebben; deze zitten namelijk in verschillende django apps. Ik maak hier een apart ticket voor aan.