### PR TITLE
[BUGFIX] update default version AB#169816

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2026-05-04 (9.6.1)
+
+* Fix bug in migration logic when default version is changed.
+* Fix deprecation warning about jsonschema format checker.
+* Mute RuntimeWarnings in tests.
+
 # 2026-04-28 (9.6.0)
 
 * Remove dry-run/execute flag from import schemas command as this is unused.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ norecursedirs = ["node_modules", ".tox", ".git"]
 filterwarnings = [
     "once::DeprecationWarning",
     "once::PendingDeprecationWarning",
+    "ignore::RuntimeWarning",
 ]
 
 # ==== Coverage ====

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.6.0
+version = 9.6.1
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -19,7 +19,7 @@ import jsonschema
 import requests
 import sqlalchemy
 from deepdiff import DeepDiff
-from jsonschema import draft7_format_checker
+from jsonschema.validators import Draft7Validator
 from sqlalchemy import Engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.future import create_engine
@@ -503,7 +503,7 @@ def validate(
             jsonschema.validate(
                 instance=dataset.json_data(inline_tables=True, inline_publishers=False),
                 schema=meta_schema,
-                format_checker=draft7_format_checker,
+                format_checker=Draft7Validator.FORMAT_CHECKER,
             )
         except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
             click.echo("Structural validation: ", nl=False)
@@ -628,7 +628,7 @@ def validate_publishers(schema_url: str, meta_schema_url: tuple[str]) -> None:
                 jsonschema.validate(
                     instance=publisher.json_data(),
                     schema=meta_schema,
-                    format_checker=draft7_format_checker,
+                    format_checker=Draft7Validator.FORMAT_CHECKER,
                 )
             except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
                 click.echo("Structural validation: ", nl=False)
@@ -684,7 +684,7 @@ def validate_scopes(schema_url: str, meta_schema_url: tuple[str]) -> None:
                 jsonschema.validate(
                     instance=scope.json_data(),
                     schema=meta_schema,
-                    format_checker=draft7_format_checker,
+                    format_checker=Draft7Validator.FORMAT_CHECKER,
                 )
             except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
                 click.echo("Structural validation: ", nl=False)
@@ -823,7 +823,7 @@ def batch_validate(
         meta_schema = _fetch_json(url)
         validator_class = jsonschema.validators.validator_for(meta_schema)
         validator_class.check_schema(meta_schema)
-        validator = validator_class(meta_schema, format_checker=draft7_format_checker)
+        validator = validator_class(meta_schema, format_checker=Draft7Validator.FORMAT_CHECKER)
         validators[meta_schema_version] = validator
 
     done = set()

--- a/src/schematools/contrib/django/factories.py
+++ b/src/schematools/contrib/django/factories.py
@@ -128,6 +128,12 @@ class DjangoModelFactory:
         # Set _current_version to default in case we directly call `build_model()`
         self._current_version: str = self.schema.default_version
 
+    def set_version(self, version: str) -> None:
+        """Set the current version for the factory, so that relations are properly linked."""
+        if version not in self.schema.versions:
+            raise ValueError(f"Version {version} not found in dataset schema.")
+        self._current_version = version
+
     def build_models(self) -> list[type[M]]:
         """Main entrypoint, creates a list of django models for a dataset.
 
@@ -455,8 +461,7 @@ class DjangoModelFactory:
             **self._get_basic_kwargs(field),
             "related_name": related_name,
             "through": (
-                f"{self.get_app_label(through_table.dataset)}."
-                f"{self.get_model_name(through_table)}"
+                f"{self.get_app_label(through_table.dataset)}.{self.get_model_name(through_table)}"
             ),
             "through_fields": through_fields,
         }

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -191,9 +191,6 @@ class Command(BaseCommand):
                 updated_table = updated_dataset.schema.get_table_by_id(
                     current_table.id, include_nested=False, include_through=False
                 )
-                if current_table.version == updated_table.version:
-                    # No migration necessary, as any change would have resulted in a version bump.
-                    continue
                 if current_table.version.vmajor == updated_table.version.vmajor:
                     # If the table is under_development and there are breaking changes to
                     # the table, drop the table

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -25,7 +25,7 @@ def migrate(
     updated_table: DatasetTableSchema,
     real_apps: list[str],
     database: str = DEFAULT_DB_ALIAS,
-    project_state: ProjectState = None,
+    project_state: ProjectState | None = None,
 ):
     """
     Creates a project state for both the current dataset and the updated dataset.
@@ -55,7 +55,10 @@ def migrate(
     migrations = get_migrations(
         current_state,
         updated_state,
-        app_name=f"{current_dataset.schema.id}_{current_dataset.schema.default_version}",
+        apps={
+            f"{current_dataset.schema.id}_{vmajor}" for vmajor in current_dataset.schema.versions
+        },
+        migration_name=f"{current_dataset.schema.id}_{current_dataset.schema.default_version}",
     )
     if not migrations:
         command.stdout.write(f"  No changes detected for table {current_table.id}")
@@ -135,21 +138,21 @@ def get_model_state(dataset_model: Dataset, table: DatasetTableSchema, managed=T
 
 
 def get_migrations(
-    state1: ProjectState, state2: ProjectState, app_name: str
+    state1: ProjectState, state2: ProjectState, apps: set[str], migration_name: str
 ) -> dict[str, list[Migration]]:
     """Generate a migration object for the given table versions."""
     detector = MigrationAutodetector(
         from_state=state1,
         to_state=state2,
-        questioner=InteractiveMigrationQuestioner(specified_apps=[app_name]),
+        questioner=InteractiveMigrationQuestioner(specified_apps=apps),
     )
     # The dependency graph remains empty here, as we assume all other models are still
     # in place. We only compare the changes between 2 models of the same table.
     dependency_graph = MigrationGraph()
     return detector.changes(
         dependency_graph,
-        trim_to_apps=[app_name],
-        migration_name=app_name,
+        trim_to_apps=apps,
+        migration_name=migration_name,
     )
 
 
@@ -182,6 +185,8 @@ def execute_migration(
             return start_state
 
         schema_editor.collect_sql = False
+        if command.verbosity >= 2:
+            command.stdout.write("\n".join(collected_sql))
         schema_editor.execute("\n".join(collected_sql))
     return start_state
 

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -93,14 +93,15 @@ def get_base_project_state(
     project_state = ProjectState(real_apps=set(real_apps))
 
     # Generate model states for all other tables in the dataset
-    for table in dataset_model.schema.get_all_tables(include_nested=True, include_through=True):
-        # Exclude the actual table that changes, including any nested/through tables.
-        if table.id == exclude_table or (
-            table.has_parent_table and table.parent_table.id == exclude_table
-        ):
-            continue
+    for vmajor, version in dataset_model.schema.versions.items():
+        for table in version.get_tables(include_nested=True, include_through=True):
+            # Exclude the actual table that changes, including any nested/through tables.
+            if table.id == exclude_table or (
+                table.has_parent_table and table.parent_table.id == exclude_table
+            ):
+                continue
 
-        project_state.add_model(get_model_state(dataset_model, table))
+            project_state.add_model(get_model_state(dataset_model, table, vmajor=vmajor))
 
     return project_state
 
@@ -112,25 +113,36 @@ def get_versioned_project_state(
     This clones the base state, so other related models are only created once.
     """
     project_state = base_state.clone()
-    project_state.add_model(get_model_state(dataset_model, table))
+    for vmajor, version in dataset_model.schema.versions.items():
+        if version.get_table_by_id(table.id) is not None:
+            project_state.add_model(get_model_state(dataset_model, table, vmajor=vmajor))
 
-    # Add any nested tables and through tables,
-    # that are also part of this table schema.
-    for field in table.fields:
-        if (through_table := field.through_table) is not None:
-            project_state.add_model(get_model_state(dataset_model, through_table))
-        elif (nested_table := field.nested_table) is not None:
-            project_state.add_model(get_model_state(dataset_model, nested_table))
+            # Add any nested tables and through tables,
+            # that are also part of this table schema.
+            for field in table.fields:
+                if (through_table := field.through_table) is not None:
+                    project_state.add_model(
+                        get_model_state(dataset_model, through_table, vmajor=vmajor)
+                    )
+                elif (nested_table := field.nested_table) is not None:
+                    project_state.add_model(
+                        get_model_state(dataset_model, nested_table, vmajor=vmajor)
+                    )
 
     return project_state
 
 
-def get_model_state(dataset_model: Dataset, table: DatasetTableSchema, managed=True) -> ModelState:
+def get_model_state(
+    dataset_model: Dataset, table: DatasetTableSchema, managed=True, vmajor=None
+) -> ModelState:
     """Generate the model state for a table."""
     # The migration-engine will only consider models that have "managed=True".
     # This is turned off by default for the DjangoModelFactory.build_model() logic,
     # and needs to be overwritten here (patching model._meta and its original_attrs is nasty).
     factory = DjangoModelFactory(dataset_model)
+    if vmajor is not None:
+        factory.set_version(vmajor)
+
     model_class = factory.build_model(table, meta_options={"managed": managed})
 
     # Generate the model. exclude_rels=True because M2M-through tables are generated manually.


### PR DESCRIPTION
Dit fixt punt twee uit het ticket. 

Probleem was dat bij een update in de default versie de twee ProjectStates geen overlap hadden en daardoor probeerde hij tabellen te droppen. 

Nu:
- maken we de ProjectStates aan met alle tabellen van alle versies.
- beperken we de migratie niet langer tot 1 versie van een dataset. 

Oude "fix" is verwijderd, want was slechts een tijdelijke oplossing om het schema te kunnen importeren.  