### PR TITLE
[BUGFIX] update later versions of same table AB#169816

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2026-05-04 (9.6.2)
+
+* Fix bug in migration logic when table with same name exists in multiple versions.
+
 # 2026-05-04 (9.6.1)
 
 * Fix bug in migration logic when default version is changed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.6.1
+version = 9.6.2
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -187,46 +187,53 @@ class Command(BaseCommand):
                 continue
 
             real_apps = self._load_dependencies(updated_dataset.schema, updated_dataset)
-            for current_table in current_dataset.schema.get_all_tables():
-                updated_table = updated_dataset.schema.get_table_by_id(
-                    current_table.id, include_nested=False, include_through=False
-                )
-                if current_table.version.vmajor == updated_table.version.vmajor:
-                    # If the table is under_development and there are breaking changes to
-                    # the table, drop the table
-                    if current_table.status == DatasetTableSchema.Status.under_development:
-                        previous_fields = current_table.json_data()["schema"]["properties"]
-                        next_fields = updated_table.json_data()["schema"]["properties"]
-                        table_errors = validation.validate_table(previous_fields, next_fields)
-                        if len(table_errors) > 0:
-                            for error in table_errors:
-                                self.stdout.write(f"  [ERROR]: {error}")
-                            if not options["create_tables"]:
-                                self.stdout.write(
-                                    "Not dropping table, as create_tables is set to false."
-                                )
-                            else:
-                                # drop the table and rely on create_tables to create it again.
-                                for field in current_table.fields:
-                                    if through_table := field.through_table:
-                                        drop_table(through_table.db_name)
-                                drop_table(current_table.db_name)
-                                self.stdout.write(
-                                    f"Dropped table {current_table.db_name} due to breaking "
-                                    "changes while under development."
-                                )
-                            # do not migrate in this case.
-                            continue
-
-                    # Migrate the table, no breaking changes
-                    migrate(
-                        self,
-                        current_dataset,
-                        updated_dataset,
-                        current_table,
-                        updated_table,
-                        real_apps,
+            for vmajor, version in current_dataset.schema.versions.items():
+                for current_table in version.get_tables():
+                    updated_version = updated_dataset.schema.versions.get(vmajor)
+                    if not updated_version:
+                        self.stdout.write(
+                            f"Version {vmajor} deleted in updated dataset, skipping..."
+                        )
+                        continue
+                    updated_table = updated_version.get_table_by_id(
+                        current_table.id, include_nested=False, include_through=False
                     )
+                    if current_table.version.vmajor == updated_table.version.vmajor:
+                        # If the table is under_development and there are breaking changes to
+                        # the table, drop the table
+                        if current_table.status == DatasetTableSchema.Status.under_development:
+                            previous_fields = current_table.json_data()["schema"]["properties"]
+                            next_fields = updated_table.json_data()["schema"]["properties"]
+                            table_errors = validation.validate_table(previous_fields, next_fields)
+                            if len(table_errors) > 0:
+                                for error in table_errors:
+                                    self.stdout.write(f"  [ERROR]: {error}")
+                                if not options["create_tables"]:
+                                    self.stdout.write(
+                                        "Not dropping table, as create_tables is set to false."
+                                    )
+                                else:
+                                    # drop the table and rely on create_tables to create it again.
+                                    for field in current_table.fields:
+                                        if through_table := field.through_table:
+                                            drop_table(through_table.db_name)
+                                    drop_table(current_table.db_name)
+                                    self.stdout.write(
+                                        f"Dropped table {current_table.db_name} due to breaking "
+                                        "changes while under development."
+                                    )
+                                # do not migrate in this case.
+                                continue
+
+                        # Migrate the table, no breaking changes
+                        migrate(
+                            self,
+                            current_dataset,
+                            updated_dataset,
+                            current_table,
+                            updated_table,
+                            real_apps,
+                        )
 
     def _run_import(self, dataset_schemas: dict[str, DatasetSchema]) -> list[Dataset]:
         datasets = []

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -14,6 +14,7 @@ from django.db.migrations.state import ModelState, ProjectState
 
 from schematools.contrib.django.factories import DjangoModelFactory
 from schematools.contrib.django.models import Dataset
+from schematools.exceptions import DatasetTableNotFound
 from schematools.types import DatasetTableSchema
 
 
@@ -114,7 +115,8 @@ def get_versioned_project_state(
     """
     project_state = base_state.clone()
     for vmajor, version in dataset_model.schema.versions.items():
-        if version.get_table_by_id(table.id) is not None:
+        try:
+            version.get_table_by_id(table.id)
             project_state.add_model(get_model_state(dataset_model, table, vmajor=vmajor))
 
             # Add any nested tables and through tables,
@@ -128,6 +130,9 @@ def get_versioned_project_state(
                     project_state.add_model(
                         get_model_state(dataset_model, nested_table, vmajor=vmajor)
                     )
+        except DatasetTableNotFound:
+            # This table is not part of the dataset version, so we ignore it.
+            continue
 
     return project_state
 

--- a/tests/django/test_schema_import.py
+++ b/tests/django/test_schema_import.py
@@ -268,6 +268,31 @@ def test_import_schema_drops_experimental_table_with_breaking_change_no_create_t
 
 
 @pytest.mark.django_db
+def test_import_schema_drops_experimental_table_with_breaking_changes_in_table_with_new_version(
+    here, capsys
+):
+    original = here / "files/datasets/statistieken/dataset.json"
+    call_command("import_schemas", original, create_tables=1)
+    assert models.Dataset.objects.count() == 1
+
+    updated = here / "files/datasets/statistieken/dataset_updated.json"
+    call_command("import_schemas", updated, create_tables=1, verbosity=3)
+    captured = capsys.readouterr()
+    assert (
+        """Dropped table statistieken_kengetallen_v2 due to breaking changes while under development."""
+        in captured.out
+    )
+    assert (
+        """Dropped table statistieken_cijfers_v2 due to breaking changes while under development."""
+        in captured.out
+    )
+    assert (
+        """Dropped table statistieken_indicatoren_v2 due to breaking changes while under development."""
+        in captured.out
+    )
+
+
+@pytest.mark.django_db
 def test_import_schema_updates_experimental_table_with_non_breaking_change(here):
     original = here / "files/datasets/experimental/original.json"
     call_command("import_schemas", original, create_tables=1)

--- a/tests/files/datasets/statistieken/dataset.json
+++ b/tests/files/datasets/statistieken/dataset.json
@@ -1,0 +1,567 @@
+{
+  "type": "dataset",
+  "id": "statistieken",
+  "title": "statistieken",
+  "description": "Statistieken van Onderzoek & Statistiek, gepubliceerd in een generieke model",
+  "owner": "Gemeente Amsterdam",
+  "publisher": {
+    "$ref": "publishers/GLEBZ"
+  },
+  "crs": "EPSG:28992",
+  "creator": "Onderzoek en Statistiek",
+  "homepage": "https://onderzoek.amsterdam.nl",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "basisstatistiek.ois@amsterdam.nl",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "version": "1.0.0",
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "tables": [
+        {
+          "id": "indicatoren",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle indicatoren (variabelen) en hun metadata",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "naam", "label", "definitie", "thema"],
+            "display": "naam",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van de indicator"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Unieke naam van de indicator"
+              },
+              "label": {
+                "type": "string",
+                "title": "label",
+                "description": "Beknopte label van de indicator t.b.v. weergave"
+              },
+              "labelUk": {
+                "type": "string",
+                "title": "labelUk",
+                "description": "Beknopte label van de indicator in het Brits-Engels t.b.v. weergave"
+              },
+              "definitie": {
+                "type": "string",
+                "title": "definitie",
+                "description": "Definitie, die ten grondslag ligt van de indicator"
+              },
+              "definitieUk": {
+                "type": "string",
+                "title": "definitieUk",
+                "description": "Definitie in het Brits-Engels, die ten grondslag ligt van de indicator"
+              },
+              "beschrijving": {
+                "type": "string",
+                "title": "beschrijving",
+                "description": "Beschrijving en overige informatie over de indicator"
+              },
+              "berekening": {
+                "type": "string",
+                "title": "berekening",
+                "description": "Rekenformule, die is gebruikt om de waarde van de indicator te berekenen"
+              },
+              "bron": {
+                "type": "string",
+                "title": "bron",
+                "description": "Herkomst van de indicator en bijhorende definitie"
+              },
+              "thema": {
+                "type": "string",
+                "title": "thema",
+                "description": "Thematische indeling waaronder de indicator valt"
+              },
+              "eenheid": {
+                "type": "string",
+                "title": "eenheid",
+                "description": "Eenheid waarin de indicator wordt uitgedrukt"
+              },
+              "symbool": {
+                "type": "string",
+                "title": "symbool",
+                "description": "Symbool, behorende bij de eenheid"
+              },
+              "decimalen": {
+                "type": "integer",
+                "title": "decimalen",
+                "description": "Aantal decimalen, waarin de waarde van de indicator moet worden gepubliceerd"
+              },
+              "dimensieNaam": {
+                "type": "string",
+                "title": "dimensieNaam",
+                "description": "Naam van de dimensie, waartoe de indicator behoort"
+              },
+              "dimensieCode": {
+                "type": "string",
+                "title": "dimensieCode",
+                "description": "Code van de dimensie, waartoe de dimensie behoort"
+              },
+              "dimensieBeschrijving": {
+                "type": "string",
+                "title": "dimensieBeschrijving",
+                "description": "Beschrijving van de dimensie, waartoe de dimensie behoort"
+              },
+              "extraAttributen": {
+                "type": "object",
+                "format": "json",
+                "title": "extraAttributen",
+                "description": "Vrij veld om aanvullende attributen met hun waarde op te slaan, die nodig kunnen zijn voor verdere visualisatie"
+              },
+              "parent": {
+                "type": "string",
+                "title": "parent",
+                "description": "Naam van een indicator, waartoe de indicator behoort"
+              },
+              "verantwoordelijke": {
+                "type": "string",
+                "title": "verantwoordelijke",
+                "description": "Naam van het team binnen de organisatie, dat verantwoordelijk is voor de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "cijfers",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "ruimtelijkeDimensieType",
+              "ruimtelijkeDimensieCode",
+              "ruimtelijkeDimensieNaam",
+              "temporeleDimensieType",
+              "begindatum",
+              "einddatum",
+              "indicator",
+              "waarde"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "ruimtelijkeDimensieType": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieType",
+                "description": "Type ruimtelijke indeling"
+              },
+              "ruimtelijkeDimensieDatum": {
+                "type": "string",
+                "format": "date",
+                "title": "ruimtelijkeDimensieDatum",
+                "description": "Datum waarop de ruimtelijke indeling van kracht is geworden"
+              },
+              "ruimtelijkeDimensieCode": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieCode",
+                "description": "Unieke code van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "ruimtelijkeDimensieNaam": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieNaam",
+                "description": "Unieke naam van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "temporeleDimensieType": {
+                "type": "string",
+                "title": "temporeleDimensieType",
+                "description": "Type van de tijddimensie. Dit kan een vaste peildatum zijn of een periode"
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date-time",
+                "title": "begindatum",
+                "description": "Begindatum waarop de tijddimensie is begonnen"
+              },
+              "einddatum": {
+                "type": "string",
+                "format": "date-time",
+                "title": "einddatum",
+                "description": "Einddatum waarop de tijddimensie is geëindigd"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator waarop het cijfer betrekking heeft"
+              },
+              "waarde": {
+                "type": "number",
+                "title": "waarde",
+                "description": "Waarde van het cijfer met het aantal decimalen, zoals vastgelegd bij de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "toepassingen",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "naam",
+              "versie",
+              "ruimtelijkeDimensie",
+              "temporeleDimensie",
+              "indicator"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Naam van de toepassing"
+              },
+              "versie": {
+                "type": "string",
+                "title": "versie",
+                "description": "Versie van de toepassing"
+              },
+              "ruimtelijkeDimensie": {
+                "type": "string",
+                "title": "ruimtelijkeDimensie",
+                "description": "Ruimtelijke indeling"
+              },
+              "temporeleDimensie": {
+                "type": "string",
+                "title": "temporeleDimensie",
+                "description": "Type van de tijddimensie. Dit kan een vaste peildatum zijn of een periode"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    },
+    "v2": {
+      "version": "2.0.0",
+      "status": "under_development",
+      "enableAPI": true,
+      "tables": [
+        {
+          "id": "indicatoren",
+          "title": "indicatoren",
+          "description": "Alle indicatoren (variabelen) en hun metadata",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["naam"],
+            "required": [
+              "schema",
+              "naam",
+              "label",
+              "definitie",
+              "thema",
+              "status"
+            ],
+            "display": "naam",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Unieke naam van de indicator"
+              },
+              "label": {
+                "type": "string",
+                "title": "label",
+                "description": "Beknopte label van de indicator t.b.v. weergave"
+              },
+              "labelUk": {
+                "type": "string",
+                "title": "labelUk",
+                "description": "Beknopte label van de indicator in het Brits-Engels t.b.v. weergave"
+              },
+              "definitie": {
+                "type": "string",
+                "title": "definitie",
+                "description": "Definitie, die ten grondslag ligt van de indicator"
+              },
+              "definitieUk": {
+                "type": "string",
+                "title": "definitieUk",
+                "description": "Definitie in het Brits-Engels, die ten grondslag ligt van de indicator"
+              },
+              "beschrijving": {
+                "type": "string",
+                "title": "beschrijving",
+                "description": "Beschrijving en overige informatie over de indicator"
+              },
+              "thema": {
+                "type": "array",
+                "title": "thema",
+                "description": "Thematische indeling waaronder de indicator valt",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "eenheid": {
+                "type": "object",
+                "title": "eenheid",
+                "description": "Eenheid waarin de indicator wordt uitgedrukt",
+                "properties": {
+                  "naam": {
+                    "type": "string"
+                  },
+                  "symbool": {
+                    "type": "string"
+                  }
+                }
+              },
+              "decimalen": {
+                "type": "integer",
+                "title": "decimalen",
+                "description": "Aantal decimalen, waarin de waarde van de indicator moet worden gepubliceerd"
+              },
+              "privacygevoelig": {
+                "type": "boolean",
+                "title": "privacygevoelig",
+                "description": "Indicatie of indicator privacygevoelig is/kan zijn"
+              },
+              "status": {
+                "type": "object",
+                "title": "status",
+                "description": "Status van de indicator. De indicator kan vervallen zijn en niet meer actief worden bijgehouden",
+                "properties": {
+                  "vervallen": {
+                    "type": "boolean"
+                  },
+                  "vervaldatum": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "vervalreden": {
+                    "type": "string"
+                  }
+                }
+              },
+              "bron": {
+                "type": "array",
+                "title": "bron",
+                "description": "Herkomst van de indicator en bijhorende definitie",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "extraAttributen": {
+                "type": "object",
+                "format": "json",
+                "title": "extraAttributen",
+                "description": "Vrij veld om aanvullende attributen met hun waarde op te slaan, die nodig kunnen zijn voor verdere visualisatie"
+              }
+            }
+          }
+        },
+        {
+          "id": "cijfers",
+          "title": "cijfers",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "gebiedstype",
+              "gebiedsdatum",
+              "gebiedscode",
+              "type",
+              "begindatum",
+              "einddatum",
+              "indicator",
+              "waarde"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "gebiedstype": {
+                "type": "string",
+                "title": "gebiedstype",
+                "description": "Type ruimtelijke indeling"
+              },
+              "gebiedsdatum": {
+                "type": "string",
+                "format": "date",
+                "title": "gebiedsdatum",
+                "description": "Datum waarop de ruimtelijke indeling van kracht is geworden"
+              },
+              "gebiedscode": {
+                "type": "string",
+                "title": "gebiedscode",
+                "description": "Unieke code van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "gebiedsnaam": {
+                "type": "string",
+                "title": "gebiedsnaam",
+                "description": "Unieke naam van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "tijdseenheid": {
+                "type": "string",
+                "title": "tijdseenheid",
+                "description": "Eenheid van de tijddimensie. Dit kan een vaste peildatum zijn of een periode"
+              },
+              "jaartal": {
+                "type": "integer",
+                "title": "jaartal",
+                "description": "Jaar waarop het cijfer betrekking heeft"
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date",
+                "title": "begindatum",
+                "description": "Begindatum waarop de tijddimensie is begonnen"
+              },
+              "einddatum": {
+                "type": "string",
+                "format": "date",
+                "title": "einddatum",
+                "description": "Einddatum waarop de tijddimensie is geëindigd"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator waarop het cijfer betrekking heeft",
+                "relation": "statistieken:indicatoren"
+              },
+              "waarde": {
+                "type": "number",
+                "title": "waarde",
+                "description": "Waarde van het cijfer met het aantal decimalen, zoals vastgelegd bij de indicator"
+              }
+            }
+          }
+        },
+        {
+          "id": "kengetallen",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "description": "De spreidings- en centrummaten van de cijfers",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "indicator", "jaartal", "begindatum"],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator waarop het kengetal betrekking heeft",
+                "relation": "statistieken:indicatoren"
+              },
+              "jaartal": {
+                "type": "integer",
+                "title": "jaartal",
+                "description": "Jaar waarop het kengetal betrekking heeft"
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date",
+                "title": "begindatum",
+                "description": "Begindatum waarop de tijddimensie is begonnen"
+              },
+              "gebiedstype": {
+                "type": "string",
+                "title": "gebiedstype",
+                "description": "Gebiedstype, die als bron dient voor de kengetallen"
+              },
+              "gemiddelde": {
+                "type": "number",
+                "title": "gemiddelde",
+                "description": "Berekende gemiddelde van de indicator / begindatum"
+              },
+              "standaarddeviatie": {
+                "type": "number",
+                "title": "standaarddeviatie",
+                "description": "Berekende standaarddeviatie van de indicator / begindatum"
+              }
+            }
+          }
+        }
+      ],
+      "exports": [
+        {
+          "name": "all",
+          "tables": "*",
+          "filetypes": ["csv", "geojson"],
+          "scopes": ["openbaar"]
+        }
+      ]
+    }
+  }
+}

--- a/tests/files/datasets/statistieken/dataset_updated.json
+++ b/tests/files/datasets/statistieken/dataset_updated.json
@@ -1,0 +1,631 @@
+{
+  "type": "dataset",
+  "id": "statistieken",
+  "title": "statistieken",
+  "description": "Statistieken van Onderzoek & Statistiek, gepubliceerd in een generieke model",
+  "owner": "Gemeente Amsterdam",
+  "publisher": {
+    "$ref": "publishers/GLEBZ"
+  },
+  "crs": "EPSG:28992",
+  "creator": "Onderzoek en Statistiek",
+  "homepage": "https://onderzoek.amsterdam.nl",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "basisstatistiek.ois@amsterdam.nl",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "version": "1.0.0",
+      "status": "stable",
+      "enableAPI": true,
+      "enableGeosearch": true,
+      "tables": [
+        {
+          "id": "indicatoren",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle indicatoren (variabelen) en hun metadata",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "naam", "label", "definitie", "thema"],
+            "display": "naam",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van de indicator"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Unieke naam van de indicator"
+              },
+              "label": {
+                "type": "string",
+                "title": "label",
+                "description": "Beknopte label van de indicator t.b.v. weergave"
+              },
+              "labelUk": {
+                "type": "string",
+                "title": "labelUk",
+                "description": "Beknopte label van de indicator in het Brits-Engels t.b.v. weergave"
+              },
+              "definitie": {
+                "type": "string",
+                "title": "definitie",
+                "description": "Definitie, die ten grondslag ligt van de indicator"
+              },
+              "definitieUk": {
+                "type": "string",
+                "title": "definitieUk",
+                "description": "Definitie in het Brits-Engels, die ten grondslag ligt van de indicator"
+              },
+              "beschrijving": {
+                "type": "string",
+                "title": "beschrijving",
+                "description": "Beschrijving en overige informatie over de indicator"
+              },
+              "berekening": {
+                "type": "string",
+                "title": "berekening",
+                "description": "Rekenformule, die is gebruikt om de waarde van de indicator te berekenen"
+              },
+              "bron": {
+                "type": "string",
+                "title": "bron",
+                "description": "Herkomst van de indicator en bijhorende definitie"
+              },
+              "thema": {
+                "type": "string",
+                "title": "thema",
+                "description": "Thematische indeling waaronder de indicator valt"
+              },
+              "eenheid": {
+                "type": "string",
+                "title": "eenheid",
+                "description": "Eenheid waarin de indicator wordt uitgedrukt"
+              },
+              "symbool": {
+                "type": "string",
+                "title": "symbool",
+                "description": "Symbool, behorende bij de eenheid"
+              },
+              "decimalen": {
+                "type": "integer",
+                "title": "decimalen",
+                "description": "Aantal decimalen, waarin de waarde van de indicator moet worden gepubliceerd"
+              },
+              "dimensieNaam": {
+                "type": "string",
+                "title": "dimensieNaam",
+                "description": "Naam van de dimensie, waartoe de indicator behoort"
+              },
+              "dimensieCode": {
+                "type": "string",
+                "title": "dimensieCode",
+                "description": "Code van de dimensie, waartoe de dimensie behoort"
+              },
+              "dimensieBeschrijving": {
+                "type": "string",
+                "title": "dimensieBeschrijving",
+                "description": "Beschrijving van de dimensie, waartoe de dimensie behoort"
+              },
+              "extraAttributen": {
+                "type": "object",
+                "format": "json",
+                "title": "extraAttributen",
+                "description": "Vrij veld om aanvullende attributen met hun waarde op te slaan, die nodig kunnen zijn voor verdere visualisatie"
+              },
+              "parent": {
+                "type": "string",
+                "title": "parent",
+                "description": "Naam van een indicator, waartoe de indicator behoort"
+              },
+              "verantwoordelijke": {
+                "type": "string",
+                "title": "verantwoordelijke",
+                "description": "Naam van het team binnen de organisatie, dat verantwoordelijk is voor de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "cijfers",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "ruimtelijkeDimensieType",
+              "ruimtelijkeDimensieCode",
+              "ruimtelijkeDimensieNaam",
+              "temporeleDimensieType",
+              "begindatum",
+              "einddatum",
+              "indicator",
+              "waarde"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "ruimtelijkeDimensieType": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieType",
+                "description": "Type ruimtelijke indeling"
+              },
+              "ruimtelijkeDimensieDatum": {
+                "type": "string",
+                "format": "date",
+                "title": "ruimtelijkeDimensieDatum",
+                "description": "Datum waarop de ruimtelijke indeling van kracht is geworden"
+              },
+              "ruimtelijkeDimensieCode": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieCode",
+                "description": "Unieke code van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "ruimtelijkeDimensieNaam": {
+                "type": "string",
+                "title": "ruimtelijkeDimensieNaam",
+                "description": "Unieke naam van de ruimtelijke indeling binnen hetzelfde type en datum"
+              },
+              "temporeleDimensieType": {
+                "type": "string",
+                "title": "temporeleDimensieType",
+                "description": "Type van de tijddimensie. Dit kan een vaste peildatum zijn of een periode"
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date-time",
+                "title": "begindatum",
+                "description": "Begindatum waarop de tijddimensie is begonnen"
+              },
+              "einddatum": {
+                "type": "string",
+                "format": "date-time",
+                "title": "einddatum",
+                "description": "Einddatum waarop de tijddimensie is geëindigd"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator waarop het cijfer betrekking heeft"
+              },
+              "waarde": {
+                "type": "number",
+                "title": "waarde",
+                "description": "Waarde van het cijfer met het aantal decimalen, zoals vastgelegd bij de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "toepassingen",
+          "type": "table",
+          "version": "1.0.0",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "naam",
+              "versie",
+              "ruimtelijkeDimensie",
+              "temporeleDimensie",
+              "indicator"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Naam van de toepassing"
+              },
+              "versie": {
+                "type": "string",
+                "title": "versie",
+                "description": "Versie van de toepassing"
+              },
+              "ruimtelijkeDimensie": {
+                "type": "string",
+                "title": "ruimtelijkeDimensie",
+                "description": "Ruimtelijke indeling"
+              },
+              "temporeleDimensie": {
+                "type": "string",
+                "title": "temporeleDimensie",
+                "description": "Type van de tijddimensie. Dit kan een vaste peildatum zijn of een periode"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    },
+    "v2": {
+      "version": "2.0.0",
+      "status": "under_development",
+      "enableAPI": true,
+      "tables": [
+        {
+          "id": "indicatoren",
+          "title": "indicatoren",
+          "description": "Alle indicatoren (variabelen) en hun metadata",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "naam",
+              "label",
+              "definitie",
+              "thema",
+              "eenheid",
+              "decimalen",
+              "privacygevoelig",
+              "status",
+              "bron"
+            ],
+            "display": "naam",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het indicator"
+              },
+              "naam": {
+                "type": "string",
+                "title": "naam",
+                "description": "Unieke naam van de indicator"
+              },
+              "label": {
+                "type": "string",
+                "title": "label",
+                "description": "Label van de indicator t.b.v. weergave"
+              },
+              "labelUk": {
+                "type": "string",
+                "title": "labelUk",
+                "description": "Label van de indicator in het Brits-Engels t.b.v. weergave"
+              },
+              "labelKort": {
+                "type": "string",
+                "title": "label",
+                "description": "Beknopte label van de indicator t.b.v. weergave"
+              },
+              "labelKortUk": {
+                "type": "string",
+                "title": "labelUk",
+                "description": "Beknopte label van de indicator in het Brits-Engels t.b.v. weergave"
+              },
+              "definitie": {
+                "type": "string",
+                "title": "definitie",
+                "description": "Definitie, die ten grondslag ligt van de indicator"
+              },
+              "definitieUk": {
+                "type": "string",
+                "title": "definitieUk",
+                "description": "Definitie in het Brits-Engels, die ten grondslag ligt van de indicator"
+              },
+              "beschrijving": {
+                "type": "string",
+                "title": "beschrijving",
+                "description": "Beschrijving en overige informatie over de indicator"
+              },
+              "beschrijvingUk": {
+                "type": "string",
+                "title": "beschrijvingUk",
+                "description": "Beschrijving en overige informatie in het Brits-Engels over de indicator"
+              },
+              "thema": {
+                "type": "array",
+                "title": "thema",
+                "description": "Thematische indeling waaronder de indicator valt",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "themaUk": {
+                "type": "array",
+                "title": "thema",
+                "description": "Thematische indeling in het Brits-Engels waaronder de indicator valt",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "eenheid": {
+                "type": "object",
+                "title": "eenheid",
+                "description": "Eenheid, waarin de indicator wordt uitgedrukt",
+                "properties": {
+                  "naam": {
+                    "type": "string",
+                    "title": "naam",
+                    "description": "Naam van de eenheid"
+                  },
+                  "symbool": {
+                    "type": "string",
+                    "title": "symbool",
+                    "description": "Symbool van de eenheid"
+                  }
+                }
+              },
+              "decimalen": {
+                "type": "integer",
+                "title": "decimalen",
+                "description": "Aantal decimalen, waarin de waarde van de indicator moet worden gepubliceerd"
+              },
+              "frequentie": {
+                "type": "string",
+                "title": "frequentie",
+                "description": "Omschrijving van de regelmaat, waarmee de cijfers van de indicator worden gepubliceerd"
+              },
+              "frequentieUk": {
+                "type": "string",
+                "title": "frequentieUk",
+                "description": "Omschrijving van de regelmaat in Brits-Engels, waarmee de cijfers van de indicator worden gepubliceerd"
+              },
+              "bron": {
+                "type": "array",
+                "title": "bron",
+                "description": "Herkomst van de indicator en bijhorende definitie",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "privacygevoelig": {
+                "type": "boolean",
+                "title": "privacygevoelig",
+                "description": "Indicatie of indicator privacygevoelig is/kan zijn"
+              },
+              "status": {
+                "type": "object",
+                "title": "status",
+                "description": "Status van de indicator. De indicator kan vervallen zijn en niet meer actief worden bijgehouden",
+                "properties": {
+                  "vervallen": {
+                    "type": "boolean",
+                    "title": "vervallen",
+                    "description": "Indicatie of de indicator niet meer wordt bijgehouden."
+                  },
+                  "vervalDatum": {
+                    "type": "string",
+                    "format": "date",
+                    "title": "vervaldatum",
+                    "description": "Datum vanaf wanneer de indicator niet meer wordt bijgehouden."
+                  },
+                  "vervalReden": {
+                    "type": "string",
+                    "title": "vervalreden",
+                    "description": "Reden waarom de indicator niet meer wordt bijgehouden."
+                  }
+                }
+              },
+              "extraAttributen": {
+                "type": "object",
+                "format": "json",
+                "title": "extraAttributen",
+                "description": "Vrij veld om aanvullende attributen met hun waarde op te slaan, die nodig kunnen zijn voor verdere visualisatie"
+              }
+            }
+          }
+        },
+        {
+          "id": "cijfers",
+          "title": "cijfers",
+          "description": "Alle cijfers, gerelateerd aan de bijhorende indicatoren en dimensies",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "id",
+              "gebied",
+              "type",
+              "begindatum",
+              "einddatum",
+              "indicator",
+              "waarde"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "gebied": {
+                "type": "object",
+                "title": "gebied",
+                "description": "Ruimtelijke dimensie, waarop het cijfer betrekking heeft",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "title": "gebiedstype",
+                    "description": "Type ruimtelijke dimensie"
+                  },
+                  "datum": {
+                    "type": "string",
+                    "format": "date",
+                    "title": "gebiedsdatum",
+                    "description": "Datum, waarop de ruimtelijke dimensie van kracht is geworden"
+                  },
+                  "code": {
+                    "type": "string",
+                    "title": "gebiedscode",
+                    "description": "Unieke code van de ruimtelijke dimensie binnen hetzelfde type en datum"
+                  },
+                  "naam": {
+                    "type": "string",
+                    "title": "gebiedsnaam",
+                    "description": "Unieke naam van de ruimtelijke dimensie binnen hetzelfde type en datum"
+                  }
+                }
+              },
+              "tijdType": {
+                "type": "string",
+                "title": "tijdType",
+                "description": "Type van de temporele dimensie, waarop het cijfer betrekkking heeft."
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date",
+                "title": "begindatum",
+                "description": "Begindatum van de temporele dimensie, waarop het cijfer betrekking heeft"
+              },
+              "einddatum": {
+                "type": "string",
+                "format": "date",
+                "title": "einddatum",
+                "description": "Einddatum van de temporele dimensie, waarop het cijfer betrekking heeft"
+              },
+              "heeftBetrekkingOp": {
+                "type": "string",
+                "title": "heeftBetrekkingOp",
+                "description": "Jaar of periode, waarop het cijfer betrekking heeft"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator, waarop het cijfer betrekking heeft",
+                "relation": "statistieken:indicatoren"
+              },
+              "waarde": {
+                "type": "number",
+                "title": "waarde",
+                "description": "Waarde van het cijfer met het aantal decimalen, zoals vastgelegd bij de indicator"
+              }
+            }
+          }
+        },
+        {
+          "id": "kengetallen",
+          "type": "table",
+          "version": "2.0.0",
+          "status": "under_development",
+          "description": "De spreidings- en centrummaten van de cijfers",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": [
+              "schema",
+              "indicator",
+              "begindatum",
+              "gemiddelde",
+              "standaarddeviatie",
+              "bron"
+            ],
+            "display": "id",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "title": "id",
+                "description": "Unieke identificatie van het cijfer i.c.m. de bijhorende indicator en dimensies"
+              },
+              "indicator": {
+                "type": "string",
+                "title": "indicator",
+                "description": "Naam van de indicator, waarop het kengetal betrekking heeft",
+                "relation": "statistieken:indicatoren"
+              },
+              "begindatum": {
+                "type": "string",
+                "format": "date",
+                "title": "begindatum",
+                "description": "Begindatum van de temporele dimensie, waarop het cijfer betrekking heeft"
+              },
+              "heeftBetrekkingOp": {
+                "type": "string",
+                "title": "heeftBetrekkingOp",
+                "description": "Jaar of periode, waarop het cijfer betrekking heeft"
+              },
+              "gemiddelde": {
+                "type": "number",
+                "title": "gemiddelde",
+                "description": "Berekende gemiddelde van de indicator / begindatum"
+              },
+              "standaarddeviatie": {
+                "type": "number",
+                "title": "standaarddeviatie",
+                "description": "Berekende standaarddeviatie van de indicator / begindatum"
+              },
+              "bron": {
+                "type": "string",
+                "title": "bron",
+                "description": "Gebiedsindeling, die als bron dient voor de berekening van de kengetallen"
+              }
+            }
+          }
+        }
+      ],
+      "exports": [
+        {
+          "name": "all",
+          "tables": "*",
+          "filetypes": ["csv", "geojson"],
+          "scopes": ["openbaar"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Het probleem was dat we naief `get_table_by_id` deden, waardoor hij altijd v1 pakte van de tabel met die id. Dit fixt dat.

De test is gemaakt op basis van de [PR](https://github.com/Amsterdam/amsterdam-schema/pull/1658) in amsterdam-schema waarvan de import misging. 