### PR TITLE
anyOf/oneOf validation error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2026-06-22 (9.10.2)
+
+* Bugfix: output the leaf nodes of the ErrorTree rather than the root in case of anyOf/oneOf
+  validation.
+
 # 2026-06-22 (9.10.1)
 
 * Bugfix: output all validation errors, not just the best match.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amsterdam-schema-tools"
-version = "9.10.1"
+version = "9.10.2"
 description = "Tools to work with Amsterdam Schema."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 import io
 import json
 import logging
@@ -143,6 +144,47 @@ class ValidationIssue:
 
     def as_markdown_todo(self):
         return f"- [ ] {self.message}"
+
+
+
+def _best_jsonschema_errors(
+    error: jsonschema.SchemaError | jsonschema.ValidationError,
+) -> list[jsonschema.SchemaError | jsonschema.ValidationError]:
+    if not error.context:
+        return [error]
+
+    if error.validator not in {"anyOf", "oneOf"}:
+        smallest = heapq.nsmallest(2, error.context, key=relevance)
+        if len(smallest) == 2 and relevance(smallest[0]) == relevance(smallest[1]):
+            return [error]
+        return _best_jsonschema_errors(smallest[0])
+
+    matches_by_child = [
+        _best_jsonschema_errors(child_error)
+        for child_error in sorted(error.context, key=relevance)
+    ]
+    deepest_match = max(
+        max(len(match.absolute_path) for match in matches)
+        for matches in matches_by_child
+    )
+    return _dedupe_jsonschema_errors(
+        match
+        for matches in matches_by_child
+        if max(len(match.absolute_path) for match in matches) == deepest_match
+        for match in matches
+    )
+
+
+def _dedupe_jsonschema_errors(errors):
+    seen = set()
+    unique_errors = []
+    for error in errors:
+        marker = (tuple(error.absolute_path), error.message)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        unique_errors.append(error)
+    return unique_errors
 
 
 def _get_engine(db_url: str, pg_schemas: list[str] | None = None) -> sqlalchemy.engine.Engine:
@@ -909,9 +951,11 @@ def batch_validate(
             validator = validators[meta_schema_version]
             validation_errors = sorted(validator.iter_errors(instance), key=relevance)
             for struct_error in validation_errors:
-                if struct_error.message not in IGNORED_ERRORS:
+                for leaf_error in _best_jsonschema_errors(struct_error):
+                    if leaf_error.message in IGNORED_ERRORS:
+                        continue
                     errors[schema_file][meta_schema_version].append(
-                        ValidationIssue.from_jsonschema_error(struct_error)
+                        ValidationIssue.from_jsonschema_error(leaf_error)
                     )
 
             for sem_error in validation.run(dataset, main_file):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,73 @@ def test_batch_validate_aggregates_errors_on_stderr(tmp_path: Path, monkeypatch)
     assert f"Validating {dataset_file} against 4.2.0" in result.stdout
 
 
+def test_batch_validate_reports_nested_anyof_errors(tmp_path: Path, monkeypatch) -> None:
+    dataset_dir = tmp_path / "datasets" / "example"
+    dataset_dir.mkdir(parents=True)
+    dataset_file = dataset_dir / "dataset.json"
+    dataset_file.write_text("{}")
+
+    meta_schema = {
+        "type": "object",
+        "anyOf": [
+            {"required": ["id"]},
+            {"required": ["version"]},
+        ],
+    }
+    dataset = SimpleNamespace(json_data=lambda **_kwargs: {})
+    loader = SimpleNamespace(get_dataset_from_file=lambda _path: dataset)
+
+    monkeypatch.setattr("schematools.cli._fetch_json", lambda _url: meta_schema)
+    monkeypatch.setattr("schematools.cli.FileSystemSchemaLoader", lambda _path: loader)
+    monkeypatch.setattr("schematools.cli.validation.run", lambda *_args, **_kwargs: [])
+
+    runner = CliRunner()
+    result = runner.invoke(batch_validate, ["schema@v4.2.0", str(dataset_file)])
+
+    assert result.exit_code == 1
+    assert "- [ ] $: 'id' is a required property" in result.stderr
+    assert "- [ ] $: 'version' is a required property" in result.stderr
+    assert "is not valid under any of the given schemas" not in result.stderr
+
+
+def test_batch_validate_prefers_deeper_anyof_errors(tmp_path: Path, monkeypatch) -> None:
+    dataset_dir = tmp_path / "datasets" / "example"
+    dataset_dir.mkdir(parents=True)
+    dataset_file = dataset_dir / "dataset.json"
+    dataset_file.write_text("{}")
+
+    meta_schema = {
+        "type": "object",
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "object",
+                        "properties": {"bar": {"type": "string"}},
+                        "required": ["bar"],
+                    }
+                },
+                "required": ["foo"],
+            },
+            {"type": "object", "required": ["baz"]},
+        ],
+    }
+    dataset = SimpleNamespace(json_data=lambda **_kwargs: {"foo": {}})
+    loader = SimpleNamespace(get_dataset_from_file=lambda _path: dataset)
+
+    monkeypatch.setattr("schematools.cli._fetch_json", lambda _url: meta_schema)
+    monkeypatch.setattr("schematools.cli.FileSystemSchemaLoader", lambda _path: loader)
+    monkeypatch.setattr("schematools.cli.validation.run", lambda *_args, **_kwargs: [])
+
+    runner = CliRunner()
+    result = runner.invoke(batch_validate, ["schema@v4.2.0", str(dataset_file)])
+
+    assert result.exit_code == 1
+    assert "'bar' is a required property" in result.stderr
+    assert "'baz' is a required property" not in result.stderr
+
+
 def test_validate_tables_does_not_write_error_header_without_errors(tmp_path: Path) -> None:
     previous_table = tmp_path / "previous-table.json"
     current_table = tmp_path / "table.json"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "amsterdam-schema-tools"
-version = "9.10.1"
+version = "9.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Vorige oplossing bleek incompleet voor oneOf/anyOf validatie, omdat we te maken hebben met een ErrorTree ipv een lijst aan errors. 

Voor anyOf/oneOf moeten we alleen de diepste leaf nodes van de error tree doorgeven, omdat deze de kleinst mogelijke problemen weergeven die als ze opgelost worden de validatie laten slagen. 

Dit is een feature gap in jsonschema. Het is _of_ alles _of_ de beste match (=de meest relevante van de diepste leaf nodes). De best_match die we gebruikten voor 9.10.1 zorgde ervoor dat onze validatie slechts 1 error per keer liet zien. In 9.10.1 lieten we alle validatie errors zien, maar deze gaf alleen de root-error van de ErrorTree. In deze PR is een helper functie gemaakt om alle issues weer te geven die even diep zitten. Voor andere soorten validatie zal de best_match logica gevolgd worden.