### PR TITLE
Databricks array/object fields and relations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2026-08-04 (9.12.4)
+
+* Parse valid Databricks relations when ingesting Unity Catalog metadata.
+* Handle Databricks array and object columns, including nested field definitions that have
+  path-like tags, i.e.: `schema:items:properties:field_name:type = "string".
+
 # 2026-07-30 (9.12.3)
 
 * Improve Databricks schema generation by setting identifier and display from the first field and inferring `mainGeometry` from the first geo field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amsterdam-schema-tools"
-version = "9.12.3"
+version = "9.12.4"
 description = "Tools to work with Amsterdam Schema."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/schematools/contrib/databricks/types.py
+++ b/src/schematools/contrib/databricks/types.py
@@ -72,6 +72,15 @@ def valid_datetime(val: str):
         raise ValueError(f"Value '{val}' is not a valid ISO 8601 datetime") from None
 
 
+def valid_boolean(val: str):
+    if val not in {"true", "false"}:
+        raise ValueError(f"Value '{val}' is not a valid boolean")
+
+
+def as_bool(val: str) -> bool:
+    return val == "true"
+
+
 def semver(val: str):
     parts = val.split(".")
     if len(parts) != 3 or not all(part.isdigit() for part in parts):
@@ -86,6 +95,7 @@ as_is = AttributeSpec(validators=[not_none], transformers=[])
 as_list = AttributeSpec(validators=[not_none], transformers=[lambda v: v.split(";")])
 as_number = AttributeSpec(validators=[not_none, valid_number], transformers=[float])
 as_integer = AttributeSpec(validators=[not_none, valid_number], transformers=[int])
+as_boolean = AttributeSpec(validators=[not_none, valid_boolean], transformers=[as_bool])
 
 # Constrained scalar values
 as_semver = AttributeSpec(validators=[not_none, semver], transformers=[])
@@ -205,6 +215,7 @@ COLUMN_ATTRIBUTES = {
     "contentEncoding": as_is,
     "enum": as_list,
     "format": format,
+    "additionalProperties": as_boolean,
 }
 
 MUTUALLY_EXCLUSIVE_ATTRIBUTES = [
@@ -223,6 +234,9 @@ SCHEMA_TYPES = {
     "boolean": "boolean",
     "double": "number",
     "float": "number",
+    "array": "array",
+    "object": "object",
+    "struct": "object",
 }
 
 SCHEMA_FORMAT = {"timestamp": "date-time", "date": "date", "time": "time"}
@@ -350,6 +364,75 @@ class DatabricksInfo:
             errors.extend(spec.errors(attr, value))
         return errors
 
+    def _split_nested_column_tag(self, key: str) -> tuple[list[str], str] | None:
+        if ":" not in key:
+            return None
+        parts = key.split(":")
+        return parts[:-1], parts[-1]
+
+    def _is_valid_nested_column_tag_path(self, path: list[str]) -> bool:
+        index = 0
+        while index < len(path):
+            if path[index] == "items":
+                index += 1
+                continue
+            if path[index] == "properties" and index + 1 < len(path):
+                index += 2
+                continue
+            return False
+        return True
+
+    def _nested_column_tag_errors(self, column_name: str, tag: Tag) -> list[str]:
+        nested_tag = self._split_nested_column_tag(tag.key)
+        if nested_tag is None:
+            return []
+
+        path, attr = nested_tag
+        if not self._is_valid_nested_column_tag_path(path) or attr not in COLUMN_ATTRIBUTES:
+            return [f"Unknown column tag for {column_name}: schema:{tag.key}"]
+
+        if attr == "type" and tag.value in SCHEMA_TYPES:
+            return []
+
+        spec = COLUMN_ATTRIBUTES[attr]
+        return spec.errors(attr, tag.value)
+
+    def _ensure_nested_schema_target(self, target: dict, path: list[str]) -> dict:
+        nested_target = target
+        index = 0
+        while index < len(path):
+            if path[index] == "items":
+                nested_target = nested_target.setdefault("items", {})
+                index += 1
+                continue
+
+            properties = nested_target.setdefault("properties", {})
+            property_name = path[index + 1]
+            nested_target = properties.setdefault(property_name, {})
+            index += 2
+
+        return nested_target
+
+    def _apply_nested_column_tag(self, target: dict, tag: Tag) -> None:
+        nested_tag = self._split_nested_column_tag(tag.key)
+        if nested_tag is None:
+            return
+
+        path, attr = nested_tag
+        nested_target = self._ensure_nested_schema_target(target, path)
+
+        if attr == "type" and tag.value in SCHEMA_TYPES:
+            nested_target["type"] = SCHEMA_TYPES[tag.value]
+            if nested_format := SCHEMA_FORMAT.get(tag.value):
+                nested_target["format"] = nested_format
+            return
+
+        self._apply_tag_specs(
+            nested_target,
+            Tags(_tags=[Tag(attr, tag.value, tag.type)]),
+            COLUMN_ATTRIBUTES,
+        )
+
     def _expand_relation(self, target: dict, value: str) -> None:
         loader = get_schema_loader()
         fields = {}
@@ -418,6 +501,9 @@ class DatabricksInfo:
         for column_name, column in self.column_data.items():
             tags = column.tags
             for tag in tags:
+                if ":" in tag.key:
+                    errors.extend(self._nested_column_tag_errors(column_name, tag))
+                    continue
                 if tag.key not in COLUMN_ATTRIBUTES:
                     errors.append(f"Unknown column tag for {column_name}: schema:{tag.key}")
 
@@ -441,7 +527,14 @@ class DatabricksInfo:
             column_schema["description"] = column.comment
         if format := SCHEMA_FORMAT.get(column.type_name):
             column_schema["format"] = format
-        self._apply_tag_specs(column_schema, column.tags, COLUMN_ATTRIBUTES)
+        self._apply_tag_specs(
+            column_schema,
+            Tags(_tags=[tag for tag in column.tags if ":" not in tag.key]),
+            COLUMN_ATTRIBUTES,
+        )
+        for tag in column.tags:
+            if ":" in tag.key:
+                self._apply_nested_column_tag(column_schema, tag)
         return column_schema
 
     def __post_init__(self):

--- a/src/schematools/contrib/databricks/types.py
+++ b/src/schematools/contrib/databricks/types.py
@@ -8,6 +8,8 @@ from typing import Any, Literal
 
 from databricks.sdk.service.catalog import EntityTagAssignment
 
+from schematools.exceptions import SchemaObjectNotFound
+from schematools.loaders import get_schema_loader
 from schematools.naming import toCamelCase
 
 
@@ -80,7 +82,7 @@ def semver(val: str):
 # Reusable attribute specs
 
 # Passthrough and scalar coercion
-as_is = AttributeSpec(validators=[], transformers=[])
+as_is = AttributeSpec(validators=[not_none], transformers=[])
 as_list = AttributeSpec(validators=[not_none], transformers=[lambda v: v.split(";")])
 as_number = AttributeSpec(validators=[not_none, valid_number], transformers=[float])
 as_integer = AttributeSpec(validators=[not_none, valid_number], transformers=[int])
@@ -181,7 +183,7 @@ TABLE_SCHEMA_ATTRIBUTES = {
 
 # Per-column attributes
 COLUMN_ATTRIBUTES = {
-    "type": as_type,
+    "type": as_type,  # Should remain in first place in the dict to ensure correct processing.
     "$ref": geo,
     "title": as_is,
     "description": as_is,
@@ -348,6 +350,41 @@ class DatabricksInfo:
             errors.extend(spec.errors(attr, value))
         return errors
 
+    def _expand_relation(self, target: dict, value: str) -> None:
+        loader = get_schema_loader()
+        fields = {}
+        try:
+            dataset, table = value.split(":")
+            dataset_schema = loader.get_dataset(dataset)
+            table_schema = dataset_schema.get_table_by_id(
+                table, version=dataset_schema.default_version
+            )
+            for identifier in table_schema.identifier_fields:
+                fields[identifier.name] = {"type": identifier.type}
+            if table_schema.is_temporal:
+                for start, end in table_schema.temporal.dimensions.values():
+                    fields[start.name] = {"type": start.type}
+                    fields[end.name] = {"type": end.type}
+        except (SchemaObjectNotFound, ValueError, AttributeError):
+            self.errors.append(f"Relation '{value}' could not be resolved.")
+            return
+
+        # If the target is an array, we need to set the items property to the fields. Otherwise,
+        # we set the properties directly on the target.
+        field_target = target
+        if target["type"] == "array":
+            target["items"] = {}
+            field_target = target["items"]
+
+        # In case there is only one field, we set
+        # the type directly to that field's type. If there are multiple fields, we set the type to
+        # object and add the properties.
+        if len(fields) == 1:
+            field_target["type"] = next(iter(fields.values()))["type"]
+        else:
+            field_target["type"] = "object"
+            field_target["properties"] = fields
+
     def _apply_tag_specs(self, target: dict, tags: Tags, specs: dict[str, AttributeSpec]) -> None:
         for attr, spec in specs.items():
             if attr not in tags:
@@ -361,6 +398,8 @@ class DatabricksInfo:
                 if self.geo_field is None:
                     # set geo_field to first geo field encountered
                     self.geo_field = target.get("title")
+            if attr == "relation" and value is not None:
+                self._expand_relation(target, value)
             target[attr] = spec.transform(value)
 
     def _validate_table_tags(self) -> list[str]:
@@ -441,4 +480,4 @@ class DatabricksInfo:
 
     @cached_property
     def json(self) -> str:
-        return json.dumps(self.dict, indent=2, ensure_ascii=False)
+        return json.dumps(self.dict, indent=2, ensure_ascii=False)  #

--- a/tests/test_databricks_types.py
+++ b/tests/test_databricks_types.py
@@ -325,6 +325,183 @@ def test_databricks_info_expands_array_relations_into_items(monkeypatch) -> None
     }
 
 
+def test_databricks_info_builds_nested_array_item_properties_from_column_tags() -> None:
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="birthdays_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "verjaardagskalender": ColumnData(
+                "verjaardagskalender",
+                "string",
+                None,
+                None,
+                "",
+                Tags(
+                    _tags=[
+                        Tag(key="type", value="array", type="columns"),
+                        Tag(key="title", value="Verjaardagskalender", type="columns"),
+                        Tag(key="items:type", value="object", type="columns"),
+                        Tag(
+                            key="items:properties:naam:type",
+                            value="string",
+                            type="columns",
+                        ),
+                        Tag(
+                            key="items:properties:verjaardag:type",
+                            value="date",
+                            type="columns",
+                        ),
+                    ]
+                ),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["verjaardagskalender"] == {
+        "title": "Verjaardagskalender",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "naam": {"type": "string"},
+                "verjaardag": {"type": "string", "format": "date"},
+            },
+        },
+    }
+
+
+def test_databricks_info_builds_nested_array_scalar_items_from_column_tags() -> None:
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="lists_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "lijst": ColumnData(
+                "lijst",
+                "string",
+                None,
+                None,
+                "",
+                Tags(
+                    _tags=[
+                        Tag(key="type", value="array", type="columns"),
+                        Tag(key="title", value="lijst", type="columns"),
+                        Tag(key="items:type", value="string", type="columns"),
+                    ]
+                ),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["lijst"] == {
+        "title": "lijst",
+        "type": "array",
+        "items": {
+            "type": "string",
+        },
+    }
+
+
+def test_databricks_info_builds_object_properties_from_column_tags() -> None:
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="addresses_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "adres": ColumnData(
+                "adres",
+                "string",
+                None,
+                None,
+                "",
+                Tags(
+                    _tags=[
+                        Tag(key="type", value="object", type="columns"),
+                        Tag(key="title", value="Adres", type="columns"),
+                        Tag(key="additionalProperties", value="false", type="columns"),
+                        Tag(key="properties:straat:type", value="string", type="columns"),
+                        Tag(key="properties:huisnr:type", value="int", type="columns"),
+                        Tag(key="properties:postcode:type", value="string", type="columns"),
+                    ]
+                ),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["adres"] == {
+        "title": "Adres",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "straat": {"type": "string"},
+            "huisnr": {"type": "integer"},
+            "postcode": {"type": "string"},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected_errors"),
+    [
+        (
+            [Tag(key="properties:type", value="string", type="columns")],
+            ["Unknown column tag for invalid: schema:properties:type"],
+        ),
+        (
+            [Tag(key="items:foo:type", value="string", type="columns")],
+            ["Unknown column tag for invalid: schema:items:foo:type"],
+        ),
+        (
+            [Tag(key="properties:verjaardag:type", value="uuid", type="columns")],
+            [
+                (
+                    "type: Value 'uuid' is not in the allowed values: "
+                    "('string', 'number', 'integer', 'boolean', 'array', 'object', 'null')"
+                )
+            ],
+        ),
+        (
+            [Tag(key="additionalProperties", value="maybe", type="columns")],
+            ["additionalProperties: Value 'maybe' is not a valid boolean"],
+        ),
+    ],
+)
+def test_databricks_info_reports_invalid_nested_column_tags(
+    tags: list[Tag], expected_errors: list[str]
+) -> None:
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="invalid_tags_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "invalid": ColumnData(
+                "invalid",
+                "string",
+                None,
+                None,
+                "",
+                Tags(_tags=tags),
+            )
+        },
+    )
+
+    assert info.errors == expected_errors
+
+
 def test_databricks_info_expands_temporal_relations(monkeypatch) -> None:
     related_table = SimpleNamespace(
         identifier_fields=[SimpleNamespace(name="related_id", type="string")],

--- a/tests/test_databricks_types.py
+++ b/tests/test_databricks_types.py
@@ -9,6 +9,7 @@ from databricks.sdk.service.catalog import EntityTagAssignment
 
 from schematools.contrib.databricks import client as databricks_client
 from schematools.contrib.databricks.types import (
+    COLUMN_ATTRIBUTES,
     ColumnData,
     DatabricksInfo,
     TableData,
@@ -16,6 +17,7 @@ from schematools.contrib.databricks.types import (
     Tags,
     as_datetime,
     as_integer,
+    as_is,
     as_number,
     as_semver,
     as_type,
@@ -26,6 +28,7 @@ from schematools.contrib.databricks.types import (
     list_or_string,
     status,
 )
+from schematools.exceptions import SchemaObjectNotFound
 
 
 def test_tags_from_tag_assignments_filters_schema_tags() -> None:
@@ -222,9 +225,191 @@ def test_databricks_info_reports_explicit_none_values() -> None:
     assert info.errors == ["auth: Value cannot be None"]
 
 
+def test_databricks_info_reports_explicit_none_values_for_as_is_tags() -> None:
+    table_tags = Tags(_tags=[Tag(key="title", value=None, type="tables")])
+
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="buildings_table",
+        table_data=TableData(comment=None, tags=table_tags),
+        column_data={},
+    )
+
+    assert info.errors == ["title: Value cannot be None"]
+
+
+def test_databricks_info_expands_scalar_relations(monkeypatch) -> None:
+    related_table = SimpleNamespace(
+        identifier_fields=[SimpleNamespace(name="related_id", type="string")],
+        is_temporal=False,
+    )
+    dataset_schema = SimpleNamespace(
+        default_version="v1",
+        get_table_by_id=lambda table_id, version: related_table,
+    )
+    loader = SimpleNamespace(get_dataset=lambda dataset_id: dataset_schema)
+    monkeypatch.setattr("schematools.contrib.databricks.types.get_schema_loader", lambda: loader)
+
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="buildings_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "related": ColumnData(
+                "related",
+                "string",
+                None,
+                None,
+                "",
+                Tags(_tags=[Tag(key="relation", value="dataset:table", type="columns")]),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["related"]["type"] == "string"
+    assert payload["schema"]["properties"]["related"]["relation"] == "dataset:table"
+
+
+def test_databricks_info_expands_array_relations_into_items(monkeypatch) -> None:
+    related_table = SimpleNamespace(
+        identifier_fields=[
+            SimpleNamespace(name="related_id", type="string"),
+            SimpleNamespace(name="related_seq", type="integer"),
+        ],
+        is_temporal=False,
+    )
+    dataset_schema = SimpleNamespace(
+        default_version="v1",
+        get_table_by_id=lambda table_id, version: related_table,
+    )
+    loader = SimpleNamespace(get_dataset=lambda dataset_id: dataset_schema)
+    monkeypatch.setattr("schematools.contrib.databricks.types.get_schema_loader", lambda: loader)
+
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="buildings_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "related": ColumnData(
+                "related",
+                "string",
+                None,
+                None,
+                "",
+                Tags(
+                    _tags=[
+                        Tag(key="type", value="array", type="columns"),
+                        Tag(key="relation", value="dataset:table", type="columns"),
+                    ]
+                ),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["related"]["type"] == "array"
+    assert payload["schema"]["properties"]["related"]["items"] == {
+        "type": "object",
+        "properties": {
+            "related_id": {"type": "string"},
+            "related_seq": {"type": "integer"},
+        },
+    }
+
+
+def test_databricks_info_expands_temporal_relations(monkeypatch) -> None:
+    related_table = SimpleNamespace(
+        identifier_fields=[SimpleNamespace(name="related_id", type="string")],
+        is_temporal=True,
+        temporal=SimpleNamespace(
+            dimensions={
+                "validity": (
+                    SimpleNamespace(name="valid_from", type="string"),
+                    SimpleNamespace(name="valid_to", type="string"),
+                )
+            }
+        ),
+    )
+    dataset_schema = SimpleNamespace(
+        default_version="v1",
+        get_table_by_id=lambda table_id, version: related_table,
+    )
+    loader = SimpleNamespace(get_dataset=lambda dataset_id: dataset_schema)
+    monkeypatch.setattr("schematools.contrib.databricks.types.get_schema_loader", lambda: loader)
+
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="buildings_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "related": ColumnData(
+                "related",
+                "string",
+                None,
+                None,
+                "",
+                Tags(_tags=[Tag(key="relation", value="dataset:table", type="columns")]),
+            )
+        },
+    )
+
+    payload = json.loads(info.json)
+
+    assert info.errors == []
+    assert payload["schema"]["properties"]["related"] == {
+        "title": "related",
+        "type": "object",
+        "properties": {
+            "related_id": {"type": "string"},
+            "valid_from": {"type": "string"},
+            "valid_to": {"type": "string"},
+        },
+        "relation": "dataset:table",
+    }
+
+
+def test_databricks_info_reports_unresolved_relations(monkeypatch) -> None:
+    def raise_not_found(_dataset_id: str):
+        raise SchemaObjectNotFound("dataset")
+
+    loader = SimpleNamespace(get_dataset=raise_not_found)
+    monkeypatch.setattr("schematools.contrib.databricks.types.get_schema_loader", lambda: loader)
+
+    info = DatabricksInfo(
+        catalog="main",
+        schema="default",
+        table_name="buildings_table",
+        table_data=TableData(comment=None, tags=Tags(_tags=[])),
+        column_data={
+            "related": ColumnData(
+                "related",
+                "string",
+                None,
+                None,
+                "",
+                Tags(_tags=[Tag(key="relation", value="dataset:table", type="columns")]),
+            )
+        },
+    )
+
+    _ = info.json
+
+    assert info.errors == ["Relation 'dataset:table' could not be resolved."]
+
+
 @pytest.mark.parametrize(
     ("spec", "attr", "value", "expected_errors"),
     [
+        (as_is, "title", None, ["title: Value cannot be None"]),
         (list_or_string, "auth", None, ["auth: Value cannot be None"]),
         (
             as_number,
@@ -261,8 +446,10 @@ def test_databricks_info_reports_explicit_none_values() -> None:
             "type",
             "date",
             [
-                "type: Value 'date' is not in the allowed values: "
-                "('string', 'number', 'integer', 'boolean', 'array', 'object', 'null')"
+                (
+                    "type: Value 'date' is not in the allowed values: "
+                    "('string', 'number', 'integer', 'boolean', 'array', 'object', 'null')"
+                )
             ],
         ),
         (
@@ -270,10 +457,12 @@ def test_databricks_info_reports_explicit_none_values() -> None:
             "format",
             "uuid",
             [
-                "format: Value 'uuid' is not in the allowed values: "
-                "('date-time', 'date', 'time', 'duration', 'email', 'idn-email', 'uri', "
-                "'uri-reference', 'hostname', 'idn-hostname', 'ipv4', 'ipv6', 'iri', "
-                "'iri-reference', 'json')"
+                (
+                    "format: Value 'uuid' is not in the allowed values: "
+                    "('date-time', 'date', 'time', 'duration', 'email', 'idn-email', 'uri', "
+                    "'uri-reference', 'hostname', 'idn-hostname', 'ipv4', 'ipv6', 'iri', "
+                    "'iri-reference', 'json')"
+                )
             ],
         ),
         (
@@ -281,9 +470,11 @@ def test_databricks_info_reports_explicit_none_values() -> None:
             "$ref",
             "Circle",
             [
-                "$ref: Value 'Circle' is not in the allowed values: "
-                "('Point', 'LineString', 'Polygon', 'MultiPolygon', 'Geometry', "
-                "'MultiLineString', 'MultiPoint')"
+                (
+                    "$ref: Value 'Circle' is not in the allowed values: "
+                    "('Point', 'LineString', 'Polygon', 'MultiPolygon', 'Geometry', "
+                    "'MultiLineString', 'MultiPoint')"
+                )
             ],
         ),
         (
@@ -299,11 +490,19 @@ def test_databricks_info_reports_explicit_none_values() -> None:
             "dataclass",
             "stream",
             [
-                "dataclass: Value 'stream' is not in the allowed values: "
-                "('structured', 'blob', 'event')"
+                (
+                    "dataclass: Value 'stream' is not in the allowed values: "
+                    "('structured', 'blob', 'event')"
+                )
             ],
         ),
     ],
 )
 def test_attribute_spec_errors(spec, attr: str, value, expected_errors: list[str]) -> None:
     assert spec.errors(attr, value) == expected_errors
+
+
+def test_type_first_in_column_attributes() -> None:
+    # Ensure that 'type' is the first key in COLUMN_ATTRIBUTES to guarantee correct processing order.
+    first_key = next(iter(COLUMN_ATTRIBUTES))
+    assert first_key == "type", f"Expected 'type' to be the first key, but got '{first_key}'"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "amsterdam-schema-tools"
-version = "9.12.3"
+version = "9.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -762,7 +762,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1633,7 +1633,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -1679,7 +1679,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "certifi" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [


### PR DESCRIPTION
Dit zorgt ervoor dat we deze goed kunnen parsen (mits natuurlijk de tags goed zijn ingevuld). 

Voor relaties gebeurt dit volautomatisch, we lezen de doeltabel in en nemen hieruit de identifier(s) en eventuele temporele identifier(s). 

Voor door de gebruiker gedefinieerde array/object velden kunnen hiermee ook geneste tags worden opgegeven met een pad naar de json key/val, i.e. `schema:items:properties:naam:type = string`, wat ervoor zorgt dat dit op de juiste manier genest wordt. 

Tests ✅ 