### PR TITLE
[bugfix] import schema relations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2026-05-04 (9.6.3)
+
+* Fix bug in migration logic for adding relations.
+* Fix bug in migration logic for adding field on table present in multiple versions.
+
 # 2026-05-04 (9.6.2)
 
 * Fix bug in migration logic when table with same name exists in multiple versions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.6.2
+version = 9.6.3
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -39,6 +39,11 @@ class Command(BaseCommand):
         parser.add_argument("--no-create-tables", dest="create_tables", action="store_false")
         parser.add_argument("--migrate-tables", dest="migrate_tables", action="store_true")
         parser.add_argument("--no-migrate-tables", dest="migrate_tables", action="store_false")
+        parser.add_argument(
+            "--table-id",
+            dest="table_id",
+            help="Only import the specified table, used for testing",
+        )
         parser.set_defaults(create_tables=False)
         parser.set_defaults(create_views=False)
         parser.set_defaults(migrate_tables=True)
@@ -187,53 +192,50 @@ class Command(BaseCommand):
                 continue
 
             real_apps = self._load_dependencies(updated_dataset.schema, updated_dataset)
-            for vmajor, version in current_dataset.schema.versions.items():
-                for current_table in version.get_tables():
-                    updated_version = updated_dataset.schema.versions.get(vmajor)
-                    if not updated_version:
-                        self.stdout.write(
-                            f"Version {vmajor} deleted in updated dataset, skipping..."
-                        )
+            for current_table in current_dataset.schema.get_all_tables():
+                updated_table = updated_dataset.schema.get_table_by_id(
+                    current_table.id,
+                    table_version=current_table.version.vmajor,
+                    include_nested=False,
+                    include_through=False,
+                )
+                if options.get("table_id") and options["table_id"] != current_table.id:
+                    continue
+                # If the table is under_development and there are breaking changes to
+                # the table, drop the table
+                if current_table.status == DatasetTableSchema.Status.under_development:
+                    previous_fields = current_table.json_data()["schema"]["properties"]
+                    next_fields = updated_table.json_data()["schema"]["properties"]
+                    table_errors = validation.validate_table(previous_fields, next_fields)
+                    if len(table_errors) > 0:
+                        for error in table_errors:
+                            self.stdout.write(f"  [ERROR]: {error}")
+                        if not options["create_tables"]:
+                            self.stdout.write(
+                                "Not dropping table, as create_tables is set to false."
+                            )
+                        else:
+                            # drop the table and rely on create_tables to create it again.
+                            for field in current_table.fields:
+                                if through_table := field.through_table:
+                                    drop_table(through_table.db_name)
+                            drop_table(current_table.db_name)
+                            self.stdout.write(
+                                f"Dropped table {current_table.db_name} due to breaking "
+                                "changes while under development."
+                            )
+                        # do not migrate in this case.
                         continue
-                    updated_table = updated_version.get_table_by_id(
-                        current_table.id, include_nested=False, include_through=False
-                    )
-                    if current_table.version.vmajor == updated_table.version.vmajor:
-                        # If the table is under_development and there are breaking changes to
-                        # the table, drop the table
-                        if current_table.status == DatasetTableSchema.Status.under_development:
-                            previous_fields = current_table.json_data()["schema"]["properties"]
-                            next_fields = updated_table.json_data()["schema"]["properties"]
-                            table_errors = validation.validate_table(previous_fields, next_fields)
-                            if len(table_errors) > 0:
-                                for error in table_errors:
-                                    self.stdout.write(f"  [ERROR]: {error}")
-                                if not options["create_tables"]:
-                                    self.stdout.write(
-                                        "Not dropping table, as create_tables is set to false."
-                                    )
-                                else:
-                                    # drop the table and rely on create_tables to create it again.
-                                    for field in current_table.fields:
-                                        if through_table := field.through_table:
-                                            drop_table(through_table.db_name)
-                                    drop_table(current_table.db_name)
-                                    self.stdout.write(
-                                        f"Dropped table {current_table.db_name} due to breaking "
-                                        "changes while under development."
-                                    )
-                                # do not migrate in this case.
-                                continue
 
-                        # Migrate the table, no breaking changes
-                        migrate(
-                            self,
-                            current_dataset,
-                            updated_dataset,
-                            current_table,
-                            updated_table,
-                            real_apps,
-                        )
+                # Migrate the table, no breaking changes
+                migrate(
+                    self,
+                    current_dataset,
+                    updated_dataset,
+                    current_table,
+                    updated_table,
+                    real_apps,
+                )
 
     def _run_import(self, dataset_schemas: dict[str, DatasetSchema]) -> list[Dataset]:
         datasets = []

--- a/src/schematools/contrib/django/management/commands/import_schemas.py
+++ b/src/schematools/contrib/django/management/commands/import_schemas.py
@@ -12,6 +12,7 @@ from schematools import validation
 from schematools.contrib.django.factories import DjangoModelFactory
 from schematools.contrib.django.management.commands.migration_helpers import drop_table, migrate
 from schematools.contrib.django.models import Dataset
+from schematools.exceptions import DatasetTableNotFound
 from schematools.loaders import FileSystemSchemaLoader, get_schema_loader
 from schematools.types import DatasetSchema, DatasetTableSchema
 
@@ -192,50 +193,75 @@ class Command(BaseCommand):
                 continue
 
             real_apps = self._load_dependencies(updated_dataset.schema, updated_dataset)
-            for current_table in current_dataset.schema.get_all_tables():
-                updated_table = updated_dataset.schema.get_table_by_id(
-                    current_table.id,
-                    table_version=current_table.version.vmajor,
-                    include_nested=False,
-                    include_through=False,
-                )
-                if options.get("table_id") and options["table_id"] != current_table.id:
+            processed: set[tuple[str, str]] = set()
+            table_filter = options.get("table_id")
+            for ds_version, current_version in current_dataset.schema.versions.items():
+                updated_version = updated_dataset.schema.versions.get(ds_version)
+                if updated_version is None:
+                    self.stdout.write(
+                        f"Version {ds_version} deleted in updated dataset, skipping..."
+                    )
                     continue
-                # If the table is under_development and there are breaking changes to
-                # the table, drop the table
-                if current_table.status == DatasetTableSchema.Status.under_development:
-                    previous_fields = current_table.json_data()["schema"]["properties"]
-                    next_fields = updated_table.json_data()["schema"]["properties"]
-                    table_errors = validation.validate_table(previous_fields, next_fields)
-                    if len(table_errors) > 0:
-                        for error in table_errors:
-                            self.stdout.write(f"  [ERROR]: {error}")
-                        if not options["create_tables"]:
-                            self.stdout.write(
-                                "Not dropping table, as create_tables is set to false."
-                            )
-                        else:
-                            # drop the table and rely on create_tables to create it again.
-                            for field in current_table.fields:
-                                if through_table := field.through_table:
-                                    drop_table(through_table.db_name)
-                            drop_table(current_table.db_name)
-                            self.stdout.write(
-                                f"Dropped table {current_table.db_name} due to breaking "
-                                "changes while under development."
-                            )
-                        # do not migrate in this case.
+
+                for current_table in current_version.get_tables(
+                    include_nested=False, include_through=False
+                ):
+                    if table_filter and table_filter != current_table.id:
                         continue
 
-                # Migrate the table, no breaking changes
-                migrate(
-                    self,
-                    current_dataset,
-                    updated_dataset,
-                    current_table,
-                    updated_table,
-                    real_apps,
-                )
+                    table_key = (current_table.id, current_table.version.vmajor)
+                    if table_key in processed:
+                        continue
+                    processed.add(table_key)
+
+                    try:
+                        updated_table = updated_version.get_table_by_id(
+                            current_table.id,
+                            include_nested=False,
+                            include_through=False,
+                        )
+                    except DatasetTableNotFound:
+                        self.stdout.write(
+                            f"Table {current_table.id} deleted in updated dataset version "
+                            f"{ds_version}, skipping..."
+                        )
+                        continue
+
+                    # If the table is under_development and there are breaking changes to
+                    # the table, drop the table
+                    if current_table.status == DatasetTableSchema.Status.under_development:
+                        previous_fields = current_table.json_data()["schema"]["properties"]
+                        next_fields = updated_table.json_data()["schema"]["properties"]
+                        table_errors = validation.validate_table(previous_fields, next_fields)
+                        if len(table_errors) > 0:
+                            for error in table_errors:
+                                self.stdout.write(f"  [ERROR]: {error}")
+                            if not options["create_tables"]:
+                                self.stdout.write(
+                                    "Not dropping table, as create_tables is set to false."
+                                )
+                            else:
+                                # Drop the table and rely on create_tables to create it again.
+                                for field in current_table.fields:
+                                    if through_table := field.through_table:
+                                        drop_table(through_table.db_name)
+                                drop_table(current_table.db_name)
+                                self.stdout.write(
+                                    f"Dropped table {current_table.db_name} due to breaking "
+                                    "changes while under development."
+                                )
+                            # Do not migrate in this case.
+                            continue
+
+                    # Migrate the table, no breaking changes
+                    migrate(
+                        self,
+                        current_dataset,
+                        updated_dataset,
+                        current_table,
+                        updated_table,
+                        real_apps,
+                    )
 
     def _run_import(self, dataset_schemas: dict[str, DatasetSchema]) -> list[Dataset]:
         datasets = []

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -67,9 +67,12 @@ def migrate(
 
     # Generate SQL per migration file, just like `manage.py sqlmigrate` does:
     connection = connections[database]
+    seen_sql_statements = []
     for _app, app_migrations in migrations.items():
         for migration in app_migrations:
-            start_state = execute_migration(command, connection, start_state, migration)
+            start_state, seen_sql_statements = execute_migration(
+                command, connection, start_state, migration, seen_sql_statements
+            )
     return start_state
 
 
@@ -150,8 +153,7 @@ def get_model_state(
 
     model_class = factory.build_model(table, meta_options={"managed": managed})
 
-    # Generate the model. exclude_rels=True because M2M-through tables are generated manually.
-    return PatchedModelState.from_model(model_class, exclude_rels=True)
+    return PatchedModelState.from_model(model_class)
 
 
 def get_migrations(
@@ -178,7 +180,8 @@ def execute_migration(
     connection: BaseDatabaseWrapper,
     start_state: ProjectState,
     migration: Migration,
-) -> ProjectState:
+    seen_sql_statements: list,
+) -> tuple[ProjectState, list]:
     """Print the SQL statements for a migration"""
     with connection.schema_editor(collect_sql=True, atomic=migration.atomic) as schema_editor:
         command.stdout.write(f"-- Migration {migration.name} for dataset {migration.app_label}")
@@ -195,17 +198,24 @@ def execute_migration(
         collected_sql = _filter_alter_type_statements(schema_editor.collected_sql)
         # Escape % signs
         collected_sql = _escape_comment_statements(collected_sql)
+        # Remove already executed sql statements
+        collected_sql, seen_sql_statements = _remove_seen_statements(
+            collected_sql, seen_sql_statements
+        )
 
         # If we've only got comments left, skip this migration
         if all(statement.startswith("--") for statement in collected_sql):
             command.stdout.write("-- No actual SQL statements generated, skipping this migration")
-            return start_state
+            return start_state, seen_sql_statements
 
         schema_editor.collect_sql = False
         if command.verbosity >= 2:
+            command.stdout.write("Collected SQL")
             command.stdout.write("\n".join(collected_sql))
+            command.stdout.write("Skipped:")
+            command.stdout.write("\n".join(seen_sql_statements))
         schema_editor.execute("\n".join(collected_sql))
-    return start_state
+    return start_state, seen_sql_statements
 
 
 def _filter_alter_type_statements(sql: list) -> list:
@@ -223,6 +233,18 @@ def _escape_comment_statements(sql: list) -> list:
     when executing this on the database.
     """
     return [s.replace("%", "%%") if re.search(r"COMMENT.+", s) else s for s in sql]
+
+
+def _remove_seen_statements(sql: list, seen_sql_statements: list) -> tuple[list, list]:
+    """Deduplicate SQL statements since the migration engine can generate duplicates
+    when there are tables that exist in multiple versions.
+    """
+    deduped_sql = []
+    for statement in sql:
+        if statement not in seen_sql_statements:
+            deduped_sql.append(statement)
+            seen_sql_statements.append(statement)
+    return deduped_sql, seen_sql_statements
 
 
 class PatchedModelState(ModelState):

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -56,9 +56,7 @@ def migrate(
     migrations = get_migrations(
         current_state,
         updated_state,
-        apps={
-            f"{current_dataset.schema.id}_{vmajor}" for vmajor in current_dataset.schema.versions
-        },
+        apps={f"{current_dataset.schema.id}_{vmajor}"},
         migration_name=f"{current_dataset.schema.id}_{current_dataset.schema.default_version}",
     )
     if not migrations:
@@ -67,12 +65,9 @@ def migrate(
 
     # Generate SQL per migration file, just like `manage.py sqlmigrate` does:
     connection = connections[database]
-    seen_sql_statements = []
     for _app, app_migrations in migrations.items():
         for migration in app_migrations:
-            start_state, seen_sql_statements = execute_migration(
-                command, connection, start_state, migration, seen_sql_statements
-            )
+            start_state = execute_migration(command, connection, start_state, migration)
     return start_state
 
 
@@ -180,8 +175,7 @@ def execute_migration(
     connection: BaseDatabaseWrapper,
     start_state: ProjectState,
     migration: Migration,
-    seen_sql_statements: list,
-) -> tuple[ProjectState, list]:
+) -> ProjectState:
     """Print the SQL statements for a migration"""
     with connection.schema_editor(collect_sql=True, atomic=migration.atomic) as schema_editor:
         command.stdout.write(f"-- Migration {migration.name} for dataset {migration.app_label}")
@@ -199,23 +193,18 @@ def execute_migration(
         # Escape % signs
         collected_sql = _escape_comment_statements(collected_sql)
         # Remove already executed sql statements
-        collected_sql, seen_sql_statements = _remove_seen_statements(
-            collected_sql, seen_sql_statements
-        )
 
         # If we've only got comments left, skip this migration
         if all(statement.startswith("--") for statement in collected_sql):
             command.stdout.write("-- No actual SQL statements generated, skipping this migration")
-            return start_state, seen_sql_statements
+            return start_state
 
         schema_editor.collect_sql = False
         if command.verbosity >= 2:
             command.stdout.write("Collected SQL")
             command.stdout.write("\n".join(collected_sql))
-            command.stdout.write("Skipped:")
-            command.stdout.write("\n".join(seen_sql_statements))
         schema_editor.execute("\n".join(collected_sql))
-    return start_state, seen_sql_statements
+    return start_state
 
 
 def _filter_alter_type_statements(sql: list) -> list:
@@ -233,18 +222,6 @@ def _escape_comment_statements(sql: list) -> list:
     when executing this on the database.
     """
     return [s.replace("%", "%%") if re.search(r"COMMENT.+", s) else s for s in sql]
-
-
-def _remove_seen_statements(sql: list, seen_sql_statements: list) -> tuple[list, list]:
-    """Deduplicate SQL statements since the migration engine can generate duplicates
-    when there are tables that exist in multiple versions.
-    """
-    deduped_sql = []
-    for statement in sql:
-        if statement not in seen_sql_statements:
-            deduped_sql.append(statement)
-            seen_sql_statements.append(statement)
-    return deduped_sql, seen_sql_statements
 
 
 class PatchedModelState(ModelState):

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -612,7 +612,7 @@ class DatasetSchema(SchemaType):
     def get_table_by_id(
         self,
         table_id: str,
-        version: str | None = None,
+        table_version: str | None = None,
         include_nested: bool = True,
         include_through: bool = True,
     ) -> DatasetTableSchema:
@@ -624,6 +624,7 @@ class DatasetSchema(SchemaType):
                 include_nested=include_nested, include_through=include_through
             )
             if to_snake_case(table.id) == to_snake_case(table_id)
+            and (table_version is None or table.version.vmajor == table_version)
         )
 
     @property

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -612,7 +612,7 @@ class DatasetSchema(SchemaType):
     def get_table_by_id(
         self,
         table_id: str,
-        table_version: str | None = None,
+        version: str | None = None,
         include_nested: bool = True,
         include_through: bool = True,
     ) -> DatasetTableSchema:
@@ -624,7 +624,6 @@ class DatasetSchema(SchemaType):
                 include_nested=include_nested, include_through=include_through
             )
             if to_snake_case(table.id) == to_snake_case(table_id)
-            and (table_version is None or table.version.vmajor == table_version)
         )
 
     @property

--- a/tests/django/test_schema_import.py
+++ b/tests/django/test_schema_import.py
@@ -103,6 +103,93 @@ def test_import_schema_update_runs_migrations(here):
 
 
 @pytest.mark.django_db()
+def test_import_schema_update_add_relation_field_creates_db_column(here):
+    original = here / "files/datasets/relationadd_original.json"
+    call_command("import_schemas", original, create_tables=1)
+
+    books_table = models.DatasetTable.objects.get(dataset__name="relationadd", name="books")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""SELECT
+                column_name
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = '{books_table.db_table}'
+            """
+        )
+        columns = [col for row in cursor.fetchall() for col in row]
+        assert "author_id" not in columns
+
+    updated = here / "files/datasets/relationadd_updated.json"
+    call_command("import_schemas", updated)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""SELECT
+                column_name
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = '{books_table.db_table}'
+            """
+        )
+        columns = [col for row in cursor.fetchall() for col in row]
+        assert "author_id" in columns
+
+
+@pytest.mark.django_db()
+def test_import_schema_add_field_on_table_existing_in_multiple_versions_does_not_error(here):
+    original = here / "files/datasets/multiversionadd_original.json"
+    call_command("import_schemas", original, create_tables=1)
+
+    tables = list(
+        models.DatasetTable.objects.filter(dataset__name="multiversionadd", name="items")
+    )
+    assert len(tables) == 2
+    tables_by_version = {"v1": None, "v2": None}
+    for table in tables:
+        if table.db_table.endswith("_v1"):
+            tables_by_version["v1"] = table
+        elif table.db_table.endswith("_v2"):
+            tables_by_version["v2"] = table
+
+    assert tables_by_version["v1"] is not None
+    assert tables_by_version["v2"] is not None
+
+    for table in (tables_by_version["v1"], tables_by_version["v2"]):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""SELECT
+                    column_name
+                FROM
+                    information_schema.columns
+                WHERE
+                    table_name = '{table.db_table}'
+                """
+            )
+            columns = [col for row in cursor.fetchall() for col in row]
+            assert "extra" not in columns
+
+    updated = here / "files/datasets/multiversionadd_updated.json"
+    call_command("import_schemas", updated)
+
+    for table in (tables_by_version["v1"], tables_by_version["v2"]):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""SELECT
+                    column_name
+                FROM
+                    information_schema.columns
+                WHERE
+                    table_name = '{table.db_table}'
+                """
+            )
+            columns = [col for row in cursor.fetchall() for col in row]
+            assert "extra" in columns
+
+
+@pytest.mark.django_db()
 def test_import_schema_with_table_migrations(here, capsys):
     """Prove that importing a dataset schema with migrate tables runs migrations"""
     verblijfsobjecten = here / "files/datasets/verblijfsobjecten.json"

--- a/tests/files/datasets/experimental/original_m2m.json
+++ b/tests/files/datasets/experimental/original_m2m.json
@@ -21,10 +21,7 @@
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {
@@ -40,12 +37,21 @@
                 "type": "string"
               },
               "ligtInOtherTable": {
-                "type": "object",
-                "properties": {
-                  "identificatie": {"type": "string"},
-                  "volgnummer": {"type": "integer"},
-                  "beginGeldigheid": {"type": "string", "format": "date-time"},
-                  "eindGeldigheid": {"type": "string", "format": "date-time"}
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "identificatie": { "type": "string" },
+                    "volgnummer": { "type": "integer" },
+                    "beginGeldigheid": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "eindGeldigheid": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
                 },
                 "relation": "experimental:othertable",
                 "title": "ligt in other table",
@@ -65,10 +71,7 @@
             "identifier": "id",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id",
-              "schema"
-            ],
+            "required": ["id", "schema"],
             "display": "id",
             "properties": {
               "schema": {

--- a/tests/files/datasets/multiversionadd_original.json
+++ b/tests/files/datasets/multiversionadd_original.json
@@ -1,0 +1,77 @@
+{
+  "type": "dataset",
+  "id": "multiversionadd",
+  "title": "multiversionadd",
+  "crs": "EPSG:28992",
+  "publisher": "unknown",
+  "auth": "OPENBAAR",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "1.0.0",
+      "tables": [
+        {
+          "id": "items",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/multiversionadd/items.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    },
+    "v2": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "2.0.0",
+      "tables": [
+        {
+          "id": "items",
+          "type": "table",
+          "version": "2.0.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/multiversionadd/items.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/tests/files/datasets/multiversionadd_updated.json
+++ b/tests/files/datasets/multiversionadd_updated.json
@@ -1,0 +1,85 @@
+{
+  "type": "dataset",
+  "id": "multiversionadd",
+  "title": "multiversionadd",
+  "crs": "EPSG:28992",
+  "publisher": "unknown",
+  "auth": "OPENBAAR",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "1.0.1",
+      "tables": [
+        {
+          "id": "items",
+          "type": "table",
+          "version": "1.1.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/multiversionadd/items.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "extra": {
+                "type": "string",
+                "description": "New field in v1"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    },
+    "v2": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "2.0.1",
+      "tables": [
+        {
+          "id": "items",
+          "type": "table",
+          "version": "2.1.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/multiversionadd/items.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "extra": {
+                "type": "string",
+                "description": "New field in v2"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/tests/files/datasets/relationadd_original.json
+++ b/tests/files/datasets/relationadd_original.json
@@ -1,0 +1,74 @@
+{
+  "type": "dataset",
+  "id": "relationadd",
+  "title": "relationadd",
+  "crs": "EPSG:28992",
+  "publisher": "unknown",
+  "auth": "OPENBAAR",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "1.0.0",
+      "tables": [
+        {
+          "id": "authors",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/relationadd/authors.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "description": "Primary key"
+              },
+              "name": {
+                "type": "string",
+                "description": "Author name"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "books",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/relationadd/books.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "title"],
+            "display": "title",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "description": "Primary key"
+              },
+              "title": {
+                "type": "string",
+                "description": "Book title"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/tests/files/datasets/relationadd_updated.json
+++ b/tests/files/datasets/relationadd_updated.json
@@ -1,0 +1,79 @@
+{
+  "type": "dataset",
+  "id": "relationadd",
+  "title": "relationadd",
+  "crs": "EPSG:28992",
+  "publisher": "unknown",
+  "auth": "OPENBAAR",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "1.0.1",
+      "tables": [
+        {
+          "id": "authors",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/relationadd/authors.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "name"],
+            "display": "name",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "description": "Primary key"
+              },
+              "name": {
+                "type": "string",
+                "description": "Author name"
+              }
+            }
+          },
+          "status": "stable"
+        },
+        {
+          "id": "books",
+          "type": "table",
+          "version": "1.1.0",
+          "schema": {
+            "$id": "https://example.invalid/schemas/relationadd/books.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "identifier": ["id"],
+            "required": ["schema", "id", "title"],
+            "display": "title",
+            "properties": {
+              "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+              },
+              "id": {
+                "type": "integer",
+                "description": "Primary key"
+              },
+              "title": {
+                "type": "string",
+                "description": "Book title"
+              },
+              "author": {
+                "type": "integer",
+                "relation": "relationadd:authors",
+                "description": "Relation to an author"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
fixt 2 bugs:
- FK relaties werden uit de ProjectState gefilterd. 
- Veld toevoegen aan tabel die in meerdere versies voorkomt resulteerde in dubbele SQL statements en daardoor faalde de import. 