### PR TITLE
use raw sql to fetch table metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
+# 2026-07-22 (9.12.0-rc3)
+
+* Instead use raw sql to get table description.
+* Fix: put files in correct directory when calling `ingest` from other directory.
+* Fix: cast databricks type to schema type.
+
 # 2026-07-21 (9.12.0-rc2)
 
-* Create schema files based on Unity Catalog tables.
+* Use include_browse to fetch tables.
 
 # 2026-07-08 (9.12.0-rc1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amsterdam-schema-tools"
-version = "9.12.0-rc2"
+version = "9.12.0-rc3"
 description = "Tools to work with Amsterdam Schema."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -1225,6 +1225,7 @@ def ingest(dataset_file: str) -> None:
     """Ingest tables from databricks."""
     click.echo(f"Ingesting dataset from {dataset_file}")
     dataset: dict = read_json_path(dataset_file)
+    dirname = os.path.dirname(dataset_file)
     errors = {}
 
     for ds_version in dataset.get("versions", {}).values():
@@ -1240,7 +1241,7 @@ def ingest(dataset_file: str) -> None:
                     ]
 
                 table_version = f"v{db_info.dict['version'].split('.')[0]}"
-                filename = Path(db_info.table_id, f"{table_version}.json")
+                filename = Path(dirname, db_info.table_id, f"{table_version}.json")
                 click.echo(f"Writing table to {filename}")
                 filename.parent.mkdir(parents=True, exist_ok=True)
                 with open(filename, "w") as f:

--- a/src/schematools/contrib/databricks/client.py
+++ b/src/schematools/contrib/databricks/client.py
@@ -1,6 +1,10 @@
+import os
+
 from databricks.sdk import WorkspaceClient
 
 from schematools.contrib.databricks.types import DatabricksInfo, Tags
+
+DATABRICKS_WAREHOUSE_ID = os.environ.get("DATABRICKS_WAREHOUSE_ID")
 
 
 def get_databricks_info(full_name: str) -> DatabricksInfo:
@@ -13,22 +17,30 @@ def get_databricks_info(full_name: str) -> DatabricksInfo:
     Returns:
         DatabricksInfo: An object containing Databricks information.
     """
+    if DATABRICKS_WAREHOUSE_ID is None:
+        raise ValueError("DATABRICKS_WAREHOUSE_ID environment variable is not set.")
+
     client = WorkspaceClient()
     catalog, schema, table_name = full_name.split(".")
-    table_info = client.tables.get(full_name, include_browse=True)
+    table_description = client.statement_execution.execute_statement(
+        statement=f"DESCRIBE TABLE {full_name}", warehouse_id=DATABRICKS_WAREHOUSE_ID
+    ).result
+    if table_description is None:
+        raise RuntimeError(f"Failed to retrieve table information for {full_name}.")
+
     table_tags = Tags.from_tag_assignments(client.entity_tag_assignments.list("tables", full_name))
     column_tags = {
-        col.name: Tags.from_tag_assignments(
-            client.entity_tag_assignments.list("columns", f"{full_name}.{col.name}")
+        name: Tags.from_tag_assignments(
+            client.entity_tag_assignments.list("columns", f"{full_name}.{name}")
         )
-        for col in (table_info.columns if table_info.columns is not None else [])
-        if col.name is not None
+        for name, _, _ in (table_description.data_array or [])
+        if name is not None
     }
     return DatabricksInfo(
         catalog=catalog,
         schema=schema,
         table_name=table_name,
-        table_info=table_info,
+        table_description=table_description,
         table_tags=table_tags,
         column_tags=column_tags,
     )

--- a/src/schematools/contrib/databricks/types.py
+++ b/src/schematools/contrib/databricks/types.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from functools import cached_property
 from typing import Literal
 
-from databricks.sdk.service.catalog import EntityTagAssignment, TableInfo
+from databricks.sdk.service.catalog import EntityTagAssignment
+from databricks.sdk.service.sql import ResultData
 
 from schematools.naming import toCamelCase
 
@@ -214,6 +215,18 @@ MUTUALLY_EXCLUSIVE_ATTRIBUTES = [
     ("maximum", "exclusiveMaximum"),
 ]
 
+SCHEMA_TYPES = {
+    "string": "string",
+    "int": "integer",
+    "bigint": "integer",
+    "smallint": "integer",
+    "timestamp": "datetime",
+    "date": "date",
+    "boolean": "boolean",
+    "double": "number",
+    "float": "number",
+}
+
 
 @dataclass
 class Tag:
@@ -254,7 +267,7 @@ class DatabricksInfo:
     catalog: str
     schema: str
     table_name: str
-    table_info: TableInfo
+    table_description: ResultData
     table_tags: Tags
     column_tags: dict[str, Tags]
     errors: list[str] = field(default_factory=list)
@@ -276,6 +289,8 @@ class DatabricksInfo:
             if value is None and not_none in spec.validators:
                 # We only add None values if the validator allows it.
                 continue
+            if attr == "$ref":
+                target.pop("type", None)  # Remove 'type' if '$ref' is present
             target[attr] = spec.transform(value)
 
     def _validate_table_tags(self) -> list[str]:
@@ -306,8 +321,12 @@ class DatabricksInfo:
             errors.extend(self._collect_spec_errors(tags, COLUMN_ATTRIBUTES))
         return errors
 
-    def _build_column_schema(self, column_name: str) -> dict:
-        column_schema = {"title": column_name}
+    def _build_column_schema(self, column_name: str, type: str, comment: str) -> dict:
+        column_schema = {
+            "title": column_name,
+            "type": SCHEMA_TYPES.get(type),
+            "description": comment,
+        }
         tags = self.column_tags.get(column_name)
         if tags is not None:
             self._apply_tag_specs(column_schema, tags, COLUMN_ATTRIBUTES)
@@ -334,11 +353,9 @@ class DatabricksInfo:
         schema = self.get_base_schema()
         self._apply_tag_specs(schema["schema"], self.table_tags, TABLE_SCHEMA_ATTRIBUTES)
         self._apply_tag_specs(schema, self.table_tags, TABLE_ATTRIBUTES)
-        for column in self.table_info.columns or []:
-            if column.name is None:
-                continue
-            schema["schema"]["properties"][toCamelCase(column.name)] = self._build_column_schema(
-                column.name
+        for name, type, comment in self.table_description.data_array or []:
+            schema["schema"]["properties"][toCamelCase(name)] = self._build_column_schema(
+                name, type, comment
             )
         return schema
 

--- a/tests/test_databricks_types.py
+++ b/tests/test_databricks_types.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from databricks.sdk.service.catalog import EntityTagAssignment, TableInfo
+from databricks.sdk.service.catalog import EntityTagAssignment
+from databricks.sdk.service.sql import ResultData
 
 from schematools.contrib.databricks.types import (
     DatabricksInfo,
@@ -60,16 +61,21 @@ def test_databricks_info_validates_and_renders_table_json() -> None:
         ),
         "name": Tags(_tags=[Tag(key="minLength", value="2", type="columns")]),
     }
-    table_info = cast(
-        TableInfo,
-        SimpleNamespace(columns=[SimpleNamespace(name="geometry"), SimpleNamespace(name="name")]),
+    table_description = cast(
+        ResultData,
+        SimpleNamespace(
+            data_array=[
+                ["geometry", "string", "A geometry column"],
+                ["name", "string", "A name column"],
+            ]
+        ),
     )
 
     info = DatabricksInfo(
         catalog="main",
         schema="default",
         table_name="buildings_table",
-        table_info=table_info,
+        table_description=table_description,
         table_tags=table_tags,
         column_tags=column_tags,
     )
@@ -86,7 +92,6 @@ def test_databricks_info_validates_and_renders_table_json() -> None:
     assert payload["version"] == "1.2.3"
     assert payload["schema"]["identifier"] == ["id", "code"]
     assert payload["schema"]["required"] == ["schema", "name"]
-    assert payload["schema"]["properties"]["geometry"]["type"] == "string"
     assert payload["schema"]["properties"]["geometry"]["format"] == "date"
     assert (
         payload["schema"]["properties"]["geometry"]["$ref"]
@@ -96,14 +101,14 @@ def test_databricks_info_validates_and_renders_table_json() -> None:
 
 
 def test_databricks_info_reports_explicit_none_values() -> None:
-    table_info = cast(TableInfo, SimpleNamespace(columns=[]))
+    table_description = cast(ResultData, SimpleNamespace(data_array=[]))
     table_tags = Tags(_tags=[Tag(key="auth", value=None, type="tables")])
 
     info = DatabricksInfo(
         catalog="main",
         schema="default",
         table_name="buildings_table",
-        table_info=table_info,
+        table_description=table_description,
         table_tags=table_tags,
         column_tags={},
     )

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "amsterdam-schema-tools"
-version = "9.11.0"
+version = "9.12.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
De tables.get() call heeft meer permissies nodig (zie [hier](https://databricks-sdk-py.readthedocs.io/en/latest/workspace/catalog/tables.html#databricks.sdk.service.catalog.TablesAPI.get)). Dus nu gebruiken we een `DESCRIBE TABLE <full_name>` om de metadata op te halen. Dit _zou_ moeten werken.

