### PR TITLE
exports retry & error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2026-05-22 (9.8.0)
+
+* Add retry logic and failure capture to exports. Failures now do not result in the end of the
+  whole export flow, just that specific export. Subsequent exports are executed. The export
+  function returns a list of ExportTableFailures.
+
 # 2026-05-19 (9.7.0)
 
 * Added handling for array fields in csv exports.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amsterdam-schema-tools
-version = 9.7.0
+version = 9.8.0
 url = https://github.com/amsterdam/schema-tools
 license = Mozilla Public 2.0
 author = Team Data Diensten, van het Dataplatform onder de Directie Digitale Voorzieningen (Gemeente Amsterdam)

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -232,7 +232,12 @@ def export(
             version=None,
             size=size,
         )
-        export_tables(context)
+        failures = export_tables(context)
+    for failure in failures:
+        click.echo(str(failure), err=True)
+
+    if failures:
+        sys.exit(1)
 
 
 @schema.group("tocase")

--- a/src/schematools/exports/__init__.py
+++ b/src/schematools/exports/__init__.py
@@ -15,7 +15,12 @@ from schematools.exports.geojson import GeoJsonExporter
 from schematools.exports.geopackage import GeopackageExporter
 from schematools.exports.jsonlines import JsonLinesExporter
 from schematools.loaders import CachedSchemaLoader, get_schema_loader
-from schematools.types import ExportContext, ExportFileType, StorageClient
+from schematools.types import (
+    ExportContext,
+    ExportFileType,
+    ExportTableFailure,
+    StorageClient,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,10 +39,10 @@ def sanitize(input_string):
     return re.sub(r"[^\x00-\x7F]+", "", input_string)
 
 
-def export_tables(context: ExportContext):
+def export_tables(context: ExportContext) -> list[ExportTableFailure]:
     exporter_class = FILETYPE_TO_EXPORTER[context.export.filetype]
     exporter = exporter_class(context)
-    exporter.export_tables()
+    return exporter.export_tables()
 
 
 def zip_files(context: ExportContext) -> Path:
@@ -94,11 +99,12 @@ def export(
     *,
     loader: CachedSchemaLoader | None = None,  # For testing purposes.
     cleanup: bool = True,  # For testing purposes.
-):
+) -> list[ExportTableFailure]:
     """Exports all defined exports from the database to the configured storage."""
     loader = loader or get_schema_loader()
     path = Path(output_path)
     path.mkdir(parents=True, exist_ok=True)
+    all_failures: list[ExportTableFailure] = []
     for dataset_name, dataset in loader.get_all_datasets().items():
         logger.info("Exporting dataset %s.", dataset_name)
         dataset_metadata: dict[str, str] = {
@@ -115,12 +121,23 @@ def export(
                     client=storage_client,
                 )
                 logger.info("Exporting %s", export)
-                export_tables(context)
-                zip_path = zip_files(context)
-                upload_to_storage(zip_path, context, dataset_metadata)
+                failures = export_tables(context)
                 file_paths.extend(context.export.table_paths(context.folder))
                 file_paths.append(context.folder / context.export.filename_without_zip)
+                if failures:
+                    all_failures.extend(failures)
+                    logger.error(
+                        "Export %s had %s table export failures; skipping publish.",
+                        export,
+                        len(failures),
+                    )
+                    continue
+
+                zip_path = zip_files(context)
+                upload_to_storage(zip_path, context, dataset_metadata)
 
         if cleanup:
             remove_files(file_paths)
             gc.collect()
+
+    return all_failures

--- a/src/schematools/exports/base.py
+++ b/src/schematools/exports/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from typing import IO
@@ -104,32 +105,25 @@ class BaseExporter:
             )
         return None
 
-    def export_tables(self) -> list[ExportTableFailure]:
+    def export_tables(
+        self,
+        *,
+        max_attempts: int = 3,
+        delay_seconds: int = 1,
+    ) -> list[ExportTableFailure]:
+        """Export all tables for this export definition.
+
+        Returns a list of structured failures (empty on success).
+        """
         failures: list[ExportTableFailure] = []
         for table in self.tables:
             path = self.base_dir / self.export.table_filename(table.id)
-            try:
-                srid = table.crs.split(":")[1] if table.crs else None
-                if table.has_geometry_fields and srid is None:
-                    raise ValueError("Table has geo fields, but srid is None.")
-                sa_table = self.sa_tables[table.id]
-                columns = list(self._get_columns(sa_table, table))
-                if not columns:
-                    continue
-                if path.exists() and path.stat().st_size > 0:
-                    logger.warning("File %s already exists. It will be skipped.", path.name)
-                    continue
-                logger.info("Exporting %s.", path.name)
-                path.touch()
-                with path.open("w", encoding="utf8") as file_handle:
-                    self.write_rows(
-                        file_handle,
-                        table,
-                        columns,
-                        self._get_temporal_clause(sa_table, table),
-                        srid,
-                    )
-            except Exception as exc:  # noqa: BLE001
+            if path.exists() and path.stat().st_size > 0:
+                logger.warning("File %s already exists. It will be skipped.", path.name)
+                continue
+
+            srid = table.crs.split(":")[1] if table.crs else None
+            if table.has_geometry_fields and srid is None:
                 failures.append(
                     ExportTableFailure(
                         dataset_id=self.dataset_schema.id,
@@ -140,9 +134,56 @@ class BaseExporter:
                         table_id=table.id,
                         output_path=str(path),
                         attempts=1,
-                        error={"type": type(exc).__name__, "message": str(exc)},
+                        error={
+                            "type": "ValueError",
+                            "message": "Table has geo fields, but srid is None.",
+                        },
                     )
                 )
+                break
+
+            sa_table = self.sa_tables[table.id]
+            columns = list(self._get_columns(sa_table, table))
+            if not columns:
+                continue
+            temporal_clause = self._get_temporal_clause(sa_table, table)
+            logger.info("Exporting %s.", path.name)
+
+            last_exc: Exception | None = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    with path.open("w", encoding="utf8") as file_handle:
+                        self.write_rows(
+                            file_handle,
+                            table,
+                            columns,
+                            temporal_clause,
+                            srid,
+                        )
+                    last_exc = None
+                    break
+                except Exception as exc:  # noqa: BLE001
+                    last_exc = exc
+                    if attempt < max_attempts:
+                        time.sleep(delay_seconds)
+
+            if last_exc is not None:
+                failures.append(
+                    ExportTableFailure(
+                        dataset_id=self.dataset_schema.id,
+                        dataset_version=self.export.version,
+                        export_name=self.export.name,
+                        scopes=self.export.scopes_string,
+                        filetype=self.export.filetype,
+                        table_id=table.id,
+                        output_path=str(path),
+                        attempts=max_attempts,
+                        error={"type": type(last_exc).__name__, "message": str(last_exc)},
+                    )
+                )
+                path.unlink()  # remove incomplete file
+                break
+
         return failures
 
     def write_rows(  # noqa: D102

--- a/src/schematools/exports/base.py
+++ b/src/schematools/exports/base.py
@@ -14,6 +14,7 @@ from schematools.types import (
     DatasetFieldSchema,
     DatasetTableSchema,
     ExportContext,
+    ExportTableFailure,
     Scope,
 )
 
@@ -103,29 +104,46 @@ class BaseExporter:
             )
         return None
 
-    def export_tables(self):
+    def export_tables(self) -> list[ExportTableFailure]:
+        failures: list[ExportTableFailure] = []
         for table in self.tables:
-            srid = table.crs.split(":")[1] if table.crs else None
-            if table.has_geometry_fields and srid is None:
-                raise ValueError("Table has geo fields, but srid is None.")
-            sa_table = self.sa_tables[table.id]
-            columns = list(self._get_columns(sa_table, table))
-            if not columns:
-                continue
             path = self.base_dir / self.export.table_filename(table.id)
-            if path.exists() and path.stat().st_size > 0:
-                logger.warning("File %s already exists. It will be skipped.", path.name)
-                continue
-            logger.info("Exporting %s.", path.name)
-            path.touch()
-            with path.open("w", encoding="utf8") as file_handle:
-                self.write_rows(
-                    file_handle,
-                    table,
-                    columns,
-                    self._get_temporal_clause(sa_table, table),
-                    srid,
+            try:
+                srid = table.crs.split(":")[1] if table.crs else None
+                if table.has_geometry_fields and srid is None:
+                    raise ValueError("Table has geo fields, but srid is None.")
+                sa_table = self.sa_tables[table.id]
+                columns = list(self._get_columns(sa_table, table))
+                if not columns:
+                    continue
+                if path.exists() and path.stat().st_size > 0:
+                    logger.warning("File %s already exists. It will be skipped.", path.name)
+                    continue
+                logger.info("Exporting %s.", path.name)
+                path.touch()
+                with path.open("w", encoding="utf8") as file_handle:
+                    self.write_rows(
+                        file_handle,
+                        table,
+                        columns,
+                        self._get_temporal_clause(sa_table, table),
+                        srid,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    ExportTableFailure(
+                        dataset_id=self.dataset_schema.id,
+                        dataset_version=self.export.version,
+                        export_name=self.export.name,
+                        scopes=self.export.scopes_string,
+                        filetype=self.export.filetype,
+                        table_id=table.id,
+                        output_path=str(path),
+                        attempts=1,
+                        error={"type": type(exc).__name__, "message": str(exc)},
+                    )
                 )
+        return failures
 
     def write_rows(  # noqa: D102
         self,

--- a/src/schematools/exports/base.py
+++ b/src/schematools/exports/base.py
@@ -126,18 +126,10 @@ class BaseExporter:
             if table.has_geometry_fields and srid is None:
                 failures.append(
                     ExportTableFailure(
-                        dataset_id=self.dataset_schema.id,
-                        dataset_version=self.export.version,
-                        export_name=self.export.name,
-                        scopes=self.export.scopes_string,
-                        filetype=self.export.filetype,
+                        filename=self.export.filename_without_zip,
                         table_id=table.id,
-                        output_path=str(path),
-                        attempts=1,
-                        error={
-                            "type": "ValueError",
-                            "message": "Table has geo fields, but srid is None.",
-                        },
+                        error_type="ValueError",
+                        error_message="Table has geo fields, but srid is None.",
                     )
                 )
                 break
@@ -170,15 +162,10 @@ class BaseExporter:
             if last_exc is not None:
                 failures.append(
                     ExportTableFailure(
-                        dataset_id=self.dataset_schema.id,
-                        dataset_version=self.export.version,
-                        export_name=self.export.name,
-                        scopes=self.export.scopes_string,
-                        filetype=self.export.filetype,
+                        filename=self.export.filename_without_zip,
                         table_id=table.id,
-                        output_path=str(path),
-                        attempts=max_attempts,
-                        error={"type": type(last_exc).__name__, "message": str(last_exc)},
+                        error_type=type(last_exc).__name__,
+                        error_message=str(last_exc),
                     )
                 )
                 path.unlink()  # remove incomplete file

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -6,6 +6,7 @@ import subprocess
 from psycopg import sql
 
 from schematools.exports.base import BaseExporter
+from schematools.types import ExportTableFailure
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,8 @@ logger = logging.getLogger(__name__)
 class GeopackageExporter(BaseExporter):
     extension = "gpkg"
 
-    def export_tables(self):
+    def export_tables(self) -> list[ExportTableFailure]:
+        failures: list[ExportTableFailure] = []
         pg_conn_str = (
             f"host={self.engine.url.host} "
             f"port={self.engine.url.port} "
@@ -24,11 +26,14 @@ class GeopackageExporter(BaseExporter):
         consolidated_file = self.base_dir / self.export.filename_without_zip
         logger.info("Exporting %s.", self.export.filename_without_zip)
 
+        exported_table_ids: set[str] = set()
+
         for table in self.tables:
             filename = self.export.table_filename(table.id)
             output_path = self.base_dir / filename
             if output_path.exists():
                 logger.warning("File %s already exists. It will be skipped.", output_path.name)
+                exported_table_ids.add(table.id)
                 continue
             logger.info("Exporting %s.", filename)
             field_names = sql.SQL(",").join(
@@ -48,16 +53,67 @@ class GeopackageExporter(BaseExporter):
                     query=query, size=sql.Literal(self.size)
                 )
 
-            subprocess.run(  # noqa: S602
-                f'ogr2ogr -f "GPKG" {output_path} PG:"{pg_conn_str}" -sql "{query.as_string()}"',
-                shell=True,
-            )
-        for table, idx in zip(self.tables, range(len(self.tables)), strict=True):
-            flag = "" if idx == 0 else "-update"
+            try:
+                export_cmd = (
+                    f'ogr2ogr -f "GPKG" {output_path} PG:"{pg_conn_str}" '
+                    f'-sql "{query.as_string()}"'
+                )
+                subprocess.run(  # noqa: S602
+                    export_cmd,
+                    shell=True,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                exported_table_ids.add(table.id)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    ExportTableFailure(
+                        dataset_id=self.dataset_schema.id,
+                        dataset_version=self.export.version,
+                        export_name=self.export.name,
+                        scopes=self.export.scopes_string,
+                        filetype=self.export.filetype,
+                        table_id=table.id,
+                        output_path=str(output_path),
+                        attempts=1,
+                        error={"type": type(exc).__name__, "message": str(exc)},
+                    )
+                )
+
+        merged_any = False
+        for table in self.tables:
+            if table.id not in exported_table_ids:
+                continue
             filename = self.export.table_filename(table.id)
             output_path = self.base_dir / filename
-            subprocess.run(  # noqa: S602
-                f'ogr2ogr -f "GPKG" {flag} {consolidated_file} {output_path} '
-                f"-nln {table.db_name_variant(with_dataset_prefix=False)}",
-                shell=True,
-            )
+            flag = "" if not merged_any else "-update"
+            try:
+                merge_cmd = (
+                    f'ogr2ogr -f "GPKG" {flag} {consolidated_file} {output_path} '
+                    f"-nln {table.db_name_variant(with_dataset_prefix=False)}"
+                )
+                subprocess.run(  # noqa: S602
+                    merge_cmd,
+                    shell=True,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                merged_any = True
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    ExportTableFailure(
+                        dataset_id=self.dataset_schema.id,
+                        dataset_version=self.export.version,
+                        export_name=self.export.name,
+                        scopes=self.export.scopes_string,
+                        filetype=self.export.filetype,
+                        table_id=table.id,
+                        output_path=str(consolidated_file),
+                        attempts=1,
+                        error={"type": type(exc).__name__, "message": str(exc)},
+                    )
+                )
+
+        return failures

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import time
 
 from psycopg import sql
 
@@ -14,8 +15,12 @@ logger = logging.getLogger(__name__)
 class GeopackageExporter(BaseExporter):
     extension = "gpkg"
 
-    def export_tables(self) -> list[ExportTableFailure]:
-        failures: list[ExportTableFailure] = []
+    def export_tables(
+        self,
+        *,
+        max_attempts: int = 3,
+        delay_seconds: int = 1,
+    ) -> list[ExportTableFailure]:
         pg_conn_str = (
             f"host={self.engine.url.host} "
             f"port={self.engine.url.port} "
@@ -31,10 +36,13 @@ class GeopackageExporter(BaseExporter):
         for table in self.tables:
             filename = self.export.table_filename(table.id)
             output_path = self.base_dir / filename
-            if output_path.exists():
+            if output_path.exists() and output_path.stat().st_size > 0:
                 logger.warning("File %s already exists. It will be skipped.", output_path.name)
                 exported_table_ids.add(table.id)
                 continue
+            if output_path.exists():
+                # Remove zero-byte/partial artifacts from previous runs.
+                output_path.unlink()
             logger.info("Exporting %s.", filename)
             field_names = sql.SQL(",").join(
                 sql.Identifier(field.db_name)
@@ -53,21 +61,40 @@ class GeopackageExporter(BaseExporter):
                     query=query, size=sql.Literal(self.size)
                 )
 
-            try:
-                export_cmd = (
-                    f'ogr2ogr -f "GPKG" {output_path} PG:"{pg_conn_str}" '
-                    f'-sql "{query.as_string()}"'
-                )
-                subprocess.run(  # noqa: S602
-                    export_cmd,
-                    shell=True,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-                exported_table_ids.add(table.id)
-            except Exception as exc:  # noqa: BLE001
-                failures.append(
+            query_string = query.as_string()
+            last_exc: Exception | None = None
+
+            export_cmd = (
+                f'ogr2ogr -f "GPKG" "{output_path}" PG:"{pg_conn_str}" -sql "{query_string}"'
+            )
+
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    subprocess.run(  # noqa: S602
+                        export_cmd,
+                        shell=True,
+                        check=True,
+                    )
+                    exported_table_ids.add(table.id)
+                    last_exc = None
+                    break
+                except Exception as exc:  # noqa: BLE001
+                    last_exc = exc
+                    logger.error(
+                        "ogr2ogr export failed for %s (attempt %s/%s): %s",
+                        table.id,
+                        attempt,
+                        max_attempts,
+                        exc,
+                    )
+
+                    if output_path.exists():
+                        output_path.unlink()
+                    if attempt < max_attempts:
+                        time.sleep(delay_seconds)
+
+            if last_exc is not None:
+                return [
                     ExportTableFailure(
                         dataset_id=self.dataset_schema.id,
                         dataset_version=self.export.version,
@@ -76,44 +103,70 @@ class GeopackageExporter(BaseExporter):
                         filetype=self.export.filetype,
                         table_id=table.id,
                         output_path=str(output_path),
-                        attempts=1,
-                        error={"type": type(exc).__name__, "message": str(exc)},
+                        attempts=max_attempts,
+                        error={"type": type(last_exc).__name__, "message": str(last_exc)},
                     )
-                )
+                ]
 
-        merged_any = False
-        for table in self.tables:
-            if table.id not in exported_table_ids:
-                continue
-            filename = self.export.table_filename(table.id)
-            output_path = self.base_dir / filename
-            flag = "" if not merged_any else "-update"
+        tables_to_merge = [table for table in self.tables if table.id in exported_table_ids]
+        if not tables_to_merge:
+            return []
+
+        # Ensure we never leave a stale/broken consolidated output around on failure.
+        if consolidated_file.exists():
+            consolidated_file.unlink()
+
+        last_exc: Exception | None = None
+        last_table_id = tables_to_merge[0].id
+
+        for attempt in range(1, max_attempts + 1):
             try:
-                merge_cmd = (
-                    f'ogr2ogr -f "GPKG" {flag} {consolidated_file} {output_path} '
-                    f"-nln {table.db_name_variant(with_dataset_prefix=False)}"
-                )
-                subprocess.run(  # noqa: S602
-                    merge_cmd,
-                    shell=True,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-                merged_any = True
-            except Exception as exc:  # noqa: BLE001
-                failures.append(
-                    ExportTableFailure(
-                        dataset_id=self.dataset_schema.id,
-                        dataset_version=self.export.version,
-                        export_name=self.export.name,
-                        scopes=self.export.scopes_string,
-                        filetype=self.export.filetype,
-                        table_id=table.id,
-                        output_path=str(consolidated_file),
-                        attempts=1,
-                        error={"type": type(exc).__name__, "message": str(exc)},
+                merged_any = False
+                for table in tables_to_merge:
+                    last_table_id = table.id
+                    input_path = self.base_dir / self.export.table_filename(table.id)
+
+                    flag = "" if not merged_any else "-update"
+                    merge_cmd = (
+                        f'ogr2ogr -f "GPKG" {flag} {consolidated_file} {input_path} '
+                        f"-nln {table.db_name_variant(with_dataset_prefix=False)}"
                     )
+                    subprocess.run(  # noqa: S602
+                        merge_cmd,
+                        shell=True,
+                        check=True,
+                    )
+                    merged_any = True
+                last_exc = None
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                logger.error(
+                    "Merge failed for %s (attempt %s/%s): %s",
+                    last_table_id,
+                    attempt,
+                    max_attempts,
+                    exc,
                 )
 
-        return failures
+                if consolidated_file.exists():
+                    consolidated_file.unlink()
+                if attempt < max_attempts:
+                    time.sleep(delay_seconds)
+
+        if last_exc is not None:
+            return [
+                ExportTableFailure(
+                    dataset_id=self.dataset_schema.id,
+                    dataset_version=self.export.version,
+                    export_name=self.export.name,
+                    scopes=self.export.scopes_string,
+                    filetype=self.export.filetype,
+                    table_id=last_table_id,
+                    output_path=str(consolidated_file),
+                    attempts=max_attempts,
+                    error={"type": type(last_exc).__name__, "message": str(last_exc)},
+                )
+            ]
+
+        return []

--- a/src/schematools/exports/geopackage.py
+++ b/src/schematools/exports/geopackage.py
@@ -96,15 +96,10 @@ class GeopackageExporter(BaseExporter):
             if last_exc is not None:
                 return [
                     ExportTableFailure(
-                        dataset_id=self.dataset_schema.id,
-                        dataset_version=self.export.version,
-                        export_name=self.export.name,
-                        scopes=self.export.scopes_string,
-                        filetype=self.export.filetype,
+                        filename=self.export.filename_without_zip,
                         table_id=table.id,
-                        output_path=str(output_path),
-                        attempts=max_attempts,
-                        error={"type": type(last_exc).__name__, "message": str(last_exc)},
+                        error_type=type(last_exc).__name__,
+                        error_message=str(last_exc),
                     )
                 ]
 
@@ -157,15 +152,10 @@ class GeopackageExporter(BaseExporter):
         if last_exc is not None:
             return [
                 ExportTableFailure(
-                    dataset_id=self.dataset_schema.id,
-                    dataset_version=self.export.version,
-                    export_name=self.export.name,
-                    scopes=self.export.scopes_string,
-                    filetype=self.export.filetype,
+                    filename=self.export.filename_without_zip,
                     table_id=last_table_id,
-                    output_path=str(consolidated_file),
-                    attempts=max_attempts,
-                    error={"type": type(last_exc).__name__, "message": str(last_exc)},
+                    error_type=type(last_exc).__name__,
+                    error_message=str(last_exc),
                 )
             ]
 

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1040,6 +1040,27 @@ class ExportContext:
     temporal_date: datetime.datetime | None = None
 
 
+@dataclasses.dataclass(frozen=True)
+class ExportTableFailure:
+    """A structured failure for exporting a single table.
+
+    This is intentionally JSON-serializable (only primitives + nested dataclasses).
+    """
+
+    dataset_id: str
+    dataset_version: str
+    export_name: str
+    scopes: str
+    filetype: ExportFileType
+    table_id: str
+    output_path: str
+    attempts: int
+    error: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
 @dataclasses.dataclass
 class Export:
     """Class that models the export definitions in the dataset schema."""

--- a/src/schematools/types.py
+++ b/src/schematools/types.py
@@ -1047,18 +1047,16 @@ class ExportTableFailure:
     This is intentionally JSON-serializable (only primitives + nested dataclasses).
     """
 
-    dataset_id: str
-    dataset_version: str
-    export_name: str
-    scopes: str
-    filetype: ExportFileType
+    filename: str
     table_id: str
-    output_path: str
-    attempts: int
-    error: dict[str, str]
+    error_type: str
+    error_message: str
 
-    def to_dict(self) -> dict[str, Any]:
-        return dataclasses.asdict(self)
+    def __str__(self):
+        return (
+            f"Failed to export table '{self.table_id}' for export '{self.filename}': "
+            f"{self.error_type} - {self.error_message}"
+        )
 
 
 @dataclasses.dataclass

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -286,6 +286,70 @@ class TestExports:
         # When cleanup=True, artifacts for failed exports should be removed.
         assert not (tmp_folder / "fietspaaltjes_v1_fietspaaltjes_openbaar.csv").exists()
 
+    def test_export_continues_after_export_failure(
+        self,
+        engine,
+        storage_client,
+        export_schema_loader,
+        meetbouten_export_schema,
+        meetbouten_content,
+        tmp_folder,
+        monkeypatch,
+        caplog,
+    ):
+        """If a single export fails, the batch run should continue with the next export."""
+        caplog.set_level(logging.INFO)
+
+        # Limit the batch export to a single dataset to keep the test focused.
+        monkeypatch.setattr(
+            export_schema_loader,
+            "get_all_datasets",
+            lambda: {"meet_bouten": meetbouten_export_schema},
+        )
+
+        version = meetbouten_export_schema.versions[meetbouten_export_schema.default_version]
+        csv_export = next(exp for exp in version.exports if exp.filetype == "csv")
+        jsonl_export = next(exp for exp in version.exports if exp.filetype == "jsonl")
+
+        # Ensure deterministic ordering: first export fails, second should still succeed.
+        monkeypatch.setattr(version, "exports", [csv_export, jsonl_export])
+
+        # Ensure all tables referenced by these exports exist in the DB.
+        importer = NDJSONImporter(meetbouten_export_schema, engine)
+        for table_id in sorted(set(csv_export.table_ids + jsonl_export.table_ids)):
+            if table_id == "meetbouten":
+                continue  # already created + populated by meetbouten_content
+            importer.generate_db_objects(table_id, truncate=False, ind_extra_index=False)
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("forced exporter failure")
+
+        monkeypatch.setattr(CsvExporter, "write_rows", _boom)
+
+        failures = export(
+            engine,
+            storage_client,
+            output_path=str(tmp_folder),
+            loader=export_schema_loader,
+            cleanup=True,
+        )
+
+        # First export (CSV) failed and was reported.
+        assert any(
+            f.filename == csv_export.filename_without_zip
+            and f.error_type == "RuntimeError"
+            and f.error_message == "forced exporter failure"
+            for f in failures
+        )
+
+        # Second export (JSONL) still got published.
+        assert "Uploaded" in caplog.text
+        assert f"Uploaded {jsonl_export.filename} to storage container" in caplog.text
+        assert f"Uploaded {csv_export.filename} to storage container" not in caplog.text
+
+        assert "csv" not in storage_client.uploaded_blobs
+        assert list(storage_client.uploaded_blobs["jsonlines"].keys()) == [jsonl_export.filename]
+
     def test_base_exporter_retries_and_writes_atomically(
         self,
         gebieden_export_schema,

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -234,6 +234,50 @@ class TestExports:
                 "1,10180001.1,12,De meetbout,SRID=28992;POINT(119434 487091.6),,\n"
             )
 
+    def test_export_failure_skips_publish_and_returns_failures(
+        self,
+        engine,
+        storage_client,
+        export_schema_loader,
+        fietspaaltjes_export_schema,
+        fietspaaltjes_content,
+        tmp_folder,
+        monkeypatch,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO)
+
+        # Limit the batch export to a single dataset/export to keep the test focused.
+        monkeypatch.setattr(
+            export_schema_loader,
+            "get_all_datasets",
+            lambda: {"fietspaaltjes": fietspaaltjes_export_schema},
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("forced exporter failure")
+
+        monkeypatch.setattr(CsvExporter, "write_rows", _boom)
+
+        failures = export(
+            engine,
+            storage_client,
+            output_path=str(tmp_folder),
+            loader=export_schema_loader,
+            cleanup=True,
+        )
+
+        assert failures, "Expected a non-empty failure report"
+        assert failures[0].dataset_id == "fietspaaltjes"
+
+        # Publishing must be skipped when any table export fails.
+        assert storage_client.uploaded_blobs == {}
+        assert "Created zip file fietspaaltjes_v1_all_openbaar.csv.zip." not in caplog.text
+        assert "Uploaded fietspaaltjes_v1_all_openbaar.csv.zip" not in caplog.text
+
+        # When cleanup=True, artifacts for failed exports should be removed.
+        assert not (tmp_folder / "fietspaaltjes_v1_fietspaaltjes_openbaar.csv").exists()
+
     def test_csv_array_fields(
         self, fietspaaltjes_export_schema, fietspaaltjes_content, create_context
     ):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -19,7 +19,7 @@ from schematools.exports.geojson import GeoJsonExporter
 from schematools.exports.geopackage import GeopackageExporter
 from schematools.exports.jsonlines import JsonLinesExporter
 from schematools.importer.ndjson import NDJSONImporter
-from schematools.types import ExportContext
+from schematools.types import Export, ExportContext
 
 
 class TestExports:
@@ -303,7 +303,7 @@ class TestExports:
 
         monkeypatch.setattr(CsvExporter, "write_rows", _flaky_write_rows)
 
-        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0.0)
+        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0)
         assert failures == []
 
         out_path = context.folder / context.export.table_filename(first_table_id)
@@ -336,7 +336,7 @@ class TestExports:
 
         monkeypatch.setattr(CsvExporter, "write_rows", _always_fail_first_table)
 
-        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0.0)
+        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0)
         assert len(failures) == 1
         assert failures[0].table_id == first_table_id
         assert failures[0].attempts == 3
@@ -533,3 +533,79 @@ class TestExports:
             )
         path.unlink()
         Path("tmp").rmdir()
+
+    def test_geopackage_export_retries_then_succeeds(
+        self,
+        meetbouten_export_schema,
+        create_context,
+        monkeypatch,
+    ) -> None:
+        base_export_definition = next(
+            exp
+            for exp in meetbouten_export_schema.versions["v1"].exports
+            if exp.filetype == "gpkg" and len(exp.tables) == 1
+        )
+
+        # Use a custom export name so the consolidated file differs from the per-table file.
+        export_definition = Export(
+            name="retry_test",
+            tables=base_export_definition.tables,
+            scopes=base_export_definition.scopes,
+            filetype=base_export_definition.filetype,
+            version=base_export_definition.version,
+            _dataset_name=meetbouten_export_schema.id,
+        )
+        context = create_context(meetbouten_export_schema, export_definition)
+
+        calls: list[str] = []
+
+        def fake_run(cmd, *_args, **_kwargs):
+            calls.append(cmd)
+            if len(calls) == 1:
+                raise RuntimeError("boom")
+            return None
+
+        monkeypatch.setattr("schematools.exports.geopackage.subprocess.run", fake_run)
+
+        failures = GeopackageExporter(context).export_tables(max_attempts=2, delay_seconds=0)
+        assert failures == []
+        assert len(calls) >= 3  # 2x export (retry) + 1x merge
+
+    def test_geopackage_export_retries_then_fails_permanently(
+        self,
+        meetbouten_export_schema,
+        create_context,
+        monkeypatch,
+    ) -> None:
+        base_export_definition = next(
+            exp
+            for exp in meetbouten_export_schema.versions["v1"].exports
+            if exp.filetype == "gpkg" and len(exp.tables) == 1
+        )
+        export_definition = Export(
+            name="retry_test",
+            tables=base_export_definition.tables,
+            scopes=base_export_definition.scopes,
+            filetype=base_export_definition.filetype,
+            version=base_export_definition.version,
+            _dataset_name=meetbouten_export_schema.id,
+        )
+        context = create_context(meetbouten_export_schema, export_definition)
+
+        calls: list[str] = []
+
+        def fake_run(cmd, *, shell, check, **_kwargs):
+            calls.append(cmd)
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("schematools.exports.geopackage.subprocess.run", fake_run)
+
+        failures = GeopackageExporter(context).export_tables(max_attempts=3, delay_seconds=0)
+        assert len(failures) == 1
+        failure = failures[0]
+        assert failure.attempts == 3
+        assert failure.table_id == export_definition.tables[0].id
+
+        assert len(calls) == 3  # aborts before merge
+        consolidated = context.folder / export_definition.filename_without_zip
+        assert not consolidated.exists()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -278,6 +278,79 @@ class TestExports:
         # When cleanup=True, artifacts for failed exports should be removed.
         assert not (tmp_folder / "fietspaaltjes_v1_fietspaaltjes_openbaar.csv").exists()
 
+    def test_base_exporter_retries_and_writes_atomically(
+        self,
+        gebieden_export_schema,
+        create_context,
+        monkeypatch,
+    ):
+        export_definition = next(
+            exp
+            for exp in gebieden_export_schema.versions["v1"].exports
+            if exp.name == "kleine_gebieden" and exp.filetype == "csv"
+        )
+        context = create_context(gebieden_export_schema, export_definition)
+
+        first_table_id = export_definition.table_ids[0]
+        call_counts: dict[str, int] = {}
+
+        def _flaky_write_rows(self, file_handle, table, *_args, **_kwargs):
+            call_counts[table.id] = call_counts.get(table.id, 0) + 1
+            if table.id == first_table_id and call_counts[table.id] < 3:
+                file_handle.write("partial\n")
+                raise RuntimeError("boom")
+            file_handle.write("ok\n")
+
+        monkeypatch.setattr(CsvExporter, "write_rows", _flaky_write_rows)
+
+        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0.0)
+        assert failures == []
+
+        out_path = context.folder / context.export.table_filename(first_table_id)
+        assert out_path.exists() and out_path.stat().st_size > 0
+        assert out_path.read_text(encoding="utf8") == "ok\n"
+        assert call_counts[first_table_id] == 3
+
+    def test_base_exporter_aborts_after_retries_exhausted(
+        self,
+        gebieden_export_schema,
+        create_context,
+        monkeypatch,
+    ):
+        export_definition = next(
+            exp
+            for exp in gebieden_export_schema.versions["v1"].exports
+            if exp.name == "kleine_gebieden" and exp.filetype == "csv"
+        )
+        context = create_context(gebieden_export_schema, export_definition)
+
+        first_table_id, second_table_id = export_definition.table_ids[:2]
+        call_counts: dict[str, int] = {}
+
+        def _always_fail_first_table(self, file_handle, table, *_args, **_kwargs):
+            call_counts[table.id] = call_counts.get(table.id, 0) + 1
+            if table.id == first_table_id:
+                file_handle.write("partial\n")
+                raise RuntimeError("boom")
+            file_handle.write("ok\n")
+
+        monkeypatch.setattr(CsvExporter, "write_rows", _always_fail_first_table)
+
+        failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0.0)
+        assert len(failures) == 1
+        assert failures[0].table_id == first_table_id
+        assert failures[0].attempts == 3
+
+        first_out = context.folder / context.export.table_filename(first_table_id)
+        second_out = context.folder / context.export.table_filename(second_table_id)
+        assert not first_out.exists()
+        assert not second_out.exists()
+
+        assert call_counts[first_table_id] == 3
+        assert second_table_id not in call_counts
+
+        assert list(context.folder.iterdir()) == []
+
     def test_csv_array_fields(
         self, fietspaaltjes_export_schema, fietspaaltjes_content, create_context
     ):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -268,7 +268,15 @@ class TestExports:
         )
 
         assert failures, "Expected a non-empty failure report"
-        assert failures[0].dataset_id == "fietspaaltjes"
+        failure = failures[0]
+        assert failure.filename == "fietspaaltjes_v1_all_openbaar.csv"
+        assert failure.table_id == "fietspaaltjes"
+        assert failure.error_type == "RuntimeError"
+        assert failure.error_message == "forced exporter failure"
+        assert str(failure) == (
+            "Failed to export table 'fietspaaltjes' for export 'fietspaaltjes_v1_all_openbaar.csv':"
+            " RuntimeError - forced exporter failure"
+        )
 
         # Publishing must be skipped when any table export fails.
         assert storage_client.uploaded_blobs == {}
@@ -338,8 +346,11 @@ class TestExports:
 
         failures = CsvExporter(context).export_tables(max_attempts=3, delay_seconds=0)
         assert len(failures) == 1
-        assert failures[0].table_id == first_table_id
-        assert failures[0].attempts == 3
+        failure = failures[0]
+        assert failure.filename == export_definition.filename_without_zip
+        assert failure.table_id == first_table_id
+        assert failure.error_type == "RuntimeError"
+        assert failure.error_message == "boom"
 
         first_out = context.folder / context.export.table_filename(first_table_id)
         second_out = context.folder / context.export.table_filename(second_table_id)
@@ -603,8 +614,10 @@ class TestExports:
         failures = GeopackageExporter(context).export_tables(max_attempts=3, delay_seconds=0)
         assert len(failures) == 1
         failure = failures[0]
-        assert failure.attempts == 3
+        assert failure.filename == export_definition.filename_without_zip
         assert failure.table_id == export_definition.tables[0].id
+        assert failure.error_type == "RuntimeError"
+        assert failure.error_message == "boom"
 
         assert len(calls) == 3  # aborts before merge
         consolidated = context.folder / export_definition.filename_without_zip


### PR DESCRIPTION
- Een falende export wordt nu 3 x geprobeerd
- Een falende export voorkomt niet meer dat daarna volgende exports niet draaien
- `export` en `export_tables` geven een lijst aan ExportTableFailures terug die gebruikt kunnen worden voor logging by afnemer
- Voor cli is dit al geimplementeerd, export job zal later volgen. 
- Tests!