### PR TITLE
[BUGFIX] escape percentage char

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2026-07-28 (9.11.1)
+
+* Bugfix: escape %-sign in generated SQL.
+
 # 2026-06-24 (9.11.0)
 
 * Added soft and hard delete functionalities to delete tables after grace period.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amsterdam-schema-tools"
-version = "9.11.0"
+version = "9.11.1"
 description = "Tools to work with Amsterdam Schema."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/schematools/contrib/django/management/commands/migration_helpers.py
+++ b/src/schematools/contrib/django/management/commands/migration_helpers.py
@@ -202,7 +202,7 @@ def execute_migration(
         # Filter out ALTER COLUMN statements
         collected_sql = _filter_alter_type_statements(schema_editor.collected_sql)
         # Escape % signs
-        collected_sql = _escape_comment_statements(collected_sql)
+        collected_sql = _escape_percentage_chars(collected_sql)
         # Remove already executed sql statements
 
         # If we've only got comments left, skip this migration
@@ -228,11 +228,14 @@ def _filter_alter_type_statements(sql: list) -> list:
     return [s for s in sql if not re.search(r"ALTER COLUMN.+TYPE", s)]
 
 
-def _escape_comment_statements(sql: list) -> list:
-    """Escape percent signs in comments from the generated SQL since this causes issues
-    when executing this on the database.
+def _escape_percentage_chars(sql: list) -> list:
+    """Escape percent signs in comments and constraints from the generated SQL since this causes
+    issues when executing this on the database.
     """
-    return [s.replace("%", "%%") if re.search(r"COMMENT.+", s) else s for s in sql]
+    return [
+        s.replace("%", "%%") if re.search(r"COMMENT.+", s) or re.search(r"CONSTRAINT.+", s) else s
+        for s in sql
+    ]
 
 
 class PatchedModelState(ModelState):

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "amsterdam-schema-tools"
-version = "9.11.0"
+version = "9.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Generated SQL included the following:
```
-- Create constraint benkagg_v1_handelsregisterkvk_v4_identificatie_not_contains_slash on model table
--
ALTER TABLE "table_v3" ADD CONSTRAINT "table_v4_identificatie_not_contains_slash" CHECK (NOT ("identificatie"::text LIKE '%/%'));
--
```
This errored in psycopg's cursor.execute, because it tries to interpolate `%/`, which is invalid.