### PR TITLE
Bugfixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2026-07-29 (9.12.1)
+
+* Allow the CLI to load without the optional Databricks dependencies; only the `ingest` command now requires that extra when used.
+* Report validator exceptions as validation errors instead of aborting validation.
+* Improve test database and SQLite cleanup, and add coverage for import, export, CLI, and permission flows.
+
 # 2026-07-29 (9.12.0)
 
 * Refactor Databricks Unity Catalog types and client handling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ filterwarnings = [
     "once::DeprecationWarning",
     "once::PendingDeprecationWarning",
     "ignore:Model '.*' was already registered. Reloading models is not advised.*:RuntimeWarning",
+    'ignore:DateTimeField .* received a naive datetime .* while time zone support is active\.:RuntimeWarning:django\.db\.models\.fields',
 ]
 
 # ==== Coverage ====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amsterdam-schema-tools"
-version = "9.12.0"
+version = "9.12.1"
 description = "Tools to work with Amsterdam Schema."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/schematools/cli.py
+++ b/src/schematools/cli.py
@@ -33,7 +33,6 @@ from schematools import (
     ckan,
     validation,
 )
-from schematools.contrib.databricks.client import get_databricks_info
 from schematools.exceptions import (
     DatasetNotFound,
     DuplicateScopeId,
@@ -1215,8 +1214,18 @@ def convert_to_snake_case(input_str: str) -> str:
     click.echo(to_snake_case(input_str))
 
 
-if __name__ == "__main__":
-    main()
+def _get_databricks_info(catalog: str, schema: str, table_name: str):
+    try:
+        from schematools.contrib.databricks.client import get_databricks_info
+    except ModuleNotFoundError as e:
+        if e.name and e.name.startswith("databricks"):
+            raise click.ClickException(
+                "The 'ingest' command requires the optional databricks dependencies. "
+                "Install schema-tools with the 'databricks' extra."
+            ) from e
+        raise
+
+    return get_databricks_info(catalog, schema, table_name)
 
 
 @schema.command("ingest")
@@ -1234,7 +1243,7 @@ def ingest(dataset_file: str) -> None:
             if provenance is not None and provenance.startswith("uc:"):
                 click.echo(f"Ingesting table {provenance}")
                 catalog, schema, table_name = provenance[3:].split(".")
-                db_info = get_databricks_info(catalog, schema, table_name)
+                db_info = _get_databricks_info(catalog, schema, table_name)
 
                 if db_info.errors:
                     errors[(db_info.table_id, provenance[3:])] = [
@@ -1263,3 +1272,7 @@ def ingest(dataset_file: str) -> None:
                 click.echo(f"{table_id}: {issue.message}")
                 click.echo(issue.as_markdown_todo(), err=True)
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/schematools/validation.py
+++ b/src/schematools/validation.py
@@ -63,8 +63,14 @@ def run(dataset: DatasetSchema, location: str | None = None) -> Iterator[Validat
 
     """  # noqa: W605
     for name, validator in _all:
-        for msg in validator(dataset, location):
-            yield ValidationError(validator_name=name, message=msg)
+        try:
+            for msg in validator(dataset, location):
+                yield ValidationError(validator_name=name, message=msg)
+        except (SchemaObjectNotFound, ValueError) as e:
+            yield ValidationError(
+                validator_name=name,
+                message=f"Validator {name!r} couldn't validate due to an exception: {e}",
+            )
 
 
 def _register_validator(name: str) -> Callable:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,8 @@ def sqlalchemy_connect_url(request, db_url):
 def db_schema(engine, sqlalchemy_keep_db):
     db_exists = sqlalchemy_utils.functions.database_exists(engine.url)
     if db_exists and not sqlalchemy_keep_db:
-        raise RuntimeError("DB exists, remove it before proceeding")
+        sqlalchemy_utils.functions.drop_database(engine.url)
+        db_exists = False
 
     if not db_exists:
         sqlalchemy_utils.functions.create_database(engine.url)
@@ -72,7 +73,8 @@ def db_schema(engine, sqlalchemy_keep_db):
             conn.execute(text("CREATE EXTENSION postgis"))
             conn.commit()
     yield
-    sqlalchemy_utils.functions.drop_database(engine.url)
+    if not sqlalchemy_keep_db:
+        sqlalchemy_utils.functions.drop_database(engine.url)
 
 
 @pytest.fixture

--- a/tests/django/test_import_publishers.py
+++ b/tests/django/test_import_publishers.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from io import StringIO
+from unittest.mock import Mock
+
 import pytest
 from django.core.management import call_command
 
 from schematools.contrib.django import models
+from schematools.contrib.django.management.commands import import_publishers
+from schematools.types import Publisher as PublisherSchema
 
 
 @pytest.mark.django_db
@@ -13,3 +18,48 @@ def test_import_publishers(here):
     call_command("import_publishers", *args)
     assert models.Publisher.objects.count() == 1
     assert models.Publisher.objects.first().id == "glebz"
+
+
+@pytest.mark.django_db
+def test_import_publishers_from_url(here, monkeypatch):
+    schema = PublisherSchema.from_file(here / "files/publishers/GLEBZ.json")
+
+    class StubLoader:
+        def get_all_publishers(self):
+            return {schema.id: schema}
+
+    monkeypatch.setattr(import_publishers, "get_schema_loader", lambda schema_url: StubLoader())
+
+    stdout = StringIO()
+    call_command("import_publishers", schema_url="https://example.com/schema", stdout=stdout)
+
+    assert models.Publisher.objects.count() == 1
+    assert models.Publisher.objects.first().id == "glebz"
+    assert "Loading publishers from https://example.com/schema" in stdout.getvalue()
+    assert "Imported publishers: 1" in stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_publishers_updates_existing_publisher(here):
+    schema = PublisherSchema.from_file(here / "files/publishers/GLEBZ.json")
+    command = import_publishers.Command(stdout=StringIO())
+    publisher = Mock(spec=models.Publisher)
+    publisher.save_for_schema.return_value = publisher
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(models.Publisher.objects, "get", lambda id: publisher)
+        result = command._import(schema)
+
+    assert result is publisher
+    publisher.save_for_schema.assert_called_once_with(schema)
+    assert "Updated Datateam Glebz" in command.stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_publishers_reports_no_new_publishers_when_import_is_noop(here, monkeypatch):
+    command = import_publishers.Command(stdout=StringIO())
+    monkeypatch.setattr(command, "import_from_files", lambda publisher_files: [])
+
+    command.handle(publisher=[here / "files/publishers/GLEBZ.json"], schema_url="unused")
+
+    assert "No new publishers imported." in command.stdout.getvalue()

--- a/tests/django/test_import_scopes.py
+++ b/tests/django/test_import_scopes.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from io import StringIO
+from unittest.mock import Mock
+
 import pytest
 from django.core.management import call_command
 
 from schematools.contrib.django import models
+from schematools.contrib.django.management.commands import import_scopes
+from schematools.types import Scope as ScopeSchema
 
 
 @pytest.mark.django_db
@@ -13,3 +18,48 @@ def test_import_scopes(here):
     call_command("import_scopes", *args)
     assert models.Scope.objects.count() == 1
     assert models.Scope.objects.first().id == "glebz"
+
+
+@pytest.mark.django_db
+def test_import_scopes_from_url(here, monkeypatch):
+    schema = ScopeSchema.from_file(here / "files/scopes/GLEBZ/glebzscope.json")
+
+    class StubLoader:
+        def get_all_scopes(self):
+            return {schema.id: schema}
+
+    monkeypatch.setattr(import_scopes, "get_schema_loader", lambda schema_url: StubLoader())
+
+    stdout = StringIO()
+    call_command("import_scopes", schema_url="https://example.com/schema", stdout=stdout)
+
+    assert models.Scope.objects.count() == 1
+    assert models.Scope.objects.first().id == "glebz"
+    assert "Loading scopes from https://example.com/schema" in stdout.getvalue()
+    assert "Imported scopes: 1" in stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_scopes_updates_existing_scope(here):
+    schema = ScopeSchema.from_file(here / "files/scopes/GLEBZ/glebzscope.json")
+    command = import_scopes.Command(stdout=StringIO())
+    scope = Mock(spec=models.Scope)
+    scope.save_for_schema.return_value = scope
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(models.Scope.objects, "get", lambda id: scope)
+        result = command._import(schema)
+
+    assert result is scope
+    scope.save_for_schema.assert_called_once_with(schema)
+    assert "Updated GLEBZscope" in command.stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_scopes_reports_no_new_scopes_when_import_is_noop(here, monkeypatch):
+    command = import_scopes.Command(stdout=StringIO())
+    monkeypatch.setattr(command, "import_from_files", lambda scope_files: [])
+
+    command.handle(scope=[here / "files/scopes/GLEBZ/glebzscope.json"], schema_url="unused")
+
+    assert "No new scopes imported." in command.stdout.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import builtins
+import importlib
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 from click.testing import CliRunner
 
+import schematools
 from schematools.cli import (
     batch_validate,
     validate_datasets,
@@ -21,6 +25,29 @@ class Publisher(SimpleNamespace):
 
 class Scope(SimpleNamespace):
     pass
+
+
+def test_cli_import_does_not_require_databricks_sdk(monkeypatch) -> None:
+    original_import = builtins.__import__
+    original_cli_attr = getattr(schematools, "cli", None)
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("databricks"):
+            raise ModuleNotFoundError("No module named 'databricks'", name=name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    sys.modules.pop("schematools.cli", None)
+
+    try:
+        cli = importlib.import_module("schematools.cli")
+    finally:
+        if original_cli_attr is None:
+            delattr(schematools, "cli")
+        else:
+            schematools.cli = original_cli_attr
+
+    assert cli is not None
 
 
 def test_validate_tables_aggregates_errors_on_stderr(tmp_path: Path) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import shlex
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -517,18 +518,20 @@ class TestExports:
         )
         context = create_context(meetbouten_export_schema, export_definition)
         GeopackageExporter(context).export_tables()
-        sqlite3_conn = sqlite3.connect(context.folder / "meet_bouten_v1_all_openbaar.gpkg")
-        cursor = sqlite3_conn.cursor()
-        cursor.execute("select * from rtree_meetbouten_v1_geometrie")
-        res = cursor.fetchall()
-        assert res == [(1, 119434.0, 119434.0, 487091.59375, 487091.65625)]
-        cursor.execute(
-            """
-                select identificatie, ligt_in_buurt_id, merk_code, merk_omschrijving from meetbouten_v1
-            """
-        )
-        res = cursor.fetchall()
-        assert res == [(1, "10180001.1", "12", "De meetbout")]
+        with closing(
+            sqlite3.connect(context.folder / "meet_bouten_v1_all_openbaar.gpkg")
+        ) as sqlite3_conn:
+            cursor = sqlite3_conn.cursor()
+            cursor.execute("select * from rtree_meetbouten_v1_geometrie")
+            res = cursor.fetchall()
+            assert res == [(1, 119434.0, 119434.0, 487091.59375, 487091.65625)]
+            cursor.execute(
+                """
+                    select identificatie, ligt_in_buurt_id, merk_code, merk_omschrijving from meetbouten_v1
+                """
+            )
+            res = cursor.fetchall()
+            assert res == [(1, "10180001.1", "12", "De meetbout")]
 
     def test_geopackage_export_multiple_layers(self, gebieden_export_schema, create_context):
         """Prove that geopackage export contains the correct content."""
@@ -543,18 +546,18 @@ class TestExports:
             importer.generate_db_objects(table_id, truncate=False, ind_extra_index=False)
 
         GeopackageExporter(context).export_tables()
-        sqlite3_conn = sqlite3.connect(context.folder / "gebieden_v1_grote_gebieden_openbaar.gpkg")
-        cursor = sqlite3_conn.cursor()
+        with closing(
+            sqlite3.connect(context.folder / "gebieden_v1_grote_gebieden_openbaar.gpkg")
+        ) as sqlite3_conn:
+            cursor = sqlite3_conn.cursor()
 
-        cursor.execute("SELECT table_name FROM gpkg_contents ORDER BY table_name;")
-        layer_names = [row[0] for row in cursor.fetchall()]
-        assert layer_names == [
-            "ggw_gebieden_v1",
-            "stadsdelen_v1",
-            "wijken_v1",
-        ]
-
-        sqlite3_conn.close()
+            cursor.execute("SELECT table_name FROM gpkg_contents ORDER BY table_name;")
+            layer_names = [row[0] for row in cursor.fetchall()]
+            assert layer_names == [
+                "ggw_gebieden_v1",
+                "stadsdelen_v1",
+                "wijken_v1",
+            ]
 
     def test_geojson_export(self, meetbouten_export_schema, meetbouten_content, create_context):
         """Prove that geojson export contains the correct content."""

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -38,15 +38,17 @@ class TestExports:
         )
         db_exists = sqlalchemy_utils.functions.database_exists(engine.url)
         if db_exists and not sqlalchemy_keep_db:
-            raise RuntimeError("DB exists, remove it before proceeding")
+            sqlalchemy_utils.functions.drop_database(engine.url)
+            db_exists = False
 
         if not db_exists:
             sqlalchemy_utils.functions.create_database(engine.url)
             with engine.connect() as connection:
                 connection.execute(text("CREATE EXTENSION postgis"))
                 connection.commit()
-            yield engine
-        sqlalchemy_utils.functions.drop_database(engine.url)
+        yield engine
+        if not sqlalchemy_keep_db:
+            sqlalchemy_utils.functions.drop_database(engine.url)
         engine.dispose()
 
     @pytest.fixture

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -54,7 +54,7 @@ class TestReadPermissions:
             engine, "scope_level_c", "gebieden_bouwblokken_v1", "begin_geldigheid"
         )
 
-    def test_roles_created(self, engine, gebieden_schema_auth):
+    def test_roles_created(self, engine, gebieden_schema_auth, dbsession):
         scope = Scope.from_string("certain_role")
         scope2 = Scope.from_string("another_role")
         apply_schema_and_profile_permissions(
@@ -62,6 +62,8 @@ class TestReadPermissions:
             gebieden_schema_auth,
             profiles=[],
             create_roles=True,
+            set_read_permissions=False,
+            set_write_permissions=False,
             all_scopes=[scope, scope2],
         )
         _check_role_exists(engine, "scope_certain_role")
@@ -78,6 +80,7 @@ class TestReadPermissions:
         parkeervakken_schema,
         gebieden_schema_auth,
         caplog,
+        dbsession,
     ):
         """Prove that the profiles are properly included in the grants."""
         all_schemas = {
@@ -931,7 +934,7 @@ class TestReadPermissions:
 
 
 class TestWritePermissions:
-    def test_dataset_write_role(self, engine, gebieden_schema_auth):
+    def test_dataset_write_role(self, engine, gebieden_schema_auth, dbsession):
         """
         Prove that a write role with name write_{dataset.id} is created with DML rights
         Check INSERT, UPDATE, DELETE, TRUNCATE permissions
@@ -1005,7 +1008,9 @@ class TestWritePermissions:
         # TRUNCATE is also allowed, even though the table is already empty by now
         _check_truncate_permission_granted(engine, "testuser", "gebieden_bouwblokken_v1")
 
-    def test_multiple_datasets_write_roles(self, engine, parkeervakken_schema, afval_schema):
+    def test_multiple_datasets_write_roles(
+        self, engine, parkeervakken_schema, afval_schema, dbsession
+    ):
         """
         Prove that the write_{dataset.id} roles only have DML rights for their associated
         dataset tables.

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "amsterdam-schema-tools"
-version = "9.12.0"
+version = "9.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
* Allow the CLI to load without the optional Databricks dependencies; only the `ingest` command now requires that extra when used.
* Report validator exceptions as validation errors instead of aborting validation.
* Improve test database and SQLite cleanup, and add coverage for import, export, CLI, and permission flows.