### PR TITLE
Exports: create connection for each table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2026-04-23 (9.5.0)
+
+* Refactor exports so that it does not reuse the same db connection for all exports. Instead pass
+  in the db engine and create a connection for each export.
+
 # 2026-04-22 (9.4.3)
 
 * Bugfix: Do not migrate any table that doesn't change its version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.4.3
+version = 9.5.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -20,7 +20,7 @@ import requests
 import sqlalchemy
 from deepdiff import DeepDiff
 from jsonschema import draft7_format_checker
-from sqlalchemy import Connection, inspect
+from sqlalchemy import Engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.future import create_engine
 
@@ -153,7 +153,7 @@ def import_() -> None:
 
 
 def create_export_context(
-    connection: Connection,
+    engine: Engine,
     dataset: DatasetSchema,
     table_ids: list[str],
     scope: str,
@@ -179,7 +179,7 @@ def create_export_context(
         _dataset_name=dataset.id,
     )
     return ExportContext(
-        connection=connection,
+        engine=engine,
         dataset=dataset,
         folder=Path(output or "tmp"),
         client=None,
@@ -221,19 +221,18 @@ def export(
     """Command to export data."""
     engine = _get_engine(db_url)
     dataset_schema = _get_dataset_schema(dataset_id, schema_url)
-    with engine.begin() as connection:
-        for scope in scopes:
-            context = create_export_context(
-                connection,
-                dataset_schema,
-                table_ids,
-                scope=scope,
-                output=output,
-                filetype=filetype,
-                version=None,
-                size=size,
-            )
-            export_tables(context)
+    for scope in scopes:
+        context = create_export_context(
+            engine,
+            dataset_schema,
+            table_ids,
+            scope=scope,
+            output=output,
+            filetype=filetype,
+            version=None,
+            size=size,
+        )
+        export_tables(context)
 
 
 @schema.group("tocase")

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -7,7 +7,7 @@ import re
 import zipfile
 from pathlib import Path
 
-from sqlalchemy import Connection
+from sqlalchemy import Engine
 
 from schematools.exports.base import BaseExporter
 from schematools.exports.csv import CsvExporter
@@ -88,7 +88,7 @@ def remove_files(file_paths: list[Path]):
 
 
 def export(
-    connection: Connection,
+    engine: Engine,
     storage_client: StorageClient,
     output_path: str = "tmp",
     *,
@@ -107,19 +107,20 @@ def export(
         file_paths: list[Path] = []
         for version in dataset.versions.values():
             for export in version.exports:
-                context = ExportContext(
-                    connection=connection,
-                    dataset=dataset,
-                    folder=path,
-                    export=export,
-                    client=storage_client,
-                )
-                logger.info("Exporting %s", export)
-                export_tables(context)
-                zip_path = zip_files(context)
-                upload_to_storage(zip_path, context, dataset_metadata)
-                file_paths.extend(context.export.table_paths(context.folder))
-                file_paths.append(context.folder / context.export.filename_without_zip)
+                with engine.connect() as connection:
+                    context = ExportContext(
+                        connection=connection,
+                        dataset=dataset,
+                        folder=path,
+                        export=export,
+                        client=storage_client,
+                    )
+                    logger.info("Exporting %s", export)
+                    export_tables(context)
+                    zip_path = zip_files(context)
+                    upload_to_storage(zip_path, context, dataset_metadata)
+                    file_paths.extend(context.export.table_paths(context.folder))
+                    file_paths.append(context.folder / context.export.filename_without_zip)
 
         if cleanup:
             remove_files(file_paths)

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -107,20 +107,19 @@ def export(
         file_paths: list[Path] = []
         for version in dataset.versions.values():
             for export in version.exports:
-                with engine.connect() as connection:
-                    context = ExportContext(
-                        connection=connection,
-                        dataset=dataset,
-                        folder=path,
-                        export=export,
-                        client=storage_client,
-                    )
-                    logger.info("Exporting %s", export)
-                    export_tables(context)
-                    zip_path = zip_files(context)
-                    upload_to_storage(zip_path, context, dataset_metadata)
-                    file_paths.extend(context.export.table_paths(context.folder))
-                    file_paths.append(context.folder / context.export.filename_without_zip)
+                context = ExportContext(
+                    engine=engine,
+                    dataset=dataset,
+                    folder=path,
+                    export=export,
+                    client=storage_client,
+                )
+                logger.info("Exporting %s", export)
+                export_tables(context)
+                zip_path = zip_files(context)
+                upload_to_storage(zip_path, context, dataset_metadata)
+                file_paths.extend(context.export.table_paths(context.folder))
+                file_paths.append(context.folder / context.export.filename_without_zip)
 
         if cleanup:
             remove_files(file_paths)

--- a/src/schematools/exports/base.py
+++ b/src/schematools/exports/base.py
@@ -32,16 +32,16 @@ class BaseExporter:
         """Constructor.
 
         Args:
-        connection: SQLAlchemy connection object.
-        dataset_schema: Schema that needs export as geopackage.
-        output: path on the filesystem where output should be stored.
-        table_ids: optional parameter for a subset for the tables of the dataset.
-        scopes: Keycloak scopes that need to be taken into account.
-            The geopackage will be produced contains information that is only
-            accessible with these scopes.
-        size: To produce a subset of the rows, mainly for testing.
+        context: ExportContext object containing all necessary information for the export, such as
+            engine: SQLAlchemy engine object.
+            dataset: Schema that needs export as geopackage.
+            folder: Path on the filesystem where output should be stored.
+            export: Export definition.
+            client: Storage client to upload the produced files.
+            size: To produce a subset of the rows, mainly for testing.
+            temporal_date: To produce a subset of the rows based on the temporal dimension.
         """
-        self.connection = context.connection
+        self.engine = context.engine
         self.dataset_schema = context.dataset
         self.export = context.export
         self.scopes = context.export.scopes

--- a/src/schematools/exports/csv.py
+++ b/src/schematools/exports/csv.py
@@ -39,8 +39,11 @@ class CsvExporter(BaseExporter):  # noqa: D101
             query = query.limit(self.size)
 
         # Use server-side cursor with small batches
-        with self.connection.execution_options(stream_results=True, max_row_buffer=1000).execute(
-            query
-        ) as result:
+        with (
+            self.engine.execution_options(
+                stream_results=True, max_row_buffer=1000
+            ).connect() as connection,
+            connection.execute(query) as result,
+        ):
             for partition in result.mappings().partitions(size=1000):
                 writer.writerows(dict(row) for row in partition)

--- a/src/schematools/exports/geojson.py
+++ b/src/schematools/exports/geojson.py
@@ -50,9 +50,12 @@ class GeoJsonExporter(BaseExporter):
             file_handle.write('{"type": "FeatureCollection", "features": [')
 
             first_feature = True
-            with self.connection.execution_options(
-                stream_results=True, max_row_buffer=1000
-            ).execute(query) as result:
+            with (
+                self.engine.execution_options(
+                    stream_results=True, max_row_buffer=1000
+                ).connect() as connection,
+                connection.execute(query) as result,
+            ):
                 for partition in result.mappings().partitions(size=1000):
                     for row in partition:
                         try:

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 class GeopackageExporter(BaseExporter):
     def export_tables(self):
         pg_conn_str = (
-            f"host={self.connection.engine.url.host} "
-            f"port={self.connection.engine.url.port} "
-            f"dbname={self.connection.engine.url.database} "
-            f"user={self.connection.engine.url.username} "
-            f"password={self.connection.engine.url.password}"
+            f"host={self.engine.url.host} "
+            f"port={self.engine.url.port} "
+            f"dbname={self.engine.url.database} "
+            f"user={self.engine.url.username} "
+            f"password={self.engine.url.password}"
         )
         consolidated_file = self.base_dir / self.export.filename_without_zip
         logger.info("Exporting %s.", self.export.filename_without_zip)

--- a/src/schematools/exports/jsonlines.py
+++ b/src/schematools/exports/jsonlines.py
@@ -66,7 +66,7 @@ class JsonLinesExporter(BaseExporter):  # noqa: D101
         if self.size is not None:
             query = query.limit(self.size)
 
-        with self.connection.engine.execution_options(yield_per=1000).connect() as conn:
+        with self.engine.execution_options(yield_per=1000).connect() as conn:
             result = conn.execute(query)
             for partition in result.mappings().partitions():
                 for r in partition:

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -29,7 +29,7 @@ from typing import (
 )
 
 from deepdiff import DeepDiff
-from sqlalchemy import Connection
+from sqlalchemy import Engine
 
 from schematools import MAX_TABLE_NAME_LENGTH
 from schematools._utils import cached_method
@@ -1019,15 +1019,19 @@ class BlobClient(Protocol):
     def upload_blob(
         self, data: BufferedReader, overwrite: bool, metadata: dict[str, Any] | None
     ): ...
+
+
 class ContainerClient(Protocol):
     def get_blob_client(self, blob_name: str) -> BlobClient: ...
+
+
 class StorageClient(Protocol):
     def get_container_client(self, container_name: str) -> ContainerClient: ...
 
 
 @dataclasses.dataclass
 class ExportContext:
-    connection: Connection
+    engine: Engine
     dataset: DatasetSchema
     folder: Path
     export: Export
@@ -1105,8 +1109,7 @@ class Export:
     @property
     def filename_without_zip(self) -> str:
         return (
-            f"{self._dataset_name}_{self.version}_{self.name}_{self.scopes_string}."
-            f"{self.filetype}"
+            f"{self._dataset_name}_{self.version}_{self.name}_{self.scopes_string}.{self.filetype}"
         )
 
     @property
@@ -1115,8 +1118,7 @@ class Export:
 
     def table_filename(self, table_id: str) -> str:
         return (
-            f"{self._dataset_name}_{self.version}_{table_id}_{self.scopes_string}."
-            f"{self.filetype}"
+            f"{self._dataset_name}_{self.version}_{table_id}_{self.scopes_string}.{self.filetype}"
         )
 
     def table_paths(self, folder: Path) -> list[Path]:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -105,13 +105,10 @@ class TestExports:
     @pytest.fixture
     def create_context(self, engine, storage_client, tmp_folder):
         """Factory fixture to create ExportContext objects for testing."""
-        connections = []
 
         def create(dataset, export):
-            connection = engine.connect()
-            connections.append(connection)
             return ExportContext(
-                connection=connection,
+                engine=engine,
                 client=storage_client,
                 dataset=dataset,
                 export=export,
@@ -119,10 +116,7 @@ class TestExports:
                 size=1,
             )
 
-        yield create
-
-        for connection in connections:
-            connection.close()
+        return create
 
     def test_export(
         self,
@@ -310,7 +304,7 @@ class TestExports:
         context = create_context(gebieden_export_schema, export_definition)
 
         # Ensure the DB tables exist so ogr2ogr can create layers.
-        importer = NDJSONImporter(gebieden_export_schema, context.connection.engine)
+        importer = NDJSONImporter(gebieden_export_schema, context.engine)
         for table_id in ("stadsdelen", "ggw_gebieden", "wijken"):
             importer.generate_db_objects(table_id, truncate=False, ind_extra_index=False)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -24,7 +24,7 @@ from schematools.types import ExportContext
 
 class TestExports:
     @pytest.fixture
-    def connection(self, db_url, sqlalchemy_keep_db):
+    def engine(self, db_url, sqlalchemy_keep_db):
         """Use a separate db for these tests, as they can interfere with the tests using the main
         test database."""
         engine = create_engine(
@@ -44,7 +44,7 @@ class TestExports:
             with engine.connect() as connection:
                 connection.execute(text("CREATE EXTENSION postgis"))
                 connection.commit()
-                yield connection
+            yield engine
         sqlalchemy_utils.functions.drop_database(engine.url)
         engine.dispose()
 
@@ -86,9 +86,9 @@ class TestExports:
         return DummyStorageClient()
 
     @pytest.fixture
-    def meetbouten_content(self, here, connection, meetbouten_export_schema):
+    def meetbouten_content(self, here, engine, meetbouten_export_schema):
         ndjson_path = here / "files" / "data" / "meetbouten.ndjson"
-        importer = NDJSONImporter(meetbouten_export_schema, connection.engine)
+        importer = NDJSONImporter(meetbouten_export_schema, engine)
         importer.generate_db_objects("meetbouten", truncate=True, ind_extra_index=False)
         importer.load_file(ndjson_path)
 
@@ -103,10 +103,13 @@ class TestExports:
         path.rmdir()
 
     @pytest.fixture
-    def create_context(self, connection, storage_client, tmp_folder):
+    def create_context(self, engine, storage_client, tmp_folder):
         """Factory fixture to create ExportContext objects for testing."""
+        connections = []
 
         def create(dataset, export):
+            connection = engine.connect()
+            connections.append(connection)
             return ExportContext(
                 connection=connection,
                 client=storage_client,
@@ -116,11 +119,14 @@ class TestExports:
                 size=1,
             )
 
-        return create
+        yield create
+
+        for connection in connections:
+            connection.close()
 
     def test_export(
         self,
-        connection,
+        engine,
         storage_client,
         gebieden_export_schema,
         meetbouten_export_schema,
@@ -128,16 +134,16 @@ class TestExports:
         caplog,
     ):
         caplog.set_level(logging.INFO)
-        importer = NDJSONImporter(gebieden_export_schema, connection.engine)
+        importer = NDJSONImporter(gebieden_export_schema, engine)
         importer.generate_db_objects("bouwblokken", truncate=False, ind_extra_index=False)
         importer.generate_db_objects("buurten", truncate=False, ind_extra_index=False)
         importer.generate_db_objects("wijken", truncate=False, ind_extra_index=False)
         importer.generate_db_objects("stadsdelen", truncate=False, ind_extra_index=False)
         importer.generate_db_objects("ggw_gebieden", truncate=False, ind_extra_index=False)
-        importer = NDJSONImporter(meetbouten_export_schema, connection.engine)
+        importer = NDJSONImporter(meetbouten_export_schema, engine)
         importer.generate_db_objects("meetbouten", truncate=False, ind_extra_index=False)
         importer.generate_db_objects("metingen", truncate=False, ind_extra_index=False)
-        export(connection, storage_client, loader=export_schema_loader, cleanup=False)
+        export(engine, storage_client, loader=export_schema_loader, cleanup=False)
         local_files = [
             "gebieden_v1_bouwblokken_openbaar.csv",
             "gebieden_v1_buurten_openbaar.csv",
@@ -222,23 +228,25 @@ class TestExports:
                 "1,10180001.1,12,De meetbout,SRID=28992;POINT(119434 487091.6),,\n"
             )
 
-    def test_csv_export_only_actual(self, gebieden_export_schema, create_context, connection):
+    def test_csv_export_only_actual(self, gebieden_export_schema, create_context, engine):
         """Prove that csv export contains only the actual records, not the history."""
-        importer = NDJSONImporter(gebieden_export_schema, connection.engine, logger=logger)
+        importer = NDJSONImporter(gebieden_export_schema, engine, logger=logger)
         importer.generate_db_objects("ggw_gebieden", truncate=True, ind_extra_index=False)
-        connection.execute(
-            text(
-                "INSERT INTO gebieden_ggw_gebieden_v1 (id, identificatie, volgnummer, "
-                "begin_geldigheid, eind_geldigheid) VALUES (1, 'ggw_gebied1', 1, '2020-01-01', "
-                "'2020-12-31')"
+        with engine.connect() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO gebieden_ggw_gebieden_v1 (id, identificatie, volgnummer, "
+                    "begin_geldigheid, eind_geldigheid) VALUES (1, 'ggw_gebied1', 1, '2020-01-01', "
+                    "'2020-12-31')"
+                )
             )
-        )
-        connection.execute(
-            text(
-                "INSERT INTO gebieden_ggw_gebieden_v1 (id, identificatie, volgnummer, "
-                "begin_geldigheid, eind_geldigheid) VALUES (2, 'ggw_gebied1', 2, '2021-01-01', NULL)"
+            connection.execute(
+                text(
+                    "INSERT INTO gebieden_ggw_gebieden_v1 (id, identificatie, volgnummer, "
+                    "begin_geldigheid, eind_geldigheid) VALUES (2, 'ggw_gebied1', 2, '2021-01-01', NULL)"
+                )
             )
-        )
+            connection.commit()
         export_definition = next(
             exp
             for exp in gebieden_export_schema.versions["v1"].exports
@@ -347,14 +355,14 @@ class TestExports:
                 "geometry": {"type": "Point", "coordinates": [4.86497, 52.37055]},
             }
 
-    def test_export_cli(self, connection, meetbouten_content):
+    def test_export_cli(self, engine, meetbouten_content):
         """Test the export CLI command."""
         runner = CliRunner()
         result = runner.invoke(
             export_cli,
             [
                 "--db-url",
-                connection.engine.url.render_as_string(hide_password=False),
+                engine.url.render_as_string(hide_password=False),
                 "--schema-url",
                 str(Path(__file__).parent / "files" / "exports"),
                 "meet_bouten",


### PR DESCRIPTION
Dit zorgt ervoor dat de exports niet dezelfde connectie herbruiken, maar voor elke tabel een eigen connectie maakt en de export uitvoert. 